### PR TITLE
chore: NCP Object Storage 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
     // Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.security:spring-security-test'
@@ -52,6 +53,9 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // AWS
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/depromeet/infra/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/depromeet/infra/config/properties/PropertiesConfig.java
@@ -1,10 +1,9 @@
 package com.depromeet.infra.config.properties;
 
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
-
 import com.depromeet.infra.config.redis.RedisProperties;
 import com.depromeet.infra.config.storage.StorageProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 
 @EnableConfigurationProperties({StorageProperties.class, RedisProperties.class})
 @Configuration

--- a/src/main/java/com/depromeet/infra/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/depromeet/infra/config/properties/PropertiesConfig.java
@@ -1,0 +1,10 @@
+package com.depromeet.infra.config.properties;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import com.depromeet.infra.config.storage.StorageProperties;
+
+@EnableConfigurationProperties(StorageProperties.class)
+@Configuration
+public class PropertiesConfig {}

--- a/src/main/java/com/depromeet/infra/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/depromeet/infra/config/properties/PropertiesConfig.java
@@ -3,8 +3,9 @@ package com.depromeet.infra.config.properties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import com.depromeet.infra.config.redis.RedisProperties;
 import com.depromeet.infra.config.storage.StorageProperties;
 
-@EnableConfigurationProperties(StorageProperties.class)
+@EnableConfigurationProperties({StorageProperties.class, RedisProperties.class})
 @Configuration
 public class PropertiesConfig {}

--- a/src/main/java/com/depromeet/infra/config/redis/RedisConfig.java
+++ b/src/main/java/com/depromeet/infra/config/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.depromeet.infra.config;
+package com.depromeet.infra.config.redis;
 
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/depromeet/infra/config/redis/RedisConfig.java
+++ b/src/main/java/com/depromeet/infra/config/redis/RedisConfig.java
@@ -10,23 +10,19 @@ import org.springframework.data.redis.connection.lettuce.LettuceClientConfigurat
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
+import lombok.RequiredArgsConstructor;
+
 @EnableRedisRepositories
 @Configuration
