### PR TITLE
fix: MemberUtilTest에 DatabaseCleaner 적용

### DIFF
--- a/src/test/java/com/depromeet/global/util/MemberUtilTest.java
+++ b/src/test/java/com/depromeet/global/util/MemberUtilTest.java
@@ -6,7 +6,6 @@ import com.depromeet.DatabaseCleaner;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.Profile;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,12 +16,12 @@ class MemberUtilTest {
 
     @Autowired private MemberUtil memberUtil;
     @Autowired private MemberRepository memberRepository;
-	@Autowired private DatabaseCleaner databaseCleaner;
+    @Autowired private DatabaseCleaner databaseCleaner;
 
-	@BeforeEach
-	void setUp() {
-		databaseCleaner.execute();
-	}
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+    }
 
     @Test
     void 이미_회원이_존재하면_임시_회원을_삽입하지_않는다() {

--- a/src/test/java/com/depromeet/global/util/MemberUtilTest.java
+++ b/src/test/java/com/depromeet/global/util/MemberUtilTest.java
@@ -2,9 +2,12 @@ package com.depromeet.global.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.depromeet.DatabaseCleaner;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.Profile;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,6 +17,12 @@ class MemberUtilTest {
 
     @Autowired private MemberUtil memberUtil;
     @Autowired private MemberRepository memberRepository;
+	@Autowired private DatabaseCleaner databaseCleaner;
+
+	@BeforeEach
+	void setUp() {
+		databaseCleaner.execute();
+	}
 
     @Test
     void 이미_회원이_존재하면_임시_회원을_삽입하지_않는다() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #89

## 📌 작업 내용 및 특이사항
- MemberUtilTest에 DatabaseCleaner가 적용되지 않아
다른 Service 테스트에서 잔여하는 Member로 인해 테스트 실패 케이스 발생


![image](https://github.com/depromeet/10mm-server/assets/64088250/b708b90c-8b7b-456f-8923-9c76b305f7a1)


## 📝 참고사항
- 

## 📚 기타
- 
