### PR TITLE
feat: 미션 기록 저장 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -20,11 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class MissionRecordController {
     private final MissionRecordService missionRecordService;
 
-    @Operation(summary = "미션 기록 생성", description = "미션 기록을 생성합니다.")
+    @Operation(summary = "미션 기록 생성", description = "미션 기록을 생성하고 생성 된 id를 반환합니다.")
     @PostMapping
-    public ResponseEntity<Void> missionRecordCreate(
+    public ResponseEntity<Long> missionRecordCreate(
             @Valid @RequestBody MissionRecordCreateRequest request) {
-        missionRecordService.createMissionRecord(request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        Long missionRecordId = missionRecordService.createMissionRecord(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(missionRecordId);
     }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -1,0 +1,30 @@
+package com.depromeet.domain.missionRecord.api;
+
+import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
+import com.depromeet.domain.missionRecord.service.MissionRecordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "[미션 기록]", description = "미션 기록 관련 API")
+@RestController
+@RequestMapping("/records")
+@RequiredArgsConstructor
+public class MissionRecordController {
+    private final MissionRecordService missionRecordService;
+
+    @Operation(summary = "미션 기록 생성", description = "미션 기록을 생성합니다.")
+    @PostMapping
+    public ResponseEntity<Void> missionRecordCreate(
+            @Valid @RequestBody MissionRecordCreateRequest request) {
+        missionRecordService.createMissionRecord(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
@@ -75,6 +75,9 @@ public class MissionRecord extends BaseTimeEntity {
             Mission mission) {
         Integer duration = durationMin * 60 + durationSec;
 
+        if (duration > 3600) {
+            duration = 3600;
+        }
         return MissionRecord.builder()
                 .duration(duration)
                 .uploadStatus(ImageUploadStatus.NONE)

--- a/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
@@ -2,6 +2,9 @@ package com.depromeet.domain.missionRecord.domain;
 
 import com.depromeet.domain.common.model.BaseTimeEntity;
 import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,6 +15,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,13 +33,12 @@ public class MissionRecord extends BaseTimeEntity {
     @Column(name = "mission_record_id")
     private Long id;
 
-    private Integer duration;
+    private Duration duration;
 
     @Comment("미션 일지")
     private String remark;
 
     @Comment("인증 사진")
-    @Column(nullable = false)
     private String imageUrl;
 
     @Enumerated(EnumType.STRING)
@@ -51,7 +54,7 @@ public class MissionRecord extends BaseTimeEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private MissionRecord(
-            Integer duration,
+            Duration duration,
             String remark,
             String imageUrl,
             ImageUploadStatus uploadStatus,
@@ -68,16 +71,7 @@ public class MissionRecord extends BaseTimeEntity {
     }
 
     public static MissionRecord createMissionRecord(
-            Integer durationMin,
-            Integer durationSec,
-            LocalDateTime startedAt,
-            LocalDateTime finishedAt,
-            Mission mission) {
-        Integer duration = durationMin * 60 + durationSec;
-
-        if (duration > 3600) {
-            duration = 3600;
-        }
+            Duration duration, LocalDateTime startedAt, LocalDateTime finishedAt, Mission mission) {
         return MissionRecord.builder()
                 .duration(duration)
                 .uploadStatus(ImageUploadStatus.NONE)

--- a/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
@@ -2,9 +2,6 @@ package com.depromeet.domain.missionRecord.domain;
 
 import com.depromeet.domain.common.model.BaseTimeEntity;
 import com.depromeet.domain.mission.domain.Mission;
-import com.depromeet.global.error.exception.CustomException;
-import com.depromeet.global.error.exception.ErrorCode;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
@@ -68,19 +68,18 @@ public class MissionRecord extends BaseTimeEntity {
     }
 
     public static MissionRecord createMissionRecord(
-            Integer duration,
-            String remark,
-            String imageUrl,
+            Integer durationMin,
+            Integer durationSec,
             LocalDateTime startedAt,
             LocalDateTime finishedAt,
             Mission mission) {
+        Integer duration = durationMin * 60 + durationSec;
+
         return MissionRecord.builder()
                 .duration(duration)
-                .remark(remark)
                 .uploadStatus(ImageUploadStatus.NONE)
                 .startedAt(startedAt)
                 .finishedAt(finishedAt)
-                .imageUrl(imageUrl)
                 .mission(mission)
                 .build();
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/request/MissionRecordCreateRequest.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/request/MissionRecordCreateRequest.java
@@ -2,6 +2,8 @@ package com.depromeet.domain.missionRecord.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
@@ -29,9 +31,13 @@ public record MissionRecordCreateRequest(
                         defaultValue = "2023-01-03 00:34:00",
                         type = "string")
                 LocalDateTime finishedAt,
-        @NotNull(message = "미션 참여 한 시간(분)은 비워둘 수 없습니다.")
-                @Schema(description = "미션 참여 한 시간(분)", defaultValue = "32")
+        @NotNull(message = "미션 참여 시간(분)은 비워둘 수 없습니다.")
+		@Min(value = 0, message = "미션 참여 시간(분)의 최소 값은 0입니다.")
+		@Max(value = 60, message = "미션 참여 시간(분)의 최대값은 60입니다.")
+                @Schema(description = "미션 참여 시간(분)", defaultValue = "32")
                 Integer durationMin,
-        @NotNull(message = "미션 참여 한 시간(초)은 비워둘 수 없습니다.")
-                @Schema(description = "미션 참여 한 시간(초)", defaultValue = "14")
+        @NotNull(message = "미션 참여 시간(초)은 비워둘 수 없습니다.")
+		@Min(value = 0, message = "미션 참여 시간(초)의 최소값는 0입니다.")
+		@Max(value = 60, message = "미션 참여 시간(초)의 최대값는 60입니다.")
+                @Schema(description = "미션 참여 시간(초)", defaultValue = "14")
                 Integer durationSec) {}

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/request/MissionRecordCreateRequest.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/request/MissionRecordCreateRequest.java
@@ -1,0 +1,37 @@
+package com.depromeet.domain.missionRecord.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record MissionRecordCreateRequest(
+        @NotNull(message = "미션 아이디는 비워둘 수 없습니다.")
+                @Schema(description = "미션 아이디", defaultValue = "1")
+                Long missionId,
+        @NotNull(message = "미션 기록 시작 시간은 비워둘 수 없습니다.")
+                @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 기록 시작 시간",
+                        defaultValue = "2024-01-03 00:00:00",
+                        type = "string")
+                LocalDateTime startedAt,
+        @NotNull(message = "미션 기록 종료 시간은 비워둘 수 없습니다.")
+                @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 기록 종료 시간",
+                        defaultValue = "2023-01-03 00:34:00",
+                        type = "string")
+                LocalDateTime finishedAt,
+        @NotNull(message = "미션 참여 한 시간(분)은 비워둘 수 없습니다.")
+                @Schema(description = "미션 참여 한 시간(분)", defaultValue = "32")
+                Integer durationMin,
+        @NotNull(message = "미션 참여 한 시간(초)은 비워둘 수 없습니다.")
+                @Schema(description = "미션 참여 한 시간(초)", defaultValue = "14")
+                Integer durationSec) {}

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/request/MissionRecordCreateRequest.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/request/MissionRecordCreateRequest.java
@@ -32,12 +32,12 @@ public record MissionRecordCreateRequest(
                         type = "string")
                 LocalDateTime finishedAt,
         @NotNull(message = "미션 참여 시간(분)은 비워둘 수 없습니다.")
-		@Min(value = 0, message = "미션 참여 시간(분)의 최소 값은 0입니다.")
-		@Max(value = 60, message = "미션 참여 시간(분)의 최대값은 60입니다.")
+                @Min(value = 0, message = "미션 참여 시간(분)의 최소 값은 0입니다.")
+                @Max(value = 60, message = "미션 참여 시간(분)의 최대값은 60입니다.")
                 @Schema(description = "미션 참여 시간(분)", defaultValue = "32")
                 Integer durationMin,
         @NotNull(message = "미션 참여 시간(초)은 비워둘 수 없습니다.")
-		@Min(value = 0, message = "미션 참여 시간(초)의 최소값는 0입니다.")
-		@Max(value = 60, message = "미션 참여 시간(초)의 최대값는 60입니다.")
+                @Min(value = 0, message = "미션 참여 시간(초)의 최소값는 0입니다.")
+                @Max(value = 60, message = "미션 참여 시간(초)의 최대값는 60입니다.")
                 @Schema(description = "미션 참여 시간(초)", defaultValue = "14")
                 Integer durationSec) {}

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -26,11 +26,11 @@ public class MissionRecordService {
         final Mission mission = findMission(request);
         final Member member = memberUtil.getCurrentMember();
 
-		Duration duration =
-			Duration.ofMinutes(request.durationMin()).plusSeconds(request.durationSec());
+        Duration duration =
+                Duration.ofMinutes(request.durationMin()).plusSeconds(request.durationSec());
 
         validateMissionRecordUserMismatch(mission, member);
-		validateMissionRecordDuration(duration);
+        validateMissionRecordDuration(duration);
 
         MissionRecord missionRecord =
                 MissionRecord.createMissionRecord(

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -1,0 +1,49 @@
+package com.depromeet.domain.missionRecord.service;
+
+import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.mission.dao.MissionRepository;
+import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
+import com.depromeet.global.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MissionRecordService {
+    private final MemberUtil memberUtil;
+    private final MissionRepository missionRepository;
+    private final MissionRecordRepository missionRecordRepository;
+
+    public void createMissionRecord(MissionRecordCreateRequest request) {
+        final Mission mission =
+                missionRepository
+                        .findByMissionId(request.missionId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
+        final Member member = memberUtil.getCurrentMember();
+
+        validateMissionRecordUserMismatch(mission, member);
+
+        MissionRecord missionRecord =
+                MissionRecord.createMissionRecord(
+                        request.durationMin(),
+                        request.durationSec(),
+                        request.startedAt(),
+                        request.finishedAt(),
+                        mission);
+
+        missionRecordRepository.save(missionRecord);
+    }
+
+    private void validateMissionRecordUserMismatch(Mission mission, Member member) {
+        if (member.getId().equals(mission.getMember().getId())) {
+            throw new CustomException(ErrorCode.MISSION_RECORD_USER_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 
     // MissionRecord
     MISSION_RECORD_USER_MISMATCH(HttpStatus.BAD_REQUEST, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
+    MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -23,7 +23,11 @@ public enum ErrorCode {
     // Mission
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션을 찾을 수 없습니다."),
 
-    MISSION_VISIBILITY_NULL(HttpStatus.BAD_REQUEST, "미션 공개 여부가 null입니다.");
+    MISSION_VISIBILITY_NULL(HttpStatus.BAD_REQUEST, "미션 공개 여부가 null입니다."),
+
+    // MissionRecord
+    MISSION_RECORD_USER_MISMATCH(HttpStatus.BAD_REQUEST, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
@@ -8,20 +8,18 @@ import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.domain.MissionCategory;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import java.time.LocalDateTime;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class MissionRecordTest {
 
-    Mission mission;
-
-    @BeforeEach
-    void setUp() {
+    @Nested
+    class 미션기록_생성_시 {
         Profile profile = new Profile("testNickname", "testProfileImageUrl");
         Member member = Member.createNormalMember(profile);
         LocalDateTime missionStartedAt = LocalDateTime.of(2023, 12, 1, 1, 5, 0);
         LocalDateTime missionFinishedAt = missionStartedAt.minusWeeks(2);
-        mission =
+        Mission mission =
                 Mission.createMission(
                         "testMissionName",
                         "testMissionContent",
@@ -31,42 +29,62 @@ class MissionRecordTest {
                         missionStartedAt,
                         missionFinishedAt,
                         member);
-    }
 
-    @Test
-    void 미션기록_생성_시_업로드_상태_DEFAULT값은_NONE이다() {
-        // given
-        LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
-        LocalDateTime missionRecordFinishedAt =
-                missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-        MissionRecord missionRecord =
-                MissionRecord.createMissionRecord(
-                        32, 14, missionRecordStartedAt, missionRecordFinishedAt, mission);
+        @Test
+        void 업로드_상태_DEFAULT값은_NONE이다() {
+            // given
+            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+            LocalDateTime missionRecordFinishedAt =
+                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+            MissionRecord missionRecord =
+                    MissionRecord.createMissionRecord(
+                            32, 14, missionRecordStartedAt, missionRecordFinishedAt, mission);
 
-        // when
-        ImageUploadStatus uploadStatus = missionRecord.getUploadStatus();
+            // when
+            ImageUploadStatus uploadStatus = missionRecord.getUploadStatus();
 
-        // then
-        assertEquals(ImageUploadStatus.NONE, uploadStatus);
-    }
+            // then
+            assertEquals(ImageUploadStatus.NONE, uploadStatus);
+        }
 
-    @Test
-    void 미션기록_생성_시_참여_시간은_초로_환산된다() {
-        // given
-        LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
-        LocalDateTime missionRecordFinishedAt =
-                missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-        Integer durationMin = 32;
-        Integer durationSec = 14;
-        MissionRecord missionRecord =
-                MissionRecord.createMissionRecord(
-                        durationMin,
-                        durationSec,
-                        missionRecordStartedAt,
-                        missionRecordFinishedAt,
-                        mission);
+        @Test
+        void 참여_시간은_초로_환산된다() {
+            // given
+            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+            LocalDateTime missionRecordFinishedAt =
+                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+            Integer durationMin = 32;
+            Integer durationSec = 14;
+            MissionRecord missionRecord =
+                    MissionRecord.createMissionRecord(
+                            durationMin,
+                            durationSec,
+                            missionRecordStartedAt,
+                            missionRecordFinishedAt,
+                            mission);
 
-        // when, then
-        assertEquals(durationMin * 60 + durationSec, missionRecord.getDuration());
+            // when, then
+            assertEquals(missionRecord.getDuration(), durationMin * 60 + durationSec);
+        }
+
+        @Test
+        void 참여_시간이_1시간이_넘어가면_1시간으로_변환된다() {
+            // given
+            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+            LocalDateTime missionRecordFinishedAt =
+                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+            Integer durationMin = 60;
+            Integer durationSec = 01;
+            MissionRecord missionRecord =
+                    MissionRecord.createMissionRecord(
+                            durationMin,
+                            durationSec,
+                            missionRecordStartedAt,
+                            missionRecordFinishedAt,
+                            mission);
+
+            // when, then
+            assertEquals(missionRecord.getDuration(), 3600);
+        }
     }
 }

--- a/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
@@ -7,6 +7,7 @@ import com.depromeet.domain.member.domain.Profile;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.domain.MissionCategory;
 import com.depromeet.domain.mission.domain.MissionVisibility;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ class MissionRecordTest {
         Profile profile = new Profile("testNickname", "testProfileImageUrl");
         Member member = Member.createNormalMember(profile);
         LocalDateTime missionStartedAt = LocalDateTime.of(2023, 12, 1, 1, 5, 0);
-        LocalDateTime missionFinishedAt = missionStartedAt.minusWeeks(2);
+        LocalDateTime missionFinishedAt = missionStartedAt.plusWeeks(2);
         Mission mission =
                 Mission.createMission(
                         "testMissionName",
@@ -36,9 +37,10 @@ class MissionRecordTest {
             LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
             LocalDateTime missionRecordFinishedAt =
                     missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+            Duration duration = Duration.ofMinutes(32).plusSeconds(14);
             MissionRecord missionRecord =
                     MissionRecord.createMissionRecord(
-                            32, 14, missionRecordStartedAt, missionRecordFinishedAt, mission);
+                            duration, missionRecordStartedAt, missionRecordFinishedAt, mission);
 
             // when
             ImageUploadStatus uploadStatus = missionRecord.getUploadStatus();
@@ -53,38 +55,13 @@ class MissionRecordTest {
             LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
             LocalDateTime missionRecordFinishedAt =
                     missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-            Integer durationMin = 32;
-            Integer durationSec = 14;
+            Duration duration = Duration.ofMinutes(32).plusSeconds(14);
             MissionRecord missionRecord =
                     MissionRecord.createMissionRecord(
-                            durationMin,
-                            durationSec,
-                            missionRecordStartedAt,
-                            missionRecordFinishedAt,
-                            mission);
+                            duration, missionRecordStartedAt, missionRecordFinishedAt, mission);
 
             // when, then
-            assertEquals(missionRecord.getDuration(), durationMin * 60 + durationSec);
-        }
-
-        @Test
-        void 참여_시간이_1시간이_넘어가면_1시간으로_변환된다() {
-            // given
-            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
-            LocalDateTime missionRecordFinishedAt =
-                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-            Integer durationMin = 60;
-            Integer durationSec = 01;
-            MissionRecord missionRecord =
-                    MissionRecord.createMissionRecord(
-                            durationMin,
-                            durationSec,
-                            missionRecordStartedAt,
-                            missionRecordFinishedAt,
-                            mission);
-
-            // when, then
-            assertEquals(missionRecord.getDuration(), 3600);
+            assertEquals(missionRecord.getDuration(), (int) duration.getSeconds());
         }
     }
 }

--- a/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
@@ -19,8 +19,8 @@ class MissionRecordTest {
     void setUp() {
         Profile profile = new Profile("testNickname", "testProfileImageUrl");
         Member member = Member.createNormalMember(profile);
-        LocalDateTime startedAt = LocalDateTime.of(2023, 12, 1, 1, 5, 0);
-        LocalDateTime finishedAt = LocalDateTime.of(2023, 12, 15, 1, 37, 0);
+        LocalDateTime missionStartedAt = LocalDateTime.of(2023, 12, 1, 1, 5, 0);
+        LocalDateTime missionFinishedAt = missionStartedAt.minusWeeks(2);
         mission =
                 Mission.createMission(
                         "testMissionName",
@@ -28,29 +28,45 @@ class MissionRecordTest {
                         1,
                         MissionCategory.ETC,
                         MissionVisibility.ALL,
-                        startedAt,
-                        finishedAt,
+                        missionStartedAt,
+                        missionFinishedAt,
                         member);
     }
 
     @Test
-    void 미션기록_업로드_상태_DEFAULT값은_NONE이다() {
+    void 미션기록_생성_시_업로드_상태_DEFAULT값은_NONE이다() {
         // given
-        LocalDateTime startedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
-        LocalDateTime finishedAt = LocalDateTime.of(2023, 12, 15, 1, 37, 0);
+        LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+        LocalDateTime missionRecordFinishedAt =
+                missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
         MissionRecord missionRecord =
                 MissionRecord.createMissionRecord(
-                        32,
-                        "testMissionRecordRemark",
-                        "image/url/path",
-                        startedAt,
-                        finishedAt,
-                        mission);
+                        32, 14, missionRecordStartedAt, missionRecordFinishedAt, mission);
 
         // when
         ImageUploadStatus uploadStatus = missionRecord.getUploadStatus();
 
         // then
         assertEquals(ImageUploadStatus.NONE, uploadStatus);
+    }
+
+    @Test
+    void 미션기록_생성_시_참여_시간은_초로_환산된다() {
+        // given
+        LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+        LocalDateTime missionRecordFinishedAt =
+                missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+        Integer durationMin = 32;
+        Integer durationSec = 14;
+        MissionRecord missionRecord =
+                MissionRecord.createMissionRecord(
+                        durationMin,
+                        durationSec,
+                        missionRecordStartedAt,
+                        missionRecordFinishedAt,
+                        mission);
+
+        // when, then
+        assertEquals(durationMin * 60 + durationSec, missionRecord.getDuration());
     }
 }

--- a/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
@@ -48,20 +48,5 @@ class MissionRecordTest {
             // then
             assertEquals(ImageUploadStatus.NONE, uploadStatus);
         }
-
-        @Test
-        void 참여_시간은_초로_환산된다() {
-            // given
-            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
-            LocalDateTime missionRecordFinishedAt =
-                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-            Duration duration = Duration.ofMinutes(32).plusSeconds(14);
-            MissionRecord missionRecord =
-                    MissionRecord.createMissionRecord(
-                            duration, missionRecordStartedAt, missionRecordFinishedAt, mission);
-
-            // when, then
-            assertEquals(missionRecord.getDuration(), (int) duration.getSeconds());
-        }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #87 

## 📌 작업 내용 및 특이사항
- 미션 기록 저장 API입니다.
- Validation 의존성 없어서 추가해두었습니다.
- 해당 PR에서는 미션 기록 저장만 존재하고, 이미지와 일지는  #95 이슈 처리 후 작업하도록 하겠습니다.
- 이벤트 발행 및 Redis 관련 처리는 #88 머지 후 작업 예정
- 우선 domain test만 작성해두었습니다 추 후 새로운 이슈에서 Controller, Service 테스트 작성하겠슴니다.
- duration은 분과 초를 나누어서 받도록 프론트 @sumi-0011 와 협의 완료
