### PR TITLE
chore: docker compose 적용

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -63,6 +63,17 @@ jobs:
           push: true
           tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ steps.github-sha-short.outputs.sha }}
 
+      # 서버로 docker-compose 파일 전송
+      - name: Copy docker-compose.yml to NCP Server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: tenminute
+          key: ${{ secrets.NCP_PRIVATE_KEY }}
+          port: ${{ secrets.NCP_PORT }}
+          source: docker-compose.yaml
+          target: /
+
   deploy:
     runs-on: ubuntu-latest
     environment: DEV

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Deploy to NCP Server
         uses: appleboy/ssh-action@master
-        #        env:
+        env:
         #          NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
         #          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
         with:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Deploy to NCP Server
         uses: appleboy/ssh-action@master
-        env:
+        #        env:
         #          NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
         #          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
         with:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -89,7 +89,7 @@ jobs:
           username: tenminute
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
-          envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG
+          envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수
           script: |
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -68,7 +68,7 @@ jobs:
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.NCP_HOST }}
-          username: tenminute
+          username: ${{ secrets.NCP_USERNAME }}
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
           source: docker-compose.yaml

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -83,7 +83,7 @@ jobs:
         uses: appleboy/ssh-action@master
         env:
           NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
-          NCP_IMAGE_TAG: ${{ steps.github-sha-short.outputs.sha }}
+          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -78,12 +78,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: DEV
     needs: build
-    env:
-      NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
-      NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
     steps:
-      - name: Login to NCP Server
+      - name: Deploy to NCP Server
         uses: appleboy/ssh-action@master
+        env:
+          NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -94,6 +94,6 @@ jobs:
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d
-            docker system prune -a -f
+            docker image prune -a -f
 #            docker stop server-spring && docker rm server-spring
 #            docker run -d --name server-spring -p 8080:8080 -d ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -83,7 +83,7 @@ jobs:
         uses: appleboy/ssh-action@master
         env:
           NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
-          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
+          NCP_IMAGE_TAG: ${{ steps.github-sha-short.outputs.sha }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute
@@ -94,5 +94,6 @@ jobs:
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d
+            docker system prune -a -f
 #            docker stop server-spring && docker rm server-spring
 #            docker run -d --name server-spring -p 8080:8080 -d ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -95,5 +95,3 @@ jobs:
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d
             docker image prune -a -f
-#            docker stop server-spring && docker rm server-spring
-#            docker run -d --name server-spring -p 8080:8080 -d ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -72,7 +72,7 @@ jobs:
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
           source: docker-compose.yaml
-          target: /
+          target: /home/tenminute/
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -82,14 +82,14 @@ jobs:
       - name: Deploy to NCP Server
         uses: appleboy/ssh-action@master
         env:
-        #          NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
-        #          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
+          NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
-          #          envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG
+          envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG
           script: |
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -65,7 +65,7 @@ jobs:
 
       # 서버로 docker-compose 파일 전송
       - name: Copy docker-compose.yml to NCP Server
-        uses: appleboy/scp-action@0.1.4
+        uses: appleboy/scp-action@v0.1.4
         with:
           host: ${{ secrets.NCP_HOST }}
           username: ${{ secrets.NCP_USERNAME }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -65,7 +65,7 @@ jobs:
 
       # 서버로 docker-compose 파일 전송
       - name: Copy docker-compose.yml to NCP Server
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@0.1.4
         with:
           host: ${{ secrets.NCP_HOST }}
           username: ${{ secrets.NCP_USERNAME }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -92,5 +92,6 @@ jobs:
           script: |
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
-            docker stop server-spring && docker rm server-spring 
-            docker run -d --name server-spring -p 8080:8080 -d ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
+            docker compose -f /home/tenminute/docker-compose.yaml up -d
+#            docker stop server-spring && docker rm server-spring
+#            docker run -d --name server-spring -p 8080:8080 -d ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -89,6 +89,7 @@ jobs:
           username: tenminute
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
+          envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG
           script: |
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,8 +3,6 @@ name: develop Build And Deploy
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,6 +3,8 @@ name: develop Build And Deploy
 on:
   push:
     branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -78,6 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: DEV
     needs: build
+    env:
+      NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+      NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
     steps:
       - name: Login to NCP Server
         uses: appleboy/ssh-action@master

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -82,14 +82,14 @@ jobs:
       - name: Deploy to NCP Server
         uses: appleboy/ssh-action@master
         env:
-          NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
-          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
+        #          NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+        #          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
-          envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG
+          #          envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG
           script: |
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -68,7 +68,7 @@ jobs:
         uses: appleboy/scp-action@v0.1.4
         with:
           host: ${{ secrets.NCP_HOST }}
-          username: ${{ secrets.NCP_USERNAME }}
+          username: tenminute
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
           source: docker-compose.yaml

--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -11,19 +11,21 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: DEV
+    needs: build
     steps:
-      - name: checkout
-        uses: actions/checkout@master
-
-      - name: Login to NCP Server
+      - name: Deploy to NCP Server
         uses: appleboy/ssh-action@master
+        env:
+          NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
+          envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수
           script: |
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
-            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ github.event.inputs.commit_hash }}
-            docker stop server-spring && docker rm server-spring
-            docker run -d --name server-spring -p 8080:8080 -d ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ github.event.inputs.commit_hash }}
+            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
+            docker compose -f /home/tenminute/docker-compose.yaml up -d
+            docker image prune -a -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,5 +6,3 @@ services:
     container_name: server-spring
     restart: always
     network_mode: host
