### PR TITLE
chore: Redis 설정

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
       # test 돌릴때 레디스 필요
       - name: Start containers
-        run: docker-compose up -d
+        run: docker-compose -f ./docker-compose-test.yaml up -d
 
       # Gradlew 실행 허용
       - name: Run chmod to make gradlew executable

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -32,6 +32,10 @@ jobs:
         id: image-tag
         run: echo "value=$(echo ${GITHUB_SHA::7})" >> $GITHUB_OUTPUT
 
+      # test 돌릴때 레디스 필요
+      - name: Start containers
+        run: docker-compose up -d
+
       # Gradlew 실행 허용
       - name: Run chmod to make gradlew executable
         run: chmod +x ./gradlew

--- a/.github/workflows/develop_pull_request.yml
+++ b/.github/workflows/develop_pull_request.yml
@@ -19,6 +19,9 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
 
+      - name: Start containers  # test 돌릴때 레디스 필요
+        run: docker-compose up -d
+
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 

--- a/.github/workflows/develop_pull_request.yml
+++ b/.github/workflows/develop_pull_request.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Start containers  # test 돌릴때 레디스 필요
-        run: docker-compose up -d
+        run: docker-compose -f ./docker-compose-test.yaml up -d
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('bootBuildImage') {

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,0 +1,9 @@
+version: "3.8"
+
+services:
+  redis:
+    image: "redis:alpine"
+    ports:
+      - "6379:6379"
+    environment:
+      - TZ=Asia/Seoul

--- a/src/main/java/com/depromeet/infra/config/RedisConfig.java
+++ b/src/main/java/com/depromeet/infra/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.depromeet.infra.config;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig =
+                new RedisStandaloneConfiguration(redisHost, redisPort);
+        if (!redisPassword.isBlank()) redisConfig.setPassword(redisPassword);
+        LettuceClientConfiguration clientConfig =
+                LettuceClientConfiguration.builder()
+                        .commandTimeout(Duration.ofSeconds(1))
+                        .shutdownTimeout(Duration.ZERO)
+                        .build();
+        return new LettuceConnectionFactory(redisConfig, clientConfig);
+    }
+}

--- a/src/main/java/com/depromeet/infra/config/RedisConfig.java
+++ b/src/main/java/com/depromeet/infra/config/RedisConfig.java
@@ -13,13 +13,13 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 @EnableRedisRepositories
 @Configuration
 public class RedisConfig {
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String redisHost;
 
-    @Value("${spring.redis.port}")
+	@Value("${spring.data.redis.port}")
     private int redisPort;
 
-    @Value("${spring.redis.password}")
+	@Value("${spring.data.redis.password}")
     private String redisPassword;
 
     @Bean

--- a/src/main/java/com/depromeet/infra/config/RedisConfig.java
+++ b/src/main/java/com/depromeet/infra/config/RedisConfig.java
@@ -16,10 +16,10 @@ public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String redisHost;
 
-	@Value("${spring.data.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int redisPort;
 
-	@Value("${spring.data.redis.password}")
+    @Value("${spring.data.redis.password}")
     private String redisPassword;
 
     @Bean

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "redis"
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,9 @@ spring:
   profiles:
     group:
       test: "test"
-      local: "local, datasource"
-      dev: "dev, datasource, actuator"
-      prod: "prod, datasource, actuator"
+      local: "local, datasource, redis"
+      dev: "dev, datasource, redis, actuator"
+      prod: "prod, datasource, redis, actuator"
 
 swagger:
   version: 0.0.1

--- a/src/test/java/com/depromeet/TenminuteApplicationTests.java
+++ b/src/test/java/com/depromeet/TenminuteApplicationTests.java
@@ -2,8 +2,10 @@ package com.depromeet;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class TenminuteApplicationTests {
     @Test
     void contextLoads() {}

--- a/src/test/java/com/depromeet/global/util/MemberUtilTest.java
+++ b/src/test/java/com/depromeet/global/util/MemberUtilTest.java
@@ -8,8 +8,10 @@ import com.depromeet.domain.member.domain.Profile;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MemberUtilTest {
 
     @Autowired private MemberUtil memberUtil;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,3 +4,9 @@ spring:
       on-profile: "test"
   datasource:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:


### PR DESCRIPTION
## 🌱 관련 이슈
- close #85

## 📌 작업 내용 및 특이사항
- Redis를 사용하기 위한 Redis Config 추가
- redis yml 파일 생성
- 테스트 환경에서 격리 된 redis를 생성하기위해 `docker-compose-test.yml`을 생성 후 빌드과정에서 사용합니다.
- 기존 `SpringBootTest`에서 미리 생성해 둔 `profile=test`를 사용하고 있지 않아 `@ActiveProfiles`을 통해 test profile을 사용하도록 설정해두었습니다

## 📝 참고사항
- 

## 📚 기타
- 
