### PR TITLE
chore: CI/CD 워크플로우 생성

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -1,0 +1,81 @@
+name: develop Build And Deploy
+
+on:
+  push:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: DEV
+    strategy:
+      matrix:
+        java-version: [ 17 ]
+        distribution: [ 'temurin' ]
+    outputs:
+      VERSION: ${{ steps.github-sha-short.outputs.sha }}
+    steps:
+      # 기본 체크아웃
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # JDK를 17 버전으로 세팅
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.distribution }}
+
+      # GITHUB SHA Short
+      - name: GitHub SHA Short
+        id: github-sha-short
+        run: echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
+
+      # Gradlew 실행 허용
+      - name: Run chmod to make gradlew executable
+        run: chmod +x ./gradlew
+
+      # Gradle 빌드
+      - name: Build with Gradle
+        id: gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            build
+            --scan
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+      # NCP Container Registry 로그인
+      - name: Login to NCP Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+          username: ${{ secrets.NCP_ACCESS_KEY }}
+          password: ${{ secrets.NCP_SECRET_KEY }}
+
+      # Docker 이미지 빌드 및 푸시
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ steps.github-sha-short.outputs.sha }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    environment: DEV
+    needs: build
+    steps:
+      - name: Login to NCP Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: root
+          password: ${{ secrets.NCP_PASSWORD }}
+          key: ${{ secrets.NCP_PRIVATE_KEY }}
+          port: ${{ secrets.NCP_PORT }}
+          script: |
+            echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
+            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
+            docker stop server-spring
+            docker run -d --name server-spring -p 8080:8080 -d server-spring:${{ needs.build.outputs.sha }}

--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -1,0 +1,30 @@
+name: develop Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_hash:
+        description: 'commit_hash'
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: DEV
+    steps:
+      - name: checkout
+        uses: actions/checkout@master
+
+      - name: Login to NCP Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: root
+          password: ${{ secrets.NCP_PASSWORD }}
+          key: ${{ secrets.NCP_PRIVATE_KEY }}
+          port: ${{ secrets.NCP_PORT }}
+          script: |
+            echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
+            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ github.event.inputs.commit_hash }}
+            docker stop server-spring
+            docker run -d --name server-spring -p 8080:8080 -d server-spring:${{ github.event.inputs.commit_hash }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM amazoncorretto:17
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -51,3 +51,5 @@ checkstyle {
     configFile = file("config/checkstyle/naver-checkstyle-rules.xml")
     configProperties = ['suppressionFile': file("config/checkstyle/naver-checkstyle-suppressions.xml")]
 }
+
+jar.enabled = false


### PR DESCRIPTION
## 🌱 관련 이슈
- close #16

---
## 📌 작업 내용 및 특이사항
- workflow에서 docker 빌드하기 위한 Dockerfile을 root 위치에 생성
- plain jar 생성안되도록 build.gradle 파일 변경
- CI/CD workflow 생성
---
## 📝 참고사항
- develop 환경 배포 버저닝은 github commit sha 7글자를 짤라서 사용합니다.
- 커밋해시 GitHub SHA Short step에서 `sha`변수로 추출하여 사용
- `docker/build-push-action@v5` actions에서 `no such file or directory` 에러
  - [Dockerfile의 context 지정해주어야 한다](https://github.com/docker/build-push-action/issues/574#issuecomment-1075527470)


--- 
## 📚 기타
### 추가 작업이 필요
- 현재 docker run으로 되어있는 부분 docker-compose으로 변경
- 빌드 성공 결과에 따른 Slack 알림