-    ports:
-      - "8080:8080"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  backend:
+    image: ${NCP_CONTAINER_REGISTRY}/server-spring:${NCP_IMAGE_TAG}
+    container_name: server-spring
+    restart: always
+    network_mode: host
+    ports:
+      - "8080:8080"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   backend:
-    image: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
+    image: ${NCP_CONTAINER_REGISTRY}/server-spring:${NCP_IMAGE_TAG}
     container_name: server-spring
     restart: always
     network_mode: host

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   backend:
-    image: ${NCP_CONTAINER_REGISTRY}/server-spring:${NCP_IMAGE_TAG}
+    image: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
     container_name: server-spring
     restart: always
     network_mode: host


### PR DESCRIPTION
## 🌱 관련 이슈
- close #15 

---
## 📌 작업 내용 및 특이사항
- 도커 컴포즈 파일을 작성했습니다. 다음과 같이 작동합니다.
    - 해당 파일은 프로젝트 루트 디렉토리에 `docker-compose.yaml` 로 관리됩니다.
    - deploy 액션이 트리거되면, `scp-action`을 통해 ncp 서버의`home/tenminute`으로 해당 파일을 복사합니다.
    - 복사된 컴포즈 파일을 up으로 실행합니다.
- `docker image prune -a -f` 로 사용되지 않는 이미지를 삭제하는 스크립트를 추가했습니다. 
- 빌드 시 `eclipse-temurin` 이미지를 사용하도록 했습니다. 
    -  `openjdk` 이미지는 JRE를 제공하지 않기 때문에, 사용하면 안된다고 합니다.
    -  aws 서비스를 사용한다면 `amazoncorretto` 를 사용해도 좋지만, 일반적으로는 이클립트 테무린을 권장한다고 합니다. [레퍼런스, 3번 참고](https://www.docker.com/blog/9-tips-for-containerizing-your-spring-boot-code/) 

---
## 📝 참고사항
- docker-compose에 `version: "3.8"`
    - 2번째 링크에 버전 표 보고 가장 최신 도커 엔진 릴리즈에 대응되는 값을 명시해야 한다고... 
    - https://stackoverflow.com/questions/74686606/docker-compose-and-docker-file-versions-differences-and-interferences
    - https://docs.docker.com/compose/compose-file/compose-versioning/#compatibility-matrix
- docker의 네트워크 모드를 host로 설정하면 포트를 expose 할 필요가 없습니다.
    - 컴포즈 파일에서도 포트 바인딩 관련 설정을 제외해줬습니다.
    - 포트 설정을 넣으면 `WARNING: Published ports are discarded when using host network mode` 경고가 발생합니다
    - 도커 네트워크 관련해서는 이거 읽어보시는 걸 추천!
    - https://gngsn.tistory.com/140
- 아래 jdk 관련 자료 읽어보시는 것도 추천드립니다. 
    - 로컬 개발 환경에서도 위와 마찬가지로 이클립스 테무린을 추천드리고, 애플 실리콘 환경에서는 azul zulu도 좋은 선택지입니다.
    - https://whichjdk.com/

--- 
## 📚 기타
- develop_deploy와 develop_build_deploy에 중복된 로직이 존재하는 게 불편한데... 해결할 수 있는 방법을 고민해보면 좋을듯 합니다

