### PR TITLE
chore: 워크플로에서 `set-output` 커맨드 제거

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -104,7 +104,7 @@ jobs:
           port: ${{ secrets.NCP_PORT }}
           envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수
           script: |
-            echo ${{ env
+            echo ${{ env.NCP_IMAGE_TAG }}
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.NCP_IMAGE_TAG }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -72,7 +72,7 @@ jobs:
         uses: appleboy/scp-action@v0.1.4
         with:
           host: ${{ secrets.NCP_HOST }}
-          username: tenminute
+          username: ${{ secrets.NCP_USERNAME }}
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
           source: docker-compose.yaml

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "develop" ]
 
+env:
+  IMAGE_TAG: ${GITHUB_SHA::7}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,11 +35,9 @@ jobs:
 #      - name: GitHub SHA Short
 #        id: github-sha-short
 #        run: echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
-      - name: Add SHORT_SHA env
-        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
-      - name: Test SHORT_SHA env
-        run: echo $SHORT_SHA
+      - name: Test IMAGE_TAG
+        run: echo ${{ env.IMAGE_TAG }}
 
       # Gradlew 실행 허용
       - name: Run chmod to make gradlew executable
@@ -66,7 +67,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.SHORT_SHA }}
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.IMAGE_TAG }}
 
       # 서버로 docker-compose 파일 전송
       - name: Copy docker-compose.yml to NCP Server
@@ -99,7 +100,7 @@ jobs:
         uses: appleboy/ssh-action@master
         env:
           NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
-          NCP_IMAGE_TAG: ${{ env.SHORT_SHA }}
+          NCP_IMAGE_TAG: ${{ env.IMAGE_TAG }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute
@@ -107,7 +108,7 @@ jobs:
           port: ${{ secrets.NCP_PORT }}
           envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수
           script: |
-            echo ${{ env.SHORT_SHA }}
+            echo ${{ env.NCP_IMAGE_TAG }}
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.NCP_IMAGE_TAG }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -29,13 +29,13 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.distribution }}
 
-      # IMAGE_TAG 환경 변수 설정
-      - name: Set up IMAGE_TAG
+      # 이미지 태그 설정
+      - name: Set up image-tag by GITHUB_SHA
         id: image-tag
-        run: echo "value=$(echo ${GITHUB_SHA::7})" >> $GITHUB_ENV
+        run: echo "value=$(echo ${GITHUB_SHA::7})" >> $GITHUB_OUTPUT
 
       - name: Test IMAGE_TAG
-        run: echo ${{ env.IMAGE_TAG }}
+        run: echo ${{ steps.image-tag.outputs.value }}
 
       # Gradlew 실행 허용
       - name: Run chmod to make gradlew executable
@@ -65,7 +65,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ steps.image-tag.outputs.value }}
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ steps.build.outputs.image-tag }}
 
       # 서버로 docker-compose 파일 전송
       - name: Copy docker-compose.yml to NCP Server
@@ -98,7 +98,7 @@ jobs:
         uses: appleboy/ssh-action@master
         env:
           NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
-          NCP_IMAGE_TAG: ${{ needs.build.outputs.image-tag.value }}
+          NCP_IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "develop" ]
 
-env:
-  IMAGE_TAG: ${{ echo ${{ github.sha }} | cut -c1-7 }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,8 +14,9 @@ jobs:
       matrix:
         java-version: [ 17 ]
         distribution: [ 'temurin' ]
-#    outputs:
-#      sha: ${{ steps.github-sha-short.outputs.sha }}
+    outputs:
+      # IMAGE_TAG 환경 변수를 다른 Job에서 사용하기 위해 설정
+      image-tag: ${{ steps.image-tag.outputs.value }}
     steps:
       # 기본 체크아웃
       - name: Checkout
@@ -31,10 +29,10 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.distribution }}
 
-      # GITHUB SHA Short
-#      - name: GitHub SHA Short
-#        id: github-sha-short
-#        run: echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
+      # IMAGE_TAG 환경 변수 설정
+      - name: Set up IMAGE_TAG
+        id: image-tag
+        run: echo "value=$(echo ${GITHUB_SHA::7})" >> $GITHUB_ENV
 
       - name: Test IMAGE_TAG
         run: echo ${{ env.IMAGE_TAG }}
@@ -67,7 +65,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.IMAGE_TAG }}
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ steps.image-tag.outputs.value }}
 
       # 서버로 docker-compose 파일 전송
       - name: Copy docker-compose.yml to NCP Server
@@ -100,7 +98,7 @@ jobs:
         uses: appleboy/ssh-action@master
         env:
           NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
-          NCP_IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          NCP_IMAGE_TAG: ${{ needs.build.outputs.image-tag.value }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ steps.build.outputs.image-tag }}
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ steps.image-tag.outputs.value }}
 
       # 서버로 docker-compose 파일 전송
       - name: Copy docker-compose.yml to NCP Server

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -29,9 +29,11 @@ jobs:
           distribution: ${{ matrix.distribution }}
 
       # GITHUB SHA Short
-      - name: GitHub SHA Short
-        id: github-sha-short
-        run: echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
+#      - name: GitHub SHA Short
+#        id: github-sha-short
+#        run: echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
+      - name: Add GITHUB_SHORT_SHA env
+        run: echo "GITHUB_SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
       # Gradlew 실행 허용
       - name: Run chmod to make gradlew executable
