### PR TITLE
fix: GlobalResponseAdvice 응답 값이 String 타입 예외 처리

### DIFF
--- a/src/main/java/com/depromeet/global/config/response/GlobalResponseAdvice.java
+++ b/src/main/java/com/depromeet/global/config/response/GlobalResponseAdvice.java
@@ -29,7 +29,7 @@ public class GlobalResponseAdvice implements ResponseBodyAdvice {
                 ((ServletServerHttpResponse) response).getServletResponse();
         int status = servletResponse.getStatus();
         HttpStatus resolve = HttpStatus.resolve(status);
-        if (resolve == null) {
+        if (resolve == null || body instanceof String) {
             return body;
         }
         if (resolve.is2xxSuccessful()) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #55 

## 📌 작업 내용 및 특이사항
- `ExampleController에서 `ResponseEntity.ok("test string")` 리턴 시 다음 에러 발생
```
java.lang.ClassCastException: class com.depromeet.global.config.response.GlobalResponse cannot be cast to class java.lang.String (com.depromeet.global.config.response.GlobalResponse is in unnamed module 
```
GlobalResponse 클래스 data 필드가 Object 타입일 때, String 타입으로 객체 전달 시 에러 발생

String은 Object의 하위 클래스이지만 업캐스팅(Upcasting)을 해도 컴파일러가 String을 Object로 암묵적으로 변환하는 것을 허용하지 않는다고 합니다. String이 Object의 서브클래스라 할지라도, 타입 불일치로 처리
