### PR TITLE
chore: Gradle Build Scan 활성화 및 슬랙 전송 워크플로 추가

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -16,6 +16,7 @@ jobs:
         distribution: [ 'temurin' ]
     outputs:
       sha: ${{ steps.github-sha-short.outputs.sha }}
+      scan-url: ${{ steps.gradle.outputs.build-scan-url }}
     steps:
       # 기본 체크아웃
       - name: Checkout
@@ -74,6 +75,17 @@ jobs:
           source: docker-compose.yaml
           target: /home/tenminute/
 
+      # 슬랙으로 빌드 스캔 결과 전송
+      - name: Send to slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+            "text": "Gradle Build Scan Report of ${{ github.workflow }}: ${{ steps.gradle.outputs.build-scan-url }}\\n ${{ github.event.head_commit.message }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   deploy:
     runs-on: ubuntu-latest
     environment: DEV
@@ -95,17 +107,3 @@ jobs:
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d
             docker image prune -a -f
-
-  notify:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Send to slack
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          payload: |
-            {
-              "text": "Gradle Build Scan Report of ${{ github.workflow }}: ${{ steps.gradle.outputs.build-scan-url }}\\n ${{ github.event.head_commit.message }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,8 +3,6 @@ name: develop Build And Deploy
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   build:
@@ -16,7 +14,6 @@ jobs:
         distribution: [ 'temurin' ]
     outputs:
       sha: ${{ steps.github-sha-short.outputs.sha }}
-      scan-url: ${{ steps.gradle.outputs.build-scan-url }}
     steps:
       # 기본 체크아웃
       - name: Checkout
@@ -81,7 +78,7 @@ jobs:
         with:
           payload: |
             {
-            "text": "Gradle Build Scan Report of ${{ github.workflow }}: ${{ steps.gradle.outputs.build-scan-url }}\\n ${{ github.event.head_commit.message }}"
+              "text": "Gradle Build Scan Report of ${{ github.workflow }}: ${{ steps.gradle.outputs.build-scan-url }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,6 +3,8 @@ name: develop Build And Deploy
 on:
   push:
     branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -95,3 +95,17 @@ jobs:
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d
             docker image prune -a -f
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Send to slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": "Gradle Build Scan Report of ${{ github.workflow }}: ${{ steps.gradle.outputs.build-scan-url }}\\n ${{ github.event.head_commit.message }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,8 +4,6 @@ plugins {
 
 gradleEnterprise {
     buildScan {
-        def getenv = System.getenv("CI")
-        println "getenv = $getenv"
         publishAlwaysIf(System.getenv("CI") != null)
         termsOfServiceUrl = "https://gradle.com/terms-of-service"
         termsOfServiceAgree = "yes"

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,8 @@ plugins {
 
 gradleEnterprise {
     buildScan {
+        def getenv = System.getenv("CI")
+        println "getenv = $getenv"
         publishAlwaysIf(System.getenv("CI") != null)
         termsOfServiceUrl = "https://gradle.com/terms-of-service"
         termsOfServiceAgree = "yes"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,13 @@
+plugins {
+    id "com.gradle.enterprise" version "3.15.1"
+}
+
+gradleEnterprise {
+    buildScan {
+        publishAlwaysIf(System.getenv("CI") != null)
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+    }
+}
+
 rootProject.name = 'tenminute'


### PR DESCRIPTION
## 🌱 관련 이슈
- close #17 

---
## 📌 작업 내용 및 특이사항
- `slack-github-action`을 사용하여 슬랙으로 gradle build scan report의 url을 전송합니다.
<img width="373" alt="image" src="https://github.com/depromeet/10mm-server/assets/91878695/f55cfd69-1d4b-4442-ab35-d0c6bd5051c4">
(실제로는 \n은 전송되지 않습니다)

- gradle build scan의 report publish를 활성화
    - CI 환경에서만 publish 되도록 설정 (`publishAlwaysIf(System.getenv("CI") != null)`) 

---
## 📝 참고사항
- 

--- 
## 📚 기타
- 