@@ -61,7 +63,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ steps.github-sha-short.outputs.sha }}
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.GITHUB_SHORT_SHA }}
 
       # 서버로 docker-compose 파일 전송
       - name: Copy docker-compose.yml to NCP Server
@@ -94,7 +96,7 @@ jobs:
         uses: appleboy/ssh-action@master
         env:
           NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
-          NCP_IMAGE_TAG: ${{ needs.build.outputs.sha }}
+          NCP_IMAGE_TAG: ${{ env.GITHUB_SHORT_SHA }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute
@@ -103,6 +105,6 @@ jobs:
           envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수
           script: |
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
-            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ needs.build.outputs.sha }}
+            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.GITHUB_SHORT_SHA }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d
             docker image prune -a -f

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -34,9 +34,6 @@ jobs:
         id: image-tag
         run: echo "value=$(echo ${GITHUB_SHA::7})" >> $GITHUB_OUTPUT
 
-      - name: Test IMAGE_TAG
-        run: echo ${{ steps.image-tag.outputs.value }}
-
       # Gradlew 실행 허용
       - name: Run chmod to make gradlew executable
         run: chmod +x ./gradlew
@@ -106,7 +103,6 @@ jobs:
           port: ${{ secrets.NCP_PORT }}
           envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수
           script: |
-            echo ${{ env.NCP_IMAGE_TAG }}
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.NCP_IMAGE_TAG }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -96,7 +96,7 @@ jobs:
           NCP_IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
         with:
           host: ${{ secrets.NCP_HOST }}
-          username: tenminute
+          username: ${{ secrets.NCP_USERNAME }}
           key: ${{ secrets.NCP_PRIVATE_KEY }}
           port: ${{ secrets.NCP_PORT }}
           envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "develop" ]
 
 env:
-  IMAGE_TAG: ${GITHUB_SHA::7}
+  IMAGE_TAG: ${{ echo ${{ github.sha }} | cut -c1-7 }}
 
 jobs:
   build:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,8 +3,6 @@ name: develop Build And Deploy
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         java-version: [ 17 ]
         distribution: [ 'temurin' ]
-    outputs:
-      sha: ${{ steps.github-sha-short.outputs.sha }}
+#    outputs:
+#      sha: ${{ steps.github-sha-short.outputs.sha }}
     steps:
       # 기본 체크아웃
       - name: Checkout
@@ -32,8 +32,8 @@ jobs:
 #      - name: GitHub SHA Short
 #        id: github-sha-short
 #        run: echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
-      - name: Add GITHUB_SHORT_SHA env
-        run: echo "GITHUB_SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+      - name: Add SHORT_SHA env
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
       # Gradlew 실행 허용
       - name: Run chmod to make gradlew executable
@@ -63,7 +63,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.GITHUB_SHORT_SHA }}
+          tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.SHORT_SHA }}
 
       # 서버로 docker-compose 파일 전송
       - name: Copy docker-compose.yml to NCP Server
@@ -96,7 +96,7 @@ jobs:
         uses: appleboy/ssh-action@master
         env:
           NCP_CONTAINER_REGISTRY: ${{ secrets.NCP_CONTAINER_REGISTRY }}
-          NCP_IMAGE_TAG: ${{ env.GITHUB_SHORT_SHA }}
+          NCP_IMAGE_TAG: ${{ env.SHORT_SHA }}
         with:
           host: ${{ secrets.NCP_HOST }}
           username: tenminute
@@ -104,7 +104,8 @@ jobs:
           port: ${{ secrets.NCP_PORT }}
           envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수
           script: |
+            echo ${{ env
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
-            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.GITHUB_SHORT_SHA }}
+            docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.NCP_IMAGE_TAG }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d
             docker image prune -a -f

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,6 +3,8 @@ name: develop Build And Deploy
 on:
   push:
     branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Add SHORT_SHA env
         run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
+      - name: Test SHORT_SHA env
+        run: echo $SHORT_SHA
+
       # Gradlew 실행 허용
       - name: Run chmod to make gradlew executable
         run: chmod +x ./gradlew
@@ -104,7 +107,7 @@ jobs:
           port: ${{ secrets.NCP_PORT }}
           envs: NCP_CONTAINER_REGISTRY,NCP_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수
           script: |
-            echo ${{ env.NCP_IMAGE_TAG }}
+            echo ${{ env.SHORT_SHA }}
             echo "${{ secrets.NCP_SECRET_KEY }}" | docker login -u "${{ secrets.NCP_ACCESS_KEY }}" --password-stdin "${{ secrets.NCP_CONTAINER_REGISTRY }}"
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ env.NCP_IMAGE_TAG }}
             docker compose -f /home/tenminute/docker-compose.yaml up -d


### PR DESCRIPTION
## 🌱 관련 이슈
- close #32 

## 📌 작업 내용 및 특이사항
- `github-sha-short` 스텝 이름을 `image-tag` 으로 변경했습니다.
-  곧 deprecated 되는 `set-output` 대신 `GITHUB_OUTPUT` 을 사용하도록 개선했습니다. [(레퍼런스)](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- NCP username을 시크릿 처리했습니다.

## 📝 참고사항
- 

## 📚 기타
- 