+@RequiredArgsConstructor
 public class RedisConfig {
-    @Value("${spring.data.redis.host}")
-    private String redisHost;
-
-    @Value("${spring.data.redis.port}")
-    private int redisPort;
-
-    @Value("${spring.data.redis.password}")
-    private String redisPassword;
+	private final RedisProperties redisProperties;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisConfig =
-                new RedisStandaloneConfiguration(redisHost, redisPort);
-        if (!redisPassword.isBlank()) redisConfig.setPassword(redisPassword);
+                new RedisStandaloneConfiguration(redisProperties.getHost(), redisProperties.getPort());
+        if (!redisProperties.getPassword().isBlank()) redisConfig.setPassword(redisProperties.getPassword());
         LettuceClientConfiguration clientConfig =
                 LettuceClientConfiguration.builder()
                         .commandTimeout(Duration.ofSeconds(1))

--- a/src/main/java/com/depromeet/infra/config/redis/RedisConfig.java
+++ b/src/main/java/com/depromeet/infra/config/redis/RedisConfig.java
@@ -1,7 +1,7 @@
 package com.depromeet.infra.config.redis;
 
 import java.time.Duration;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -10,19 +10,19 @@ import org.springframework.data.redis.connection.lettuce.LettuceClientConfigurat
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
-import lombok.RequiredArgsConstructor;
-
 @EnableRedisRepositories
 @Configuration
 @RequiredArgsConstructor
 public class RedisConfig {
-	private final RedisProperties redisProperties;
+    private final RedisProperties redisProperties;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisConfig =
-                new RedisStandaloneConfiguration(redisProperties.getHost(), redisProperties.getPort());
-        if (!redisProperties.getPassword().isBlank()) redisConfig.setPassword(redisProperties.getPassword());
+                new RedisStandaloneConfiguration(
+                        redisProperties.getHost(), redisProperties.getPort());
+        if (!redisProperties.getPassword().isBlank())
+            redisConfig.setPassword(redisProperties.getPassword());
         LettuceClientConfiguration clientConfig =
                 LettuceClientConfiguration.builder()
                         .commandTimeout(Duration.ofSeconds(1))

--- a/src/main/java/com/depromeet/infra/config/redis/RedisConfig.java
+++ b/src/main/java/com/depromeet/infra/config/redis/RedisConfig.java
@@ -19,10 +19,9 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisConfig =
-                new RedisStandaloneConfiguration(
-                        redisProperties.getHost(), redisProperties.getPort());
-        if (!redisProperties.getPassword().isBlank())
-            redisConfig.setPassword(redisProperties.getPassword());
+                new RedisStandaloneConfiguration(redisProperties.host(), redisProperties.port());
+        if (!redisProperties.password().isBlank())
+            redisConfig.setPassword(redisProperties.password());
         LettuceClientConfiguration clientConfig =
                 LettuceClientConfiguration.builder()
                         .commandTimeout(Duration.ofSeconds(1))

--- a/src/main/java/com/depromeet/infra/config/redis/RedisProperties.java
+++ b/src/main/java/com/depromeet/infra/config/redis/RedisProperties.java
@@ -1,15 +1,14 @@
 package com.depromeet.infra.config.redis;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Getter
 @AllArgsConstructor
 @ConfigurationProperties(prefix = "spring.data.redis")
 public class RedisProperties {
-	private String host;
-	private int port;
-	private String password;
+    private String host;
+    private int port;
+    private String password;
 }

--- a/src/main/java/com/depromeet/infra/config/redis/RedisProperties.java
+++ b/src/main/java/com/depromeet/infra/config/redis/RedisProperties.java
@@ -1,14 +1,6 @@
 package com.depromeet.infra.config.redis;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@Getter
-@AllArgsConstructor
 @ConfigurationProperties(prefix = "spring.data.redis")
-public class RedisProperties {
-    private String host;
-    private int port;
-    private String password;
-}
+public record RedisProperties(String host, int port, String password) {}

--- a/src/main/java/com/depromeet/infra/config/redis/RedisProperties.java
+++ b/src/main/java/com/depromeet/infra/config/redis/RedisProperties.java
@@ -1,0 +1,15 @@
+package com.depromeet.infra.config.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "spring.data.redis")
+public class RedisProperties {
+	private String host;
+	private int port;
+	private String password;
+}

--- a/src/main/java/com/depromeet/infra/config/storage/StorageConfig.java
+++ b/src/main/java/com/depromeet/infra/config/storage/StorageConfig.java
@@ -1,30 +1,27 @@
 package com.depromeet.infra.config.storage;
 
-import org.springframework.boot.context.properties.bind.ConstructorBinding;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @RequiredArgsConstructor
 public class StorageConfig {
-	private final StorageProperties storageProperties;
+    private final StorageProperties storageProperties;
 
-	@Bean
-	public AmazonS3 amazonS3() {
-		AWSCredentials credentials =
-			new BasicAWSCredentials(
-				storageProperties.getAccessKey(), storageProperties.getSecretKey());
-		return AmazonS3ClientBuilder.standard()
-			.withCredentials(new AWSStaticCredentialsProvider(credentials))
-			.withRegion(storageProperties.getRegion())
-			.build();
-	}
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials =
+                new BasicAWSCredentials(
+                        storageProperties.getAccessKey(), storageProperties.getSecretKey());
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(storageProperties.getRegion())
+                .build();
+    }
 }

--- a/src/main/java/com/depromeet/infra/config/storage/StorageConfig.java
+++ b/src/main/java/com/depromeet/infra/config/storage/StorageConfig.java
@@ -18,10 +18,10 @@ public class StorageConfig {
     public AmazonS3 amazonS3() {
         AWSCredentials credentials =
                 new BasicAWSCredentials(
-                        storageProperties.getAccessKey(), storageProperties.getSecretKey());
+                        storageProperties.accessKey(), storageProperties.secretKey());
         return AmazonS3ClientBuilder.standard()
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                .withRegion(storageProperties.getRegion())
+                .withRegion(storageProperties.region())
                 .build();
     }
 }

--- a/src/main/java/com/depromeet/infra/config/storage/StorageConfig.java
+++ b/src/main/java/com/depromeet/infra/config/storage/StorageConfig.java
@@ -1,0 +1,30 @@
+package com.depromeet.infra.config.storage;
+
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class StorageConfig {
+	private final StorageProperties storageProperties;
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		AWSCredentials credentials =
+			new BasicAWSCredentials(
+				storageProperties.getAccessKey(), storageProperties.getSecretKey());
+		return AmazonS3ClientBuilder.standard()
+			.withCredentials(new AWSStaticCredentialsProvider(credentials))
+			.withRegion(storageProperties.getRegion())
+			.build();
+	}
+}

--- a/src/main/java/com/depromeet/infra/config/storage/StorageProperties.java
+++ b/src/main/java/com/depromeet/infra/config/storage/StorageProperties.java
@@ -1,16 +1,15 @@
 package com.depromeet.infra.config.storage;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Getter
 @AllArgsConstructor
 @ConfigurationProperties(prefix = "storage")
 public class StorageProperties {
-	private String accessKey;
-	private String secretKey;
-	private String region;
-	private String bucket;
+    private String accessKey;
+    private String secretKey;
+    private String region;
+    private String bucket;
 }

--- a/src/main/java/com/depromeet/infra/config/storage/StorageProperties.java
+++ b/src/main/java/com/depromeet/infra/config/storage/StorageProperties.java
@@ -1,0 +1,16 @@
+package com.depromeet.infra.config.storage;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "storage")
+public class StorageProperties {
+	private String accessKey;
+	private String secretKey;
+	private String region;
+	private String bucket;
+}

--- a/src/main/java/com/depromeet/infra/config/storage/StorageProperties.java
+++ b/src/main/java/com/depromeet/infra/config/storage/StorageProperties.java
@@ -1,15 +1,6 @@
 package com.depromeet.infra.config.storage;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@Getter
-@AllArgsConstructor
 @ConfigurationProperties(prefix = "storage")
-public class StorageProperties {
-    private String accessKey;
-    private String secretKey;
-    private String region;
-    private String bucket;
-}
+public record StorageProperties(String accessKey, String secretKey, String region, String bucket) {}

--- a/src/main/resources/application-storage.yml
+++ b/src/main/resources/application-storage.yml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "storage"
+storage:
+  accessKey: ${STORAGE_ACCESS_KEY:}
+  secretKey: ${STORAGE_SECRET_KEY:}
+  region: ${STORAGE_REGION:}
+  bucket: ${STORAGE_BUCKET:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,10 @@
 spring:
   profiles:
     group:
-      test: "test"
-      local: "local, datasource, redis"
-      dev: "dev, datasource, redis, actuator"
-      prod: "prod, datasource, redis, actuator"
+      test: "test, redis, storage"
+      local: "local, datasource, redis, storage"
+      dev: "dev, datasource, redis, storage, actuator"
+      prod: "prod, datasource, redis, storage, actuator"
 
 swagger:
   version: 0.0.1

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,9 +4,3 @@ spring:
       on-profile: "test"
   datasource:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
-
-  data:
-    redis:
-      host: localhost
-      port: 6379
-      password:


### PR DESCRIPTION
## 🌱 관련 이슈
- close #95 

## 📌 작업 내용 및 특이사항
- NCP Object Storage 설정
- PresignedUrl을 사용하기 위한 설정입니당
- [NCP 오브젝트 스토리지](https://www.ncloud.com/product/storage/objectStorage)는 Amazon S3와 호환되는 API를 제공하여 AWS SDK를 사용합니다
- 설정 정보들을 configuration-processor를 이용하여 추가하고 관리합니다

## 📝 참고사항
- storage 환경변수 추가되었습니다 슬랙 서버 채널에 남겨놓았으니 확인 후 추가해주세용