### PR TITLE
test: 미션 Controller 테스트 코드 작성

### DIFF
--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -125,12 +125,14 @@ class MissionControllerTest {
                                 1));
 
         // expected
-        mockMvc.perform(
+        ResultActions perform =
+                mockMvc.perform(
                         get("/missions/{missionId}", 1L)
                                 .accept(APPLICATION_JSON)
                                 .contentType(APPLICATION_JSON)
-                                .with(csrf()))
-                .andExpect(status().isOk())
+                                .with(csrf()));
+
+        perform.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.missionId").exists())
                 .andExpect(jsonPath("$.data.name").exists())
                 .andExpect(jsonPath("$.data.name").value("testMissionName"));
@@ -171,12 +173,13 @@ class MissionControllerTest {
                                 false));
 
         // expected
-        mockMvc.perform(
+        ResultActions perform =
+                mockMvc.perform(
                         get("/missions?size=3&lastId=4")
                                 .accept(APPLICATION_JSON)
                                 .contentType(APPLICATION_JSON)
-                                .with(csrf()))
-                .andExpect(status().isOk())
+                                .with(csrf()));
+        perform.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content.length()", is(3)))
                 .andExpect(jsonPath("$.data.content[0].missionId").value(3))
                 .andExpect(jsonPath("$.data.last", is(true)))

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.mission.controller;
 
 import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
@@ -22,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -76,7 +76,7 @@ class MissionControllerTest {
                         MissionCategory.STUDY,
                         MissionVisibility.ALL);
 
