### PR TITLE
chore: 성공 응답 공통 처리 어드바이스 생성

### DIFF
--- a/src/main/java/com/depromeet/global/config/response/GlobalResponse.java
+++ b/src/main/java/com/depromeet/global/config/response/GlobalResponse.java
@@ -1,9 +1,7 @@
 package com.depromeet.global.config.response;
 
 import java.time.LocalDateTime;
-import lombok.Getter;
 
-@Getter
 public record GlobalResponse(boolean success, int status, Object data, LocalDateTime timestamp) {
     public static GlobalResponse of(int status, Object data) {
         return new GlobalResponse(true, status, data, LocalDateTime.now());

--- a/src/main/java/com/depromeet/global/config/response/GlobalResponse.java
+++ b/src/main/java/com/depromeet/global/config/response/GlobalResponse.java
@@ -1,0 +1,11 @@
+package com.depromeet.global.config.response;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public record GlobalResponse(boolean success, int status, Object data, LocalDateTime timestamp) {
+    public static GlobalResponse of(int status, Object data) {
+        return new GlobalResponse(true, status, data, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/depromeet/global/config/response/GlobalResponseAdvice.java
+++ b/src/main/java/com/depromeet/global/config/response/GlobalResponseAdvice.java
@@ -1,0 +1,40 @@
+package com.depromeet.global.config.response;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class GlobalResponseAdvice implements ResponseBodyAdvice {
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response) {
+        HttpServletResponse servletResponse =
+                ((ServletServerHttpResponse) response).getServletResponse();
+        int status = servletResponse.getStatus();
+        HttpStatus resolve = HttpStatus.resolve(status);
+        if (resolve == null) {
+            return body;
+        }
+        if (resolve.is2xxSuccessful()) {
+            return GlobalResponse.of(status, body);
+        }
+        return body;
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #13 

---
## 📌 작업 내용 및 특이사항
- API 성공 응답 시 공통으로 응답 형태를 지정해주도록 어드바이스 생성
- GlabalResponse(record) 생성
- success(boolean), status(int), data(Object), timestamp(LocalDateTime) 필드를 사용합니다.
- 정적 팩토리 of 메소드를 사용하여 객체를 생성합니다 (status, data) 매개변수로 사용

