### PR TITLE
fix: Swagger가 안뜨는 문제 해결

### DIFF
--- a/src/main/java/com/depromeet/global/config/response/GlobalResponseAdvice.java
+++ b/src/main/java/com/depromeet/global/config/response/GlobalResponseAdvice.java
@@ -10,7 +10,7 @@ import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-@RestControllerAdvice
+@RestControllerAdvice(basePackages = "com.depromeet")
 public class GlobalResponseAdvice implements ResponseBodyAdvice {
     @Override
     public boolean supports(MethodParameter returnType, Class converterType) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #65 

## 📌 작업 내용 및 특이사항
- Swagger는 '/api/v3/api-docs` 로 패칭해서 가져오는데 공통 성공 응답 시 basePackage를 명시해 놓지 않아
스웨거의 응답값 마져 공통으로 응답형식을 바꿔져서 Swagger 해석하지 못하게 되는 문제를 해결합니다.
- GlobalResponseAdvice에 basePackages 적용

## 📝 참고사항
- https://devnm.tistory.com/28