### PR TITLE
fix: Swagger에 Server 리스트 안보이는 문제해결

### DIFF
--- a/src/main/java/com/depromeet/global/config/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/global/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.depromeet.global.config;
 
 import static com.depromeet.global.util.SpringEnvironmentUtil.*;
 
+import com.depromeet.global.common.constants.UrlConstants;
 import com.depromeet.global.util.SpringEnvironmentUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.jackson.ModelResolver;
@@ -48,11 +49,11 @@ public class SwaggerConfig {
     private String getServerUrl() {
         switch (springEnvironmentUtil.getCurrentProfile()) {
             case "prod":
-                return "https://api.10mm.today";
+                return UrlConstants.PROD_SERVER_URL.getValue();
             case "dev":
-                return "https://dev-api.10mm.today";
+                return UrlConstants.DEV_SERVER_URL.getValue();
             default:
-                return "https://localhost:8080";
+                return UrlConstants.LOCAL_SERVER_URL.getValue();
         }
     }
 

--- a/src/main/java/com/depromeet/global/config/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/global/config/SwaggerConfig.java
@@ -1,5 +1,8 @@
 package com.depromeet.global.config;
 
+import static com.depromeet.global.util.SpringEnvironmentUtil.*;
+
+import com.depromeet.global.util.SpringEnvironmentUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.oas.models.Components;
@@ -10,23 +13,52 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.In;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import io.swagger.v3.oas.models.servers.Server;
-import jakarta.servlet.ServletContext;
+import lombok.RequiredArgsConstructor;
+
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
+	private static final String SERVER_NAME = "10MM";
+	private static final String API_TITLE = "10MM 서버 API 문서";
+	private static final String API_DESCRIPTION = "10MM 서버 API 문서입니다.";
+	private static final String GITHUB_URL = "https://github.com/depromeet/10mm-server";
+
+
+	private final SpringEnvironmentUtil springEnvironmentUtil;
 
     @Value("${swagger.version}")
     private String version;
 
     @Bean
-    public OpenAPI openAPI(ServletContext servletContext) {
-        Server server = new Server().url(servletContext.getContextPath());
-        return new OpenAPI().servers(List.of(server)).components(authSetting()).info(swaggerInfo());
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+			.servers(swaggerServers())
+			.components(authSetting())
+			.info(swaggerInfo());
     }
+
+	private List<Server> swaggerServers() {
+		Server server = new Server()
+			.url(getServerUrl())
+			.description(API_DESCRIPTION);
+		return List.of(server);
+	}
+
+	private String getServerUrl() {
+		switch (springEnvironmentUtil.getCurrentProfile()) {
+			case "prod":
+				return "https://api.10mm.today";
+			case "dev":
+				return "https://dev-api.10mm.today";
+			default:
+				return "https://localhost:8080";
+		}
+	}
 
     private Components authSetting() {
         return new Components()
@@ -42,13 +74,13 @@ public class SwaggerConfig {
 
     private Info swaggerInfo() {
         License license = new License();
-        license.setUrl("https://github.com/depromeet/10mm-server");
-        license.setName("10MM Server Repository");
+        license.setUrl(GITHUB_URL);
+        license.setName(SERVER_NAME);
 
         return new Info()
                 .version("v" + version)
-                .title("\"10MM 서버 API문서\"")
-                .description("10MM 서버 API 문서입니다.")
+                .title(API_TITLE)
+                .description(API_DESCRIPTION)
                 .license(license);
     }
 

--- a/src/main/java/com/depromeet/global/config/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/global/config/SwaggerConfig.java
@@ -13,9 +13,8 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.In;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import io.swagger.v3.oas.models.servers.Server;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,13 +22,12 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 public class SwaggerConfig {
-	private static final String SERVER_NAME = "10MM";
-	private static final String API_TITLE = "10MM 서버 API 문서";
-	private static final String API_DESCRIPTION = "10MM 서버 API 문서입니다.";
-	private static final String GITHUB_URL = "https://github.com/depromeet/10mm-server";
+    private static final String SERVER_NAME = "10MM";
+    private static final String API_TITLE = "10MM 서버 API 문서";
+    private static final String API_DESCRIPTION = "10MM 서버 API 문서입니다.";
+    private static final String GITHUB_URL = "https://github.com/depromeet/10mm-server";
 
-
-	private final SpringEnvironmentUtil springEnvironmentUtil;
+    private final SpringEnvironmentUtil springEnvironmentUtil;
 
     @Value("${swagger.version}")
     private String version;
@@ -37,28 +35,26 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-			.servers(swaggerServers())
-			.components(authSetting())
-			.info(swaggerInfo());
+                .servers(swaggerServers())
+                .components(authSetting())
+                .info(swaggerInfo());
     }
 
-	private List<Server> swaggerServers() {
-		Server server = new Server()
-			.url(getServerUrl())
-			.description(API_DESCRIPTION);
-		return List.of(server);
-	}
+    private List<Server> swaggerServers() {
+        Server server = new Server().url(getServerUrl()).description(API_DESCRIPTION);
+        return List.of(server);
+    }
 
-	private String getServerUrl() {
-		switch (springEnvironmentUtil.getCurrentProfile()) {
-			case "prod":
-				return "https://api.10mm.today";
-			case "dev":
-				return "https://dev-api.10mm.today";
-			default:
-				return "https://localhost:8080";
-		}
-	}
+    private String getServerUrl() {
+        switch (springEnvironmentUtil.getCurrentProfile()) {
+            case "prod":
+                return "https://api.10mm.today";
+            case "dev":
+                return "https://dev-api.10mm.today";
+            default:
+                return "https://localhost:8080";
+        }
+    }
 
     private Components authSetting() {
         return new Components()


### PR DESCRIPTION
## 🌱 관련 이슈
- close #67 

## 📌 작업 내용 및 특이사항
- 서버 리스트가 나오지 않는 문제를 해결합니다
![image](https://github.com/depromeet/10mm-server/assets/64088250/ef5de73c-2bbb-442c-b16d-b82b3bfebf31)

- SpringEnvironmentUtil을 사용하여 서버 목록을 동적으로 추가합니다.
- 아래 코드부분은 #69 에서 공통 상수 처리시 변경하겠습니다
```java
private String getServerUrl() {
		switch (springEnvironmentUtil.getCurrentProfile()) {
			case "prod":
				return "https://api.10mm.today";
			case "dev":
				return "https://dev-api.10mm.today";
			default:
				return "https://localhost:8080";
		}
	}
```
