### PR TITLE
fix: CI/CD outputs 변수명 변경

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -1,7 +1,6 @@
 name: develop Build And Deploy
 
 on:
-  pull_request:
   push:
     branches: [ "develop" ]
 

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -1,6 +1,7 @@
 name: develop Build And Deploy
 
 on:
+  pull_request:
   push:
     branches: [ "develop" ]
 
@@ -13,7 +14,7 @@ jobs:
         java-version: [ 17 ]
         distribution: [ 'temurin' ]
     outputs:
-      VERSION: ${{ steps.github-sha-short.outputs.sha }}
+      sha: ${{ steps.github-sha-short.outputs.sha }}
     steps:
       # 기본 체크아웃
       - name: Checkout


### PR DESCRIPTION
## 🌱 관련 이슈
- close #22 

---
## 📌 작업 내용 및 특이사항
- docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
명령어에서 사용하는 sha 값을 outputs에서 VERSION으로 넘겨주고 있어 에러발생

해당 값 sha로 변경
```
    outputs:
      sha: ${{ steps.github-sha-short.outputs.sha }}
```
---
## 📝 참고사항
- 

--- 
## 📚 기타
- 

