### PR TITLE
chore: cors 기본 설정

### DIFF
--- a/src/main/java/com/depromeet/global/config/CorsConfig.java
+++ b/src/main/java/com/depromeet/global/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package com.depromeet.global.config;
+
+import java.util.ArrayList;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		ArrayList<String> allowedOriginPatterns = new ArrayList<>();
+		allowedOriginPatterns.add("https://10mm.today");
+		allowedOriginPatterns.add("https://dev.10mm.today");
+
+		String[] patterns = allowedOriginPatterns.toArray(String[]::new);
+		registry.addMapping("/**")
+			.allowedMethods("*")
+			.allowedOriginPatterns(patterns)
+			.allowedHeaders("Authorization", "Content-Type")
+			.exposedHeaders("Set-Cookie")
+			.allowCredentials(true);
+	}
+}

--- a/src/main/java/com/depromeet/global/config/CorsConfig.java
+++ b/src/main/java/com/depromeet/global/config/CorsConfig.java
@@ -21,6 +21,8 @@ public class CorsConfig implements WebMvcConfigurer {
 			.allowedOriginPatterns(patterns)
 			.allowedHeaders("Authorization", "Content-Type")
 			.exposedHeaders("Set-Cookie")
-			.allowCredentials(true);
+			.allowCredentials(true)
+			// preflight request에 대한 응답을 캐시할 수 있는 시간
+			.maxAge(3600);
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
<p> # 뒤에 이슈 번호를 작성해주세요. <p>

- close #24 

---
## 📌 작업 내용 및 특이사항
- 다른 origin에서 Server 리소스에 함부로 접근하지 못하게 하기 위해 Cors 설정
- 10mm.today 도메인만 리소스 접근 허용
- maxAge 옵션으로 preflight request에 대한 응답을 캐시할 수 있는 시간을 설정

---
## 📝 참고사항
- [preflight 참고 링크](https://2step-hyun.tistory.com/112)

--- 
## 📚 기타
- 

