### PR TITLE
chore: `application.yml` 환경별 분리

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,3 +6,5 @@ services:
     container_name: server-spring
     restart: always
     network_mode: host
+    env_file:
+      - .env

--- a/src/main/resources/application-actuator.yml
+++ b/src/main/resources/application-actuator.yml
@@ -7,7 +7,7 @@ management:
     web:
       exposure:
         include: health
-      base-path: ${ACTUATOR_BASE_PATH:}/10mm-actuator
+      base-path: /10mm-actuator
     jmx:
       exposure:
         exclude: "*"

--- a/src/main/resources/application-actuator.yml
+++ b/src/main/resources/application-actuator.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: "actuator"
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+      base-path: ${ACTUATOR_BASE_PATH:}/10mm-actuator
+    jmx:
+      exposure:
+        exclude: "*"
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -14,4 +14,3 @@ spring:
     properties:
       hibernate:
         default_batch_fetch_size: ${JPA_BATCH_FETCH_SIZE:100}
-

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -14,6 +14,5 @@ spring:
     properties:
       hibernate:
         default_batch_fetch_size: ${JPA_BATCH_FETCH_SIZE:100}
-    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
 
 

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -15,4 +15,3 @@ spring:
       hibernate:
         default_batch_fetch_size: ${JPA_BATCH_FETCH_SIZE:100}
 
-

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: "datasource"
+  datasource:
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&tinyInt1isBit=false
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maxLifetime: 580000
+      maximum-pool-size: 20
+    password: ${MYSQL_PASSWORD}
+    username: ${MYSQL_USERNAME}
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: ${JPA_BATCH_FETCH_SIZE:100}
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+
+

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,12 @@
+spring:
+  config:
+    activate:
+      on-profile: "dev"
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+logging:
+  level:
+    org.springframework.orm.jpa: DEBUG
+    org.springframework.transaction: DEBUG

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: "local"
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: ${SHOW_SQL:true}
+    properties:
+      hibernate:
+        format_sql: ${FORMAT_SQL:true}
+    defer-datasource-initialization: true
+    open-in-view: false
+logging:
+  level:
+    org.springframework.orm.jpa: DEBUG
+    org.springframework.transaction: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,7 @@
+spring:
+  config:
+    activate:
+      on-profile: "prod"
+  jpa:
+    hibernate:
+      ddl-auto: none

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,22 +1,13 @@
-# Actuator 설정
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health
-      base-path: /10mm-actuator
-    jmx:
-      exposure:
-        exclude: "*"
-    enabled-by-default: false
-  endpoint:
-    health:
-      enabled: true
+spring:
+  profiles:
+    group:
+      test: "test"
+      local: "local, datasource"
+      dev: "dev, datasource, actuator"
+      prod: "prod, datasource, actuator"
 
 swagger:
   version: 0.0.1
-
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
@@ -29,3 +20,7 @@ springdoc:
     syntax-highlight:
       theme: none
     urls-primary-name: 10MM API DOCS
+
+logging:
+  level:
+    com.depromeet.domain.*.api.*: debug

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+spring:
+  config:
+    activate:
+      on-profile: "test"
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL


### PR DESCRIPTION
## 🌱 관련 이슈
- close #52 

## 📌 작업 내용 및 특이사항
- application.yml을 환경변로 분리했습니다.
```yaml
spring:
  profiles:
    group:
      test: "test"
      local: "local, datasource"
      dev: "dev, datasource, actuator"
      prod: "prod, datasource, actuator"
```
기본 `application.yml`파일에서 위와같이 그룹을 통해서 중복 코드를 제거할 수 있습니다.
새로운 환경의 yml파일이 필요하다면 추가해주시면 됩니다.

```yaml
---
spring:
  config:
    activate:
      on-profile: local
---
spring:
  config:
    activate:
      on-profile: dev
```
와 같은 방법은 분리하려했는데 중복코드가 많아서 사용하지 않았습니다

+ 놓친 설정이 있다면 알려주세용 😆