-        given(missionService.createMission(ArgumentMatchers.any()))
+        given(missionService.createMission(any()))
                 .willReturn(
                         new MissionCreateResponse(
                                 1L,
@@ -127,7 +127,7 @@ class MissionControllerTest {
     @Test
     void 미션_단건_조회한다() throws Exception {
         // given
-        given(missionService.findOneMission(ArgumentMatchers.any()))
+        given(missionService.findOneMission(any()))
                 .willReturn(
                         new MissionFindResponse(
                                 1L,
@@ -207,7 +207,7 @@ class MissionControllerTest {
         MissionUpdateRequest updateRequest =
                 new MissionUpdateRequest(
                         "testMissionName", "testMissionContent", MissionVisibility.NONE);
-        given(missionService.updateMission(ArgumentMatchers.any(), ArgumentMatchers.any()))
+        given(missionService.updateMission(any(), any()))
                 .willReturn(
                         new MissionUpdateResponse(
                                 1L,
@@ -237,7 +237,7 @@ class MissionControllerTest {
         // given
         MissionUpdateRequest updateRequest =
                 new MissionUpdateRequest(null, "testMissionContent", MissionVisibility.NONE);
-        given(missionService.updateMission(ArgumentMatchers.any(), ArgumentMatchers.any()))
+        given(missionService.updateMission(any(), any()))
                 .willReturn(
                         new MissionUpdateResponse(
                                 1L,

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -1,0 +1,73 @@
+package com.depromeet.domain.mission.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.depromeet.domain.mission.domain.MissionCategory;
+import com.depromeet.domain.mission.domain.MissionVisibility;
+import com.depromeet.domain.mission.dto.request.MissionCreateRequest;
+import com.depromeet.domain.mission.dto.response.MissionCreateResponse;
+import com.depromeet.domain.mission.service.MissionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = MissionControllerTest.class)
+@ActiveProfiles("test")
+@MockBean(JpaMetamodelMappingContext.class)
+class MissionControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockBean private MissionService missionService;
+    @Autowired private ObjectMapper objectMapper;
+    // @Autowired
+    // private DatabaseCleaner databaseCleaner;
+    // @Autowired private MemberUtil memberUtil;
+    //
+    // @BeforeEach
+    // void setUp() {
+    // 	databaseCleaner.execute();
+    // 	System.out.println(memberUtil.getCurrentMember().getId());
+    // }
+
+    @Test
+    void 공부미션을_생성한다() throws Exception {
+        // given
+        MissionCreateRequest createRequest =
+                new MissionCreateRequest(
+                        "testMissionName",
+                        "testMissionContent",
+                        MissionCategory.STUDY,
+                        MissionVisibility.ALL);
+        given(missionService.createMission(any()))
+                .willReturn(
+                        new MissionCreateResponse(
+                                1L,
+                                createRequest.name(),
+                                createRequest.content(),
+                                createRequest.category(),
+                                createRequest.visibility()));
+        // expected
+        mockMvc.perform(
+                        post("/missions")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.missionId").exists())
+                .andExpect(jsonPath("$.name").exists())
+                .andExpect(jsonPath("$.name").value("testMissionName"))
+                .andExpect(jsonPath("$.content").value("testMissionContent"))
+                .andExpect(jsonPath("$.category").value("STUDY"))
+                .andExpect(jsonPath("$.visibility").value("ALL"))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -1,45 +1,33 @@
 package com.depromeet.domain.mission.controller;
 
-import static org.mockito.BDDMockito.*;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.depromeet.domain.mission.domain.MissionCategory;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.mission.dto.request.MissionCreateRequest;
-import com.depromeet.domain.mission.dto.response.MissionCreateResponse;
-import com.depromeet.domain.mission.service.MissionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = MissionControllerTest.class)
+@AutoConfigureMockMvc
+@SpringBootTest
 @ActiveProfiles("test")
-@MockBean(JpaMetamodelMappingContext.class)
 class MissionControllerTest {
 
     @Autowired private MockMvc mockMvc;
-    @MockBean private MissionService missionService;
     @Autowired private ObjectMapper objectMapper;
-    // @Autowired
-    // private DatabaseCleaner databaseCleaner;
-    // @Autowired private MemberUtil memberUtil;
-    //
-    // @BeforeEach
-    // void setUp() {
-    // 	databaseCleaner.execute();
-    // 	System.out.println(memberUtil.getCurrentMember().getId());
-    // }
 
     @Test
+    @WithMockUser(username = "testUser")
     void 공부미션을_생성한다() throws Exception {
         // given
         MissionCreateRequest createRequest =
@@ -48,26 +36,21 @@ class MissionControllerTest {
                         "testMissionContent",
                         MissionCategory.STUDY,
                         MissionVisibility.ALL);
-        given(missionService.createMission(any()))
-                .willReturn(
-                        new MissionCreateResponse(
-                                1L,
-                                createRequest.name(),
-                                createRequest.content(),
-                                createRequest.category(),
-                                createRequest.visibility()));
+
         // expected
         mockMvc.perform(
                         post("/missions")
+                                .accept(APPLICATION_JSON)
                                 .contentType(APPLICATION_JSON)
+                                .with(csrf())
                                 .content(objectMapper.writeValueAsString(createRequest)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.missionId").exists())
-                .andExpect(jsonPath("$.name").exists())
-                .andExpect(jsonPath("$.name").value("testMissionName"))
-                .andExpect(jsonPath("$.content").value("testMissionContent"))
-                .andExpect(jsonPath("$.category").value("STUDY"))
-                .andExpect(jsonPath("$.visibility").value("ALL"))
+                .andExpect(jsonPath("$.data.missionId").exists())
+                .andExpect(jsonPath("$.data.name").exists())
+                .andExpect(jsonPath("$.data.name").value("testMissionName"))
+                .andExpect(jsonPath("$.data.content").value("testMissionContent"))
+                .andExpect(jsonPath("$.data.category").value("STUDY"))
+                .andExpect(jsonPath("$.data.visibility").value("ALL"))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -54,6 +54,10 @@ class MissionControllerTest {
     }
 
     // 무한 스크롤 방식 처리하는 메서드
+    /*
+    Repository에서 구현된 List<Mission>은 Repository 계층에서 이뤄지지에
+    테스트 코드는 MissionFindResponse로 변경
+    */
     private Slice<MissionFindResponse> checkLastPage(
             Pageable pageable, List<MissionFindResponse> result) {
         boolean hasNext = false;
@@ -158,6 +162,7 @@ class MissionControllerTest {
     void 미션_리스트를_조회한다() throws Exception {
         // given
         int size = 3;
+		long lastId = 4;
         PageRequest pageRequest = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "id"));
         List<MissionFindResponse> mappedMissions =
                 Arrays.asList(
@@ -191,13 +196,13 @@ class MissionControllerTest {
         // expected
         ResultActions perform =
                 mockMvc.perform(
-                        get("/missions?size=3&lastId=4")
+                        get("/missions?size={size}&lastId={lastId}", size, lastId)
                                 .accept(APPLICATION_JSON)
                                 .contentType(APPLICATION_JSON)
                                 .with(csrf()));
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content.length()", is(3)))
-                .andExpect(jsonPath("$.data.content[0].missionId").value(3))
+                .andExpect(jsonPath("$.data.content.length()", is(size)))
+                .andExpect(jsonPath("$.data.content[0].missionId").value(size))
                 .andExpect(jsonPath("$.data.last", is(true)))
                 .andExpect(jsonPath("$.data.empty", is(false)));
     }

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -1,33 +1,56 @@
 package com.depromeet.domain.mission.controller;
 
+import static org.hamcrest.Matchers.*;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.depromeet.DatabaseCleaner;
+import com.depromeet.domain.mission.api.MissionController;
+import com.depromeet.domain.mission.domain.ArchiveStatus;
 import com.depromeet.domain.mission.domain.MissionCategory;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.mission.dto.request.MissionCreateRequest;
+import com.depromeet.domain.mission.dto.response.MissionCreateResponse;
+import com.depromeet.domain.mission.dto.response.MissionFindResponse;
+import com.depromeet.domain.mission.service.MissionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
-@AutoConfigureMockMvc
-@SpringBootTest
+@WebMvcTest(controllers = MissionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
 @ActiveProfiles("test")
 class MissionControllerTest {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;
+    @MockBean private MissionService missionService;
+    @MockBean private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+    }
 
     @Test
-    @WithMockUser(username = "testUser")
     void 공부미션을_생성한다() throws Exception {
         // given
         MissionCreateRequest createRequest =
@@ -37,14 +60,24 @@ class MissionControllerTest {
                         MissionCategory.STUDY,
                         MissionVisibility.ALL);
 
+        given(missionService.createMission(ArgumentMatchers.any()))
+                .willReturn(
+                        new MissionCreateResponse(
+                                1L,
+                                "testMissionName",
+                                "testMissionContent",
+                                MissionCategory.STUDY,
+                                MissionVisibility.ALL));
         // expected
-        mockMvc.perform(
+        ResultActions perform =
+                mockMvc.perform(
                         post("/missions")
                                 .accept(APPLICATION_JSON)
                                 .contentType(APPLICATION_JSON)
                                 .with(csrf())
-                                .content(objectMapper.writeValueAsString(createRequest)))
-                .andExpect(status().isCreated())
+                                .content(objectMapper.writeValueAsString(createRequest)));
+
+        perform.andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.missionId").exists())
                 .andExpect(jsonPath("$.data.name").exists())
                 .andExpect(jsonPath("$.data.name").value("testMissionName"))
@@ -52,5 +85,101 @@ class MissionControllerTest {
                 .andExpect(jsonPath("$.data.category").value("STUDY"))
                 .andExpect(jsonPath("$.data.visibility").value("ALL"))
                 .andDo(print());
+    }
+
+    // TODO: validation 의존성 생기면 진행
+    // @Test
+    // void 미션_생성하는_데에_이름은_null일_수_없다() throws Exception {
+    // 	// given
+    // 	MissionCreateRequest createRequest =
+    // 		new MissionCreateRequest(
+    // 			"",
+    // 			"testMissionContent",
+    // 			MissionCategory.STUDY,
+    // 			MissionVisibility.ALL);
+    //
+    // 	// expected
+    // 	mockMvc.perform(
+    // 			post("/missions")
+    // 				.accept(APPLICATION_JSON)
+    // 				.contentType(APPLICATION_JSON)
+    // 				.with(csrf())
+    // 				.content(objectMapper.writeValueAsString(createRequest)))
+    // 		.andExpect(status().isBadRequest())
+    //
+    // 		.andDo(print());
+    // }
+
+    @Test
+    void 미션_단건_조회한다() throws Exception {
+        // given
+        given(missionService.findOneMission(ArgumentMatchers.any()))
+                .willReturn(
+                        new MissionFindResponse(
+                                1L,
+                                "testMissionName",
+                                "testMissionContent",
+                                MissionCategory.STUDY,
+                                MissionVisibility.ALL,
+                                ArchiveStatus.NONE,
+                                1));
+
+        // expected
+        mockMvc.perform(
+                        get("/missions/{missionId}", 1L)
+                                .accept(APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.missionId").exists())
+                .andExpect(jsonPath("$.data.name").exists())
+                .andExpect(jsonPath("$.data.name").value("testMissionName"));
+    }
+
+    @Test
+    void 미션_리스트를_조회한다() throws Exception {
+        // given
+        given(missionService.findAllMission(anyInt(), anyLong()))
+                .willReturn(
+                        new SliceImpl<>(
+                                Arrays.asList(
+                                        new MissionFindResponse(
+                                                3L,
+                                                "testMissionName_3",
+                                                "testMissionContent_3",
+                                                MissionCategory.WRITING,
+                                                MissionVisibility.ALL,
+                                                ArchiveStatus.NONE,
+                                                3),
+                                        new MissionFindResponse(
+                                                2L,
+                                                "testMissionName_2",
+                                                "testMissionContent_2",
+                                                MissionCategory.ETC,
+                                                MissionVisibility.ALL,
+                                                ArchiveStatus.NONE,
+                                                2),
+                                        new MissionFindResponse(
+                                                1L,
+                                                "testMissionName_1",
+                                                "testMissionContent_1",
+                                                MissionCategory.STUDY,
+                                                MissionVisibility.ALL,
+                                                ArchiveStatus.NONE,
+                                                1)),
+                                PageRequest.of(0, 3, Sort.by(Sort.Direction.DESC, "id")),
+                                false));
+
+        // expected
+        mockMvc.perform(
+                        get("/missions?size=3&lastId=4")
+                                .accept(APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()", is(3)))
+                .andExpect(jsonPath("$.data.content[0].missionId").value(3))
+                .andExpect(jsonPath("$.data.last", is(true)))
+                .andExpect(jsonPath("$.data.empty", is(false)));
     }
 }

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -19,6 +19,8 @@ import com.depromeet.domain.mission.dto.response.MissionCreateResponse;
 import com.depromeet.domain.mission.dto.response.MissionFindResponse;
 import com.depromeet.domain.mission.dto.response.MissionUpdateResponse;
 import com.depromeet.domain.mission.service.MissionService;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.List;
@@ -282,9 +284,9 @@ class MissionControllerTest {
         Long nonExistingMissionId = 999L;
 
         // when
-        doThrow(new EmptyResultDataAccessException(1))
-                .when(missionService)
-                .deleteMission(nonExistingMissionId);
+		doThrow(new CustomException(ErrorCode.MISSION_NOT_FOUND))
+			.when(missionService)
+			.deleteMission(nonExistingMissionId);
 
         // then
         mockMvc.perform(
@@ -292,7 +294,7 @@ class MissionControllerTest {
                                 .accept(APPLICATION_JSON)
                                 .contentType(APPLICATION_JSON)
                                 .with(csrf()))
-                .andExpect(status().isInternalServerError())
+                .andExpect(status().isNotFound())
                 .andDo(print());
     }
 }

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.depromeet.DatabaseCleaner;
 import com.depromeet.domain.mission.api.MissionController;
 import com.depromeet.domain.mission.domain.ArchiveStatus;
 import com.depromeet.domain.mission.domain.MissionCategory;
@@ -22,7 +21,6 @@ import com.depromeet.domain.mission.service.MissionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -234,35 +232,34 @@ class MissionControllerTest {
                 .andDo(print());
     }
 
-	@Test
-	void 미션이름을_null로_수정할_수_없다 () throws Exception {
-		// given
-		MissionUpdateRequest updateRequest =
-			new MissionUpdateRequest(
-				null, "testMissionContent", MissionVisibility.NONE);
-		given(missionService.updateMission(ArgumentMatchers.any(), ArgumentMatchers.any()))
-			.willReturn(
-				new MissionUpdateResponse(
-					1L,
-					null,
-					"testMissionContent",
-					MissionCategory.STUDY,
-					MissionVisibility.FOLLOWER));
+    @Test
+    void 미션이름을_null로_수정할_수_없다() throws Exception {
+        // given
+        MissionUpdateRequest updateRequest =
+                new MissionUpdateRequest(null, "testMissionContent", MissionVisibility.NONE);
+        given(missionService.updateMission(ArgumentMatchers.any(), ArgumentMatchers.any()))
+                .willReturn(
+                        new MissionUpdateResponse(
+                                1L,
+                                null,
+                                "testMissionContent",
+                                MissionCategory.STUDY,
+                                MissionVisibility.FOLLOWER));
 
-		// expected
-		ResultActions perform =
-			mockMvc.perform(
-				put("/missions/{missionId}", 1L)
-					.accept(APPLICATION_JSON)
-					.contentType(APPLICATION_JSON)
-					.with(csrf())
-					.content(objectMapper.writeValueAsString(updateRequest)));
+        // expected
+        ResultActions perform =
+                mockMvc.perform(
+                        put("/missions/{missionId}", 1L)
+                                .accept(APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                                .content(objectMapper.writeValueAsString(updateRequest)));
 
-		perform.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-			.andExpect(jsonPath("$.message").value("{\"name\":\"이름은 비워둘 수 없습니다.\"}"))
-			.andDo(print());
-	}
+        perform.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value("{\"name\":\"이름은 비워둘 수 없습니다.\"}"))
+                .andDo(print());
+    }
 
     @Test
     void 미션_단건_삭제한다() throws Exception {

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -36,6 +36,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -110,28 +111,26 @@ class MissionControllerTest {
                 .andDo(print());
     }
 
-    // TODO: validation 의존성 생기면 진행
-    // @Test
-    // void 미션_생성하는_데에_이름은_null일_수_없다() throws Exception {
-    // 	// given
-    // 	MissionCreateRequest createRequest =
-    // 		new MissionCreateRequest(
-    // 			"",
-    // 			"testMissionContent",
-    // 			MissionCategory.STUDY,
-    // 			MissionVisibility.ALL);
-    //
-    // 	// expected
-    // 	mockMvc.perform(
-    // 			post("/missions")
-    // 				.accept(APPLICATION_JSON)
-    // 				.contentType(APPLICATION_JSON)
-    // 				.with(csrf())
-    // 				.content(objectMapper.writeValueAsString(createRequest)))
-    // 		.andExpect(status().isBadRequest())
-    //
-    // 		.andDo(print());
-    // }
+    @Test
+    void 미션_생성하는데_이름은_null일_수_없다() throws Exception {
+        // given
+        MissionCreateRequest createRequest =
+                new MissionCreateRequest(
+                        null, "testMissionContent", MissionCategory.STUDY, MissionVisibility.ALL);
+
+        // expected
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/missions")
+                                .accept(APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                                .content(objectMapper.writeValueAsString(createRequest)));
+        perform.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value("{\"name\":\"이름은 비워둘 수 없습니다.\"}"))
+                .andDo(print());
+    }
 
     @Test
     void 미션_단건_조회한다() throws Exception {

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -284,9 +283,9 @@ class MissionControllerTest {
         Long nonExistingMissionId = 999L;
 
         // when
-		doThrow(new CustomException(ErrorCode.MISSION_NOT_FOUND))
-			.when(missionService)
-			.deleteMission(nonExistingMissionId);
+        doThrow(new CustomException(ErrorCode.MISSION_NOT_FOUND))
+                .when(missionService)
+                .deleteMission(nonExistingMissionId);
 
         // then
         mockMvc.perform(


### PR DESCRIPTION
## 🌱 관련 이슈
- close #91

## 📌 작업 내용 및 특이사항
- 미션 Controller 테스트 코드 구현
- WebMvcTest로 MissionController 테스트만 진행
- AutoConfigureMockMvc로 MockMvc를 자동 구성해주지만, 필터로 자동 구성하지 않도록 했습니다.
- `@MockBean(JpaMetamodelMappingContext.class)` 추가한 이유
  - `@WebMvcTest`는 JPA 생성과 관련된 기능이 전혀 존재하지 않는 테스트 어노테이션이여서 JPA Auditing 기능을 사용할 떄`@SpringBootApplication`에 `@EnableJPaAuditing`을 추가하여 사용하고 있기 때문에 발생하는 에러가 발생합니다.

## 📝 참고사항
- https://velog.io/@sysy123/Spring-Boot-Error-ControllerTest-Spring-Security-403-%EC%97%90%EB%9F%AC
- https://youtu.be/BZBFw6fBeIU?si=mbXs3VN06SuHw_Qm
- https://velog.io/@suujeen/Error-creating-bean-with-name-jpaAuditingHandler

## 📚 기타
- 
