### PR TITLE
fix: CI/CD 접속 전용 계정 적용

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -70,8 +70,7 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.NCP_HOST }}
-          username: root
-          password: ${{ secrets.NCP_PASSWORD }}
+          username: tenminute
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
           script: |


### PR DESCRIPTION
## 🌱 관련 이슈
- close #20 

---
## 📌 작업 내용 및 특이사항
- 기존 ssh 접속을 root로 하였는데, 보안 이슈로 actions에서 접근하는 cicd 전용 계정 생성하여 해당 계정 정보로 변경
- password는 사용하지않아 해당 필드 제거


