### PR TITLE
feat: PresignedUrl을 사용하여 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/com/depromeet/domain/image/api/ImageController.java
+++ b/src/main/java/com/depromeet/domain/image/api/ImageController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "4. [이미지]", description = "이미지 관련 API입니다.")
 @RestController
-@RequestMapping("/images")
 @RequiredArgsConstructor
 public class ImageController {
     private final ImageService imageService;

--- a/src/main/java/com/depromeet/domain/image/api/ImageController.java
+++ b/src/main/java/com/depromeet/domain/image/api/ImageController.java
@@ -1,0 +1,30 @@
+package com.depromeet.domain.image.api;
+
+import com.depromeet.domain.image.application.ImageService;
+import com.depromeet.domain.image.dto.request.MissionRecordImageCreateRequest;
+import com.depromeet.domain.image.dto.response.PresignedUrlResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "3.[이미지]", description = "이미지 관련 API입니다.")
+@RestController
+@RequestMapping("/images")
+@RequiredArgsConstructor
+public class ImageController {
+    private final ImageService imageService;
+
+    @Operation(
+            summary = "미션 기록 이미지 Presigned URL 생성",
+            description = "미션 기록 이미지 Presigned URL를 생성합니다.")
+    @PostMapping("/records/upload-url")
+    public PresignedUrlResponse missionRecordPresignedUrlCreate(
+            @Valid @RequestBody MissionRecordImageCreateRequest request) {
+        return imageService.createMissionRecordPresignedUrl(request);
+    }
+}

--- a/src/main/java/com/depromeet/domain/image/api/ImageController.java
+++ b/src/main/java/com/depromeet/domain/image/api/ImageController.java
@@ -2,6 +2,7 @@ package com.depromeet.domain.image.api;
 
 import com.depromeet.domain.image.application.ImageService;
 import com.depromeet.domain.image.dto.request.MissionRecordImageCreateRequest;
+import com.depromeet.domain.image.dto.request.MissionRecordImageUploadCompleteRequest;
 import com.depromeet.domain.image.dto.response.PresignedUrlResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,5 +27,12 @@ public class ImageController {
     public PresignedUrlResponse missionRecordPresignedUrlCreate(
             @Valid @RequestBody MissionRecordImageCreateRequest request) {
         return imageService.createMissionRecordPresignedUrl(request);
+    }
+
+    @Operation(summary = "미션 기록 이미지 업로드 완료처리", description = "미션 기록 이미지 업로드 완료 시 호출하시면 됩니다.")
+    @PostMapping("/records/upload-complete")
+    public void missionRecordUploaded(
+            @Valid @RequestBody MissionRecordImageUploadCompleteRequest request) {
+        imageService.uploadCompleteMissionRecord(request);
     }
 }

--- a/src/main/java/com/depromeet/domain/image/api/ImageController.java
+++ b/src/main/java/com/depromeet/domain/image/api/ImageController.java
@@ -10,7 +10,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "4. [이미지]", description = "이미지 관련 API입니다.")

--- a/src/main/java/com/depromeet/domain/image/api/ImageController.java
+++ b/src/main/java/com/depromeet/domain/image/api/ImageController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "3.[이미지]", description = "이미지 관련 API입니다.")
+@Tag(name = "4. [이미지]", description = "이미지 관련 API입니다.")
 @RestController
 @RequestMapping("/images")
 @RequiredArgsConstructor

--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -41,7 +41,7 @@ public class ImageService {
         MissionRecord missionRecord = findMissionRecordById(request.missionRecordId());
 
         Mission mission = missionRecord.getMission();
-        mission.validateUserMismatch(currentMember);
+        validateMissionRecordUserMismatch(mission, currentMember);
 
         String fileName =
                 createFileName(
@@ -71,7 +71,7 @@ public class ImageService {
         MissionRecord missionRecord = findMissionRecordById(request.missionRecordId());
 
         Mission mission = missionRecord.getMission();
-        mission.validateUserMismatch(currentMember);
+        validateMissionRecordUserMismatch(mission, currentMember);
 
         String imageUrl =
                 storageProperties.endpoint()
@@ -119,5 +119,11 @@ public class ImageService {
         expTimeMillis += 1000 * 60 * 30;
         expiration.setTime(expTimeMillis);
         return expiration;
+    }
+
+    private void validateMissionRecordUserMismatch(Mission mission, Member member) {
+        if (!mission.getMember().getId().equals(member.getId())) {
+            throw new CustomException(ErrorCode.MISSION_RECORD_USER_MISMATCH);
+        }
     }
 }

--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -81,7 +81,7 @@ public class ImageService {
                         + "/"
                         + springEnvironmentUtil.getCurrentProfile()
                         + "/"
-                        + ImageType.MISSION_RECORD
+                        + ImageType.MISSION_RECORD.getValue()
                         + "/"
                         + request.missionRecordId()
                         + "/image."

--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -19,7 +19,6 @@ import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
 import com.depromeet.global.util.SpringEnvironmentUtil;
 import com.depromeet.infra.config.storage.StorageProperties;
-
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -63,8 +62,8 @@ public class ImageService {
 
     private MissionRecord findMissionRecordByMissionRecordId(Long request) {
         return missionRecordRepository
-                        .findById(request)
-                        .orElseThrow(() -> new CustomException(ErrorCode.MISSION_RECORD_NOT_FOUND));
+                .findById(request)
+                .orElseThrow(() -> new CustomException(ErrorCode.MISSION_RECORD_NOT_FOUND));
     }
 
     @Transactional

--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -18,6 +18,8 @@ import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
 import com.depromeet.global.util.SpringEnvironmentUtil;
 import com.depromeet.infra.config.storage.StorageProperties;
+
+import java.time.YearMonth;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -44,7 +46,6 @@ public class ImageService {
 
         String fileName =
                 createFileName(
-                        currentMember.getId(),
                         ImageType.MISSION_RECORD,
                         request.missionRecordId(),
                         request.imageFileExtension());
@@ -74,10 +75,6 @@ public class ImageService {
                         + "/"
                         + springEnvironmentUtil.getCurrentProfile()
                         + "/"
-                        + "members"
-                        + "/"
-                        + currentMember.getId()
-                        + "/"
                         + ImageType.MISSION_RECORD
                         + "/"
                         + request.missionRecordId()
@@ -87,15 +84,8 @@ public class ImageService {
     }
 
     private String createFileName(
-            Long memberId,
-            ImageType imageType,
-            Long targetId,
-            ImageFileExtension imageFileExtension) {
+            ImageType imageType, Long targetId, ImageFileExtension imageFileExtension) {
         return springEnvironmentUtil.getCurrentProfile()
-                + "/"
-                + "members"
-                + "/"
-                + memberId
                 + "/"
                 + imageType.getValue()
                 + "/"

--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -1,0 +1,101 @@
+package com.depromeet.domain.image.application;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.depromeet.domain.image.domain.ImageFileExtension;
+import com.depromeet.domain.image.domain.ImageType;
+import com.depromeet.domain.image.dto.request.MissionRecordImageCreateRequest;
+import com.depromeet.domain.image.dto.response.PresignedUrlResponse;
+import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
+import com.depromeet.global.util.MemberUtil;
+import com.depromeet.global.util.SpringEnvironmentUtil;
+import com.depromeet.infra.config.storage.StorageProperties;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+    private final MemberUtil memberUtil;
+    private final SpringEnvironmentUtil springEnvironmentUtil;
+    private final StorageProperties storageProperties;
+    private final AmazonS3 amazonS3;
+    private final MissionRecordRepository missionRecordRepository;
+
+    @Transactional
+    public PresignedUrlResponse createMissionRecordPresignedUrl(
+            MissionRecordImageCreateRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        MissionRecord missionRecord =
+                missionRecordRepository
+                        .findById(request.missionRecordId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MISSION_RECORD_NOT_FOUND));
+
+        String fileName =
+                createFileName(
+                        currentMember.getId(),
+                        ImageType.MISSION_RECORD,
+                        request.missionRecordId(),
+                        request.imageFileExtension());
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                createGeneratePreSignedUrlRequest(
+                        storageProperties.bucket(),
+                        fileName,
+                        request.imageFileExtension().getUploadExtension());
+
+        String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+
+        missionRecord.updateUploadStatusPending();
+        return PresignedUrlResponse.from(presignedUrl);
+    }
+
+    private String createFileName(
+            Long memberId,
+            ImageType imageType,
+            Long targetId,
+            ImageFileExtension imageFileExtension) {
+        return springEnvironmentUtil.getCurrentProfile()
+                + "/"
+                + "members"
+                + "/"
+                + memberId
+                + "/"
+                + imageType.getValue()
+                + "/"
+                + targetId
+                + "/image."
+                + imageFileExtension.getUploadExtension();
+    }
+
+    private GeneratePresignedUrlRequest createGeneratePreSignedUrlRequest(
+            String bucket, String fileName, String fileExtension) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileName, HttpMethod.PUT)
+                        .withKey(fileName)
+                        .withContentType("image/" + fileExtension)
+                        .withExpiration(getPreSignedUrlExpiration());
+
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        return generatePresignedUrlRequest;
+    }
+
+    private Date getPreSignedUrlExpiration() {
+        Date expiration = new Date();
+        var expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 30;
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+}

--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -38,7 +38,7 @@ public class ImageService {
             MissionRecordImageCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
-        MissionRecord missionRecord = findMissionRecordByMissionRecordId(request.missionRecordId());
+        MissionRecord missionRecord = findMissionRecordById(request.missionRecordId());
 
         Mission mission = missionRecord.getMission();
         mission.validateUserMismatch(currentMember);
@@ -60,7 +60,7 @@ public class ImageService {
         return PresignedUrlResponse.from(presignedUrl);
     }
 
-    private MissionRecord findMissionRecordByMissionRecordId(Long request) {
+    private MissionRecord findMissionRecordById(Long request) {
         return missionRecordRepository
                 .findById(request)
                 .orElseThrow(() -> new CustomException(ErrorCode.MISSION_RECORD_NOT_FOUND));
@@ -68,7 +68,7 @@ public class ImageService {
 
     public void uploadCompleteMissionRecord(MissionRecordImageUploadCompleteRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
-        MissionRecord missionRecord = findMissionRecordByMissionRecordId(request.missionRecordId());
+        MissionRecord missionRecord = findMissionRecordById(request.missionRecordId());
 
         Mission mission = missionRecord.getMission();
         mission.validateUserMismatch(currentMember);

--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ImageService {
     private final MemberUtil memberUtil;
     private final SpringEnvironmentUtil springEnvironmentUtil;
@@ -33,7 +34,6 @@ public class ImageService {
     private final AmazonS3 amazonS3;
     private final MissionRecordRepository missionRecordRepository;
 
-    @Transactional
     public PresignedUrlResponse createMissionRecordPresignedUrl(
             MissionRecordImageCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
@@ -66,7 +66,6 @@ public class ImageService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MISSION_RECORD_NOT_FOUND));
     }
 
-    @Transactional
     public void uploadCompleteMissionRecord(MissionRecordImageUploadCompleteRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
         MissionRecord missionRecord = findMissionRecordByMissionRecordId(request.missionRecordId());

--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.depromeet.domain.image.domain.ImageFileExtension;
 import com.depromeet.domain.image.domain.ImageType;
 import com.depromeet.domain.image.dto.request.MissionRecordImageCreateRequest;
+import com.depromeet.domain.image.dto.request.MissionRecordImageUploadCompleteRequest;
 import com.depromeet.domain.image.dto.response.PresignedUrlResponse;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
@@ -57,6 +58,32 @@ public class ImageService {
 
         missionRecord.updateUploadStatusPending();
         return PresignedUrlResponse.from(presignedUrl);
+    }
+
+    @Transactional
+    public void uploadCompleteMissionRecord(MissionRecordImageUploadCompleteRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        MissionRecord missionRecord =
+                missionRecordRepository
+                        .findById(request.missionRecordId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MISSION_RECORD_NOT_FOUND));
+        String imageUrl =
+                storageProperties.endpoint()
+                        + "/"
+                        + storageProperties.bucket()
+                        + "/"
+                        + springEnvironmentUtil.getCurrentProfile()
+                        + "/"
+                        + "members"
+                        + "/"
+                        + currentMember.getId()
+                        + "/"
+                        + ImageType.MISSION_RECORD
+                        + "/"
+                        + request.missionRecordId()
+                        + "/image."
+                        + request.imageFileExtension().getUploadExtension();
+        missionRecord.updateUploadStatusComplete(request.remark(), imageUrl);
     }
 
     private String createFileName(

--- a/src/main/java/com/depromeet/domain/image/domain/ImageFileExtension.java
+++ b/src/main/java/com/depromeet/domain/image/domain/ImageFileExtension.java
@@ -1,0 +1,15 @@
+package com.depromeet.domain.image.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageFileExtension {
+    JPEG("jpeg"),
+    JPG("jpg"),
+    PNG("png"),
+    ;
+
+    private final String uploadExtension;
+}

--- a/src/main/java/com/depromeet/domain/image/domain/ImageType.java
+++ b/src/main/java/com/depromeet/domain/image/domain/ImageType.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ImageType {
     MISSION_RECORD("mission_record"),
+    MEMBER_PROFILE("member_profile"),
+    MEMBER_BACKGROUND("member_background"),
     ;
     private final String value;
 }

--- a/src/main/java/com/depromeet/domain/image/domain/ImageType.java
+++ b/src/main/java/com/depromeet/domain/image/domain/ImageType.java
@@ -1,0 +1,12 @@
+package com.depromeet.domain.image.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageType {
+    MISSION_RECORD("mission_record"),
+    ;
+    private final String value;
+}

--- a/src/main/java/com/depromeet/domain/image/dto/request/MissionRecordImageCreateRequest.java
+++ b/src/main/java/com/depromeet/domain/image/dto/request/MissionRecordImageCreateRequest.java
@@ -1,0 +1,13 @@
+package com.depromeet.domain.image.dto.request;
+
+import com.depromeet.domain.image.domain.ImageFileExtension;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record MissionRecordImageCreateRequest(
+        @NotNull(message = "미션 기록 ID는 비워둘 수 없습니다.")
+                @Schema(description = "미션 기록 ID", defaultValue = "1")
+                Long missionRecordId,
+        @NotNull(message = "이미지 파일의 확장자는 비워둘 수 없습니다.")
+                @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
+                ImageFileExtension imageFileExtension) {}

--- a/src/main/java/com/depromeet/domain/image/dto/request/MissionRecordImageUploadCompleteRequest.java
+++ b/src/main/java/com/depromeet/domain/image/dto/request/MissionRecordImageUploadCompleteRequest.java
@@ -1,0 +1,15 @@
+package com.depromeet.domain.image.dto.request;
+
+import com.depromeet.domain.image.domain.ImageFileExtension;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record MissionRecordImageUploadCompleteRequest(
+        @NotNull(message = "미션 기록 ID는 비워둘 수 없습니다.")
+                @Schema(description = "미션 기록 ID", defaultValue = "1")
+                Long missionRecordId,
+        @NotNull(message = "이미지 파일의 확장자는 비워둘 수 없습니다.")
+                @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
+                ImageFileExtension imageFileExtension,
+        @Size(max = 200, message = "미션 일지는 20자 이하까지만 입력 가능합니다.") String remark) {}

--- a/src/main/java/com/depromeet/domain/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/depromeet/domain/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,9 @@
+package com.depromeet.domain.image.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PresignedUrlResponse(@Schema(description = "Presigned URL") String presignedUrl) {
+    public static PresignedUrlResponse from(String presignedUrl) {
+        return new PresignedUrlResponse(presignedUrl);
+    }
+}

--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -3,8 +3,6 @@ package com.depromeet.domain.mission.domain;
 import com.depromeet.domain.common.model.BaseTimeEntity;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
-import com.depromeet.global.error.exception.CustomException;
-import com.depromeet.global.error.exception.ErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -116,11 +114,5 @@ public class Mission extends BaseTimeEntity {
         this.name = name;
         this.content = content;
         this.visibility = visibility;
-    }
-
-    public void validateUserMismatch(Member member) {
-        if (!member.getId().equals(this.member.getId())) {
-            throw new CustomException(ErrorCode.MISSION_RECORD_USER_MISMATCH);
-        }
     }
 }

--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -3,6 +3,8 @@ package com.depromeet.domain.mission.domain;
 import com.depromeet.domain.common.model.BaseTimeEntity;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -114,5 +116,11 @@ public class Mission extends BaseTimeEntity {
         this.name = name;
         this.content = content;
         this.visibility = visibility;
+    }
+
+    public void validateUserMismatch(Member member) {
+        if (!member.getId().equals(this.member.getId())) {
+            throw new CustomException(ErrorCode.MISSION_RECORD_USER_MISMATCH);
+        }
     }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
@@ -2,6 +2,8 @@ package com.depromeet.domain.missionRecord.domain;
 
 import com.depromeet.domain.common.model.BaseTimeEntity;
 import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -79,10 +81,16 @@ public class MissionRecord extends BaseTimeEntity {
     }
 
     public void updateUploadStatusPending() {
+        if (this.uploadStatus != ImageUploadStatus.NONE) {
+            throw new CustomException(ErrorCode.MISSION_RECORD_UPLOAD_STATUS_IS_NOT_NONE);
+        }
         this.uploadStatus = ImageUploadStatus.PENDING;
     }
 
     public void updateUploadStatusComplete(String remark, String imageUrl) {
+        if (this.uploadStatus == ImageUploadStatus.COMPLETE) {
+            throw new CustomException(ErrorCode.MISSION_RECORD_UPLOAD_STATUS_ALREADY_COMPLETED);
+        }
         this.uploadStatus = ImageUploadStatus.COMPLETE;
         this.remark = remark;
         this.imageUrl = imageUrl;

--- a/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
@@ -81,4 +81,10 @@ public class MissionRecord extends BaseTimeEntity {
     public void updateUploadStatusPending() {
         this.uploadStatus = ImageUploadStatus.PENDING;
     }
+
+    public void updateUploadStatusComplete(String remark, String imageUrl) {
+        this.uploadStatus = ImageUploadStatus.COMPLETE;
+        this.remark = remark;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
@@ -88,8 +88,8 @@ public class MissionRecord extends BaseTimeEntity {
     }
 
     public void updateUploadStatusComplete(String remark, String imageUrl) {
-        if (this.uploadStatus == ImageUploadStatus.COMPLETE) {
-            throw new CustomException(ErrorCode.MISSION_RECORD_UPLOAD_STATUS_ALREADY_COMPLETED);
+        if (this.uploadStatus != ImageUploadStatus.PENDING) {
+            throw new CustomException(ErrorCode.MISSION_RECORD_UPLOAD_STATUS_IS_NOT_PENDING);
         }
         this.uploadStatus = ImageUploadStatus.COMPLETE;
         this.remark = remark;

--- a/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
@@ -77,4 +77,8 @@ public class MissionRecord extends BaseTimeEntity {
                 .mission(mission)
                 .build();
     }
+
+    public void updateUploadStatusPending() {
+        this.uploadStatus = ImageUploadStatus.PENDING;
+    }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -23,13 +23,13 @@ public class MissionRecordService {
     private final MissionRecordRepository missionRecordRepository;
 
     public Long createMissionRecord(MissionRecordCreateRequest request) {
-        final Mission mission = findMission(request);
+        final Mission mission = findMissionByMissionId(request.missionId());
         final Member member = memberUtil.getCurrentMember();
 
         Duration duration =
                 Duration.ofMinutes(request.durationMin()).plusSeconds(request.durationSec());
 
-        validateMissionRecordUserMismatch(mission, member);
+        mission.validateUserMismatch(member);
         validateMissionRecordDuration(duration);
 
         MissionRecord missionRecord =
@@ -38,16 +38,10 @@ public class MissionRecordService {
         return missionRecordRepository.save(missionRecord).getId();
     }
 
-    private Mission findMission(MissionRecordCreateRequest request) {
+    private Mission findMissionByMissionId(Long missionId) {
         return missionRepository
-                .findByMissionId(request.missionId())
+                .findByMissionId(missionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
-    }
-
-    private void validateMissionRecordUserMismatch(Mission mission, Member member) {
-        if (!member.getId().equals(mission.getMember().getId())) {
-            throw new CustomException(ErrorCode.MISSION_RECORD_USER_MISMATCH);
-        }
     }
 
     private void validateMissionRecordDuration(Duration duration) {

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -45,7 +45,7 @@ public class MissionRecordService {
 
     private Mission findMissionById(Long missionId) {
         return missionRepository
-                .findByMissionId(missionId)
+                .findById(missionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
     }
   

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -29,7 +29,7 @@ public class MissionRecordService {
         Duration duration =
                 Duration.ofMinutes(request.durationMin()).plusSeconds(request.durationSec());
 
-        mission.validateUserMismatch(member);
+        validateMissionRecordUserMismatch(mission, member);
         validateMissionRecordDuration(duration);
 
         MissionRecord missionRecord =
@@ -47,6 +47,12 @@ public class MissionRecordService {
     private void validateMissionRecordDuration(Duration duration) {
         if (duration.getSeconds() > 3600L) {
             throw new CustomException(ErrorCode.MISSION_RECORD_DURATION_OVERBALANCE);
+        }
+    }
+
+    private void validateMissionRecordUserMismatch(Mission mission, Member member) {
+        if (!mission.getMember().getId().equals(member.getId())) {
+            throw new CustomException(ErrorCode.MISSION_RECORD_USER_MISMATCH);
         }
     }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -42,13 +42,12 @@ public class MissionRecordService {
         return missionRecordRepository.save(missionRecord).getId();
     }
 
-
     private Mission findMissionById(Long missionId) {
         return missionRepository
                 .findById(missionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
     }
-  
+
     @Transactional(readOnly = true)
     public MissionRecordFindOneResponse findOneMissionRecord(Long recordId) {
         MissionRecord missionRecord =

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
     MISSION_RECORD_UPLOAD_STATUS_IS_NOT_NONE(
             HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 NONE이 아닙니다."),
+    MISSION_RECORD_UPLOAD_STATUS_IS_NOT_PENDING(HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 PENDING이 아닙니다."),
     MISSION_RECORD_UPLOAD_STATUS_ALREADY_COMPLETED(
             HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 이미 완료되어있습니다."),
     ;

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     MISSION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션 기록을 찾을 수 없습니다."),
     MISSION_RECORD_USER_MISMATCH(HttpStatus.BAD_REQUEST, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
     MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
+    MISSION_RECORD_UPLOAD_STATUS_IS_NOT_NONE(HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 NONE이 아닙니다."),
+    MISSION_RECORD_UPLOAD_STATUS_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 이미 완료되어있습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -31,7 +31,8 @@ public enum ErrorCode {
     MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
     MISSION_RECORD_UPLOAD_STATUS_IS_NOT_NONE(
             HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 NONE이 아닙니다."),
-    MISSION_RECORD_UPLOAD_STATUS_IS_NOT_PENDING(HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 PENDING이 아닙니다."),
+    MISSION_RECORD_UPLOAD_STATUS_IS_NOT_PENDING(
+            HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 PENDING이 아닙니다."),
     MISSION_RECORD_UPLOAD_STATUS_ALREADY_COMPLETED(
             HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 이미 완료되어있습니다."),
     ;

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -29,8 +29,10 @@ public enum ErrorCode {
     MISSION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션 기록을 찾을 수 없습니다."),
     MISSION_RECORD_USER_MISMATCH(HttpStatus.BAD_REQUEST, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
     MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
-    MISSION_RECORD_UPLOAD_STATUS_IS_NOT_NONE(HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 NONE이 아닙니다."),
-    MISSION_RECORD_UPLOAD_STATUS_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 이미 완료되어있습니다."),
+    MISSION_RECORD_UPLOAD_STATUS_IS_NOT_NONE(
+            HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 NONE이 아닙니다."),
+    MISSION_RECORD_UPLOAD_STATUS_ALREADY_COMPLETED(
+            HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 이미 완료되어있습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     MISSION_VISIBILITY_NULL(HttpStatus.BAD_REQUEST, "미션 공개 여부가 null입니다."),
 
     // MissionRecord
+    MISSION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션 기록을 찾을 수 없습니다."),
     MISSION_RECORD_USER_MISMATCH(HttpStatus.BAD_REQUEST, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
     MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
     ;

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -33,8 +33,6 @@ public enum ErrorCode {
             HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 NONE이 아닙니다."),
     MISSION_RECORD_UPLOAD_STATUS_IS_NOT_PENDING(
             HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 PENDING이 아닙니다."),
-    MISSION_RECORD_UPLOAD_STATUS_ALREADY_COMPLETED(
-            HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 이미 완료되어있습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/depromeet/infra/config/storage/StorageConfig.java
+++ b/src/main/java/com/depromeet/infra/config/storage/StorageConfig.java
@@ -3,6 +3,7 @@ package com.depromeet.infra.config.storage;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +20,13 @@ public class StorageConfig {
         AWSCredentials credentials =
                 new BasicAWSCredentials(
                         storageProperties.accessKey(), storageProperties.secretKey());
+        AwsClientBuilder.EndpointConfiguration endpointConfiguration =
+                new AwsClientBuilder.EndpointConfiguration(
+                        storageProperties.endpoint(), storageProperties.region());
+
         return AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(endpointConfiguration)
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                .withRegion(storageProperties.region())
                 .build();
     }
 }

--- a/src/main/java/com/depromeet/infra/config/storage/StorageProperties.java
+++ b/src/main/java/com/depromeet/infra/config/storage/StorageProperties.java
@@ -3,4 +3,5 @@ package com.depromeet.infra.config.storage;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "storage")
-public record StorageProperties(String accessKey, String secretKey, String region, String bucket) {}
+public record StorageProperties(
+        String accessKey, String secretKey, String region, String bucket, String endpoint) {}

--- a/src/main/resources/application-storage.yml
+++ b/src/main/resources/application-storage.yml
@@ -5,5 +5,6 @@ spring:
 storage:
   accessKey: ${STORAGE_ACCESS_KEY:}
   secretKey: ${STORAGE_SECRET_KEY:}
-  region: ${STORAGE_REGION:}
   bucket: ${STORAGE_BUCKET:}
+  region: ${STORAGE_REGION:}
+  endpoint: ${STORAGE_ENDPOINT:https://kr.object.ncloudstorage.com}

--- a/src/test/java/com/depromeet/domain/image/api/ImageControllerTest.java
+++ b/src/test/java/com/depromeet/domain/image/api/ImageControllerTest.java
@@ -42,7 +42,7 @@ class ImageControllerTest {
 
             // when, then
             mockMvc.perform(
-                            post("/images/records/upload-url")
+                            post("/records/upload-url")
                                     .contentType(APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest())
@@ -60,7 +60,7 @@ class ImageControllerTest {
 
             // when, then
             mockMvc.perform(
-                            post("/images/records/upload-url")
+                            post("/records/upload-url")
                                     .contentType(APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest())
@@ -83,7 +83,7 @@ class ImageControllerTest {
 
             // then
             mockMvc.perform(
-                            post("/images/records/upload-url")
+                            post("/records/upload-url")
                                     .contentType(APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -105,7 +105,7 @@ class ImageControllerTest {
 
             // when, then
             mockMvc.perform(
-                            post("/images/records/upload-complete")
+                            post("/records/upload-complete")
                                     .contentType(APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest())
@@ -124,7 +124,7 @@ class ImageControllerTest {
 
             // when, then
             mockMvc.perform(
-                            post("/images/records/upload-complete")
+                            post("/records/upload-complete")
                                     .contentType(APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest())
@@ -143,7 +143,7 @@ class ImageControllerTest {
 
             // when, then
             mockMvc.perform(
-                            post("/images/records/upload-complete")
+                            post("/records/upload-complete")
                                     .contentType(APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -161,7 +161,7 @@ class ImageControllerTest {
 
             // when, then
             mockMvc.perform(
-                            post("/images/records/upload-url")
+                            post("/records/upload-url")
                                     .contentType(APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())

--- a/src/test/java/com/depromeet/domain/image/api/ImageControllerTest.java
+++ b/src/test/java/com/depromeet/domain/image/api/ImageControllerTest.java
@@ -1,0 +1,165 @@
+package com.depromeet.domain.image.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.depromeet.domain.image.application.ImageService;
+import com.depromeet.domain.image.domain.ImageFileExtension;
+import com.depromeet.domain.image.dto.request.MissionRecordImageCreateRequest;
+import com.depromeet.domain.image.dto.request.MissionRecordImageUploadCompleteRequest;
+import com.depromeet.domain.image.dto.response.PresignedUrlResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.awt.*;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ImageController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
+class ImageControllerTest {
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockBean private ImageService imageService;
+
+    @Nested
+    class 미션_기록_이미지_PresignedUrl을_생성할_때 {
+        @Test
+        void 미션_ID가_NULL_이라면_예외를_발생시킨다() throws Exception {
+            // given
+            MissionRecordImageCreateRequest request =
+                    new MissionRecordImageCreateRequest(null, ImageFileExtension.JPEG);
+
+            // when, then
+            mockMvc.perform(
+                            post("/images/records/upload-url")
+                                    .contentType(APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(jsonPath("$.message").value("{\"missionRecordId\":\"미션 기록 ID는 비워둘 수 없습니다.\"}"))
+                    .andDo(print());
+        }
+
+		@Test
+		void 이미지_파일의_확장자가_NULL_이라면_예외를_발생시킨다() throws Exception {
+			// given
+			MissionRecordImageCreateRequest request =
+					new MissionRecordImageCreateRequest(1L, null);
+
+			// when, then
+			mockMvc.perform(
+					post("/images/records/upload-url")
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+				.andExpect(jsonPath("$.message").value("{\"imageFileExtension\":\"이미지 파일의 확장자는 비워둘 수 없습니다.\"}"))
+				.andDo(print());
+		}
+
+		@Test
+		void 입력_값이_정상이라면_예외가_발생하지_않는다() throws Exception {
+			// given
+			MissionRecordImageCreateRequest request =
+					new MissionRecordImageCreateRequest(30L, ImageFileExtension.JPEG);
+			PresignedUrlResponse response = PresignedUrlResponse.from("presignedUrl");
+
+			// when
+			given(imageService.createMissionRecordPresignedUrl(request))
+					.willReturn(response);
+
+			// then
+			mockMvc.perform(
+					post("/images/records/upload-url")
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+				.andExpect(jsonPath("$.data.presignedUrl").value("presignedUrl"))
+				.andDo(print());
+		}
+    }
+
+	@Nested
+	class 미션_기록_이미지_업로드_완료_처리할_때 {
+		@Test
+		void 미션_ID가_NULL_이라면_예외를_발생시킨다() throws Exception {
+			// given
+			MissionRecordImageUploadCompleteRequest request =
+				new MissionRecordImageUploadCompleteRequest(null, ImageFileExtension.JPEG, "미션 일지");
+
+			// when, then
+			mockMvc.perform(
+					post("/images/records/upload-complete")
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+				.andExpect(jsonPath("$.message").value("{\"missionRecordId\":\"미션 기록 ID는 비워둘 수 없습니다.\"}"))
+				.andDo(print());
+		}
+
+		@Test
+		void 이미지_파일의_확장자가_NULL_이라면_예외를_발생시킨다() throws Exception {
+			// given
+			MissionRecordImageUploadCompleteRequest request =
+				new MissionRecordImageUploadCompleteRequest(182L, null, "미션 일지");
+
+			// when, then
+			mockMvc.perform(
+					post("/images/records/upload-complete")
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+				.andExpect(jsonPath("$.message").value("{\"imageFileExtension\":\"이미지 파일의 확장자는 비워둘 수 없습니다.\"}"))
+				.andDo(print());
+		}
+
+		@Test
+		void 미션_일지는_NULL_이라도_예외가_발생하지_않는다() throws Exception {
+			MissionRecordImageUploadCompleteRequest request =
+				new MissionRecordImageUploadCompleteRequest(182L, ImageFileExtension.JPEG, null);
+
+			// when, then
+			mockMvc.perform(
+					post("/images/records/upload-complete")
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+				.andDo(print());
+		}
+
+		@Test
+		void 입력_값이_정상이라면_예외가_발생하지_않는다() throws Exception {
+			// given
+			MissionRecordImageUploadCompleteRequest request =
+				new MissionRecordImageUploadCompleteRequest(182L, ImageFileExtension.JPEG, "미션 일지");
+
+			// when, then
+			mockMvc.perform(
+					post("/images/records/upload-url")
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+				.andDo(print());
+		}
+	}
+}

--- a/src/test/java/com/depromeet/domain/image/api/ImageControllerTest.java
+++ b/src/test/java/com/depromeet/domain/image/api/ImageControllerTest.java
@@ -12,7 +12,6 @@ import com.depromeet.domain.image.domain.ImageFileExtension;
 import com.depromeet.domain.image.dto.request.MissionRecordImageCreateRequest;
 import com.depromeet.domain.image.dto.request.MissionRecordImageUploadCompleteRequest;
 import com.depromeet.domain.image.dto.response.PresignedUrlResponse;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.awt.*;
 import org.junit.jupiter.api.Nested;
@@ -48,118 +47,127 @@ class ImageControllerTest {
                                     .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                    .andExpect(jsonPath("$.message").value("{\"missionRecordId\":\"미션 기록 ID는 비워둘 수 없습니다.\"}"))
+                    .andExpect(
+                            jsonPath("$.message")
+                                    .value("{\"missionRecordId\":\"미션 기록 ID는 비워둘 수 없습니다.\"}"))
                     .andDo(print());
         }
 
-		@Test
-		void 이미지_파일의_확장자가_NULL_이라면_예외를_발생시킨다() throws Exception {
-			// given
-			MissionRecordImageCreateRequest request =
-					new MissionRecordImageCreateRequest(1L, null);
+        @Test
+        void 이미지_파일의_확장자가_NULL_이라면_예외를_발생시킨다() throws Exception {
+            // given
+            MissionRecordImageCreateRequest request = new MissionRecordImageCreateRequest(1L, null);
 
-			// when, then
-			mockMvc.perform(
-					post("/images/records/upload-url")
-						.contentType(APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isBadRequest())
-				.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-				.andExpect(jsonPath("$.message").value("{\"imageFileExtension\":\"이미지 파일의 확장자는 비워둘 수 없습니다.\"}"))
-				.andDo(print());
-		}
+            // when, then
+            mockMvc.perform(
+                            post("/images/records/upload-url")
+                                    .contentType(APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(
+                            jsonPath("$.message")
+                                    .value("{\"imageFileExtension\":\"이미지 파일의 확장자는 비워둘 수 없습니다.\"}"))
+                    .andDo(print());
+        }
 
-		@Test
-		void 입력_값이_정상이라면_예외가_발생하지_않는다() throws Exception {
-			// given
-			MissionRecordImageCreateRequest request =
-					new MissionRecordImageCreateRequest(30L, ImageFileExtension.JPEG);
-			PresignedUrlResponse response = PresignedUrlResponse.from("presignedUrl");
+        @Test
+        void 입력_값이_정상이라면_예외가_발생하지_않는다() throws Exception {
+            // given
+            MissionRecordImageCreateRequest request =
+                    new MissionRecordImageCreateRequest(30L, ImageFileExtension.JPEG);
+            PresignedUrlResponse response = PresignedUrlResponse.from("presignedUrl");
 
-			// when
-			given(imageService.createMissionRecordPresignedUrl(request))
-					.willReturn(response);
+            // when
+            given(imageService.createMissionRecordPresignedUrl(request)).willReturn(response);
 
-			// then
-			mockMvc.perform(
-					post("/images/records/upload-url")
-						.contentType(APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-				.andExpect(jsonPath("$.data.presignedUrl").value("presignedUrl"))
-				.andDo(print());
-		}
+            // then
+            mockMvc.perform(
+                            post("/images/records/upload-url")
+                                    .contentType(APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.data.presignedUrl").value("presignedUrl"))
+                    .andDo(print());
+        }
     }
 
-	@Nested
-	class 미션_기록_이미지_업로드_완료_처리할_때 {
-		@Test
-		void 미션_ID가_NULL_이라면_예외를_발생시킨다() throws Exception {
-			// given
-			MissionRecordImageUploadCompleteRequest request =
-				new MissionRecordImageUploadCompleteRequest(null, ImageFileExtension.JPEG, "미션 일지");
+    @Nested
+    class 미션_기록_이미지_업로드_완료_처리할_때 {
+        @Test
+        void 미션_ID가_NULL_이라면_예외를_발생시킨다() throws Exception {
+            // given
+            MissionRecordImageUploadCompleteRequest request =
+                    new MissionRecordImageUploadCompleteRequest(
+                            null, ImageFileExtension.JPEG, "미션 일지");
 
-			// when, then
-			mockMvc.perform(
-					post("/images/records/upload-complete")
-						.contentType(APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isBadRequest())
-				.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-				.andExpect(jsonPath("$.message").value("{\"missionRecordId\":\"미션 기록 ID는 비워둘 수 없습니다.\"}"))
-				.andDo(print());
-		}
+            // when, then
+            mockMvc.perform(
+                            post("/images/records/upload-complete")
+                                    .contentType(APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(
+                            jsonPath("$.message")
+                                    .value("{\"missionRecordId\":\"미션 기록 ID는 비워둘 수 없습니다.\"}"))
+                    .andDo(print());
+        }
 
-		@Test
-		void 이미지_파일의_확장자가_NULL_이라면_예외를_발생시킨다() throws Exception {
-			// given
-			MissionRecordImageUploadCompleteRequest request =
-				new MissionRecordImageUploadCompleteRequest(182L, null, "미션 일지");
+        @Test
+        void 이미지_파일의_확장자가_NULL_이라면_예외를_발생시킨다() throws Exception {
+            // given
+            MissionRecordImageUploadCompleteRequest request =
+                    new MissionRecordImageUploadCompleteRequest(182L, null, "미션 일지");
 
-			// when, then
-			mockMvc.perform(
-					post("/images/records/upload-complete")
-						.contentType(APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isBadRequest())
-				.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-				.andExpect(jsonPath("$.message").value("{\"imageFileExtension\":\"이미지 파일의 확장자는 비워둘 수 없습니다.\"}"))
-				.andDo(print());
-		}
+            // when, then
+            mockMvc.perform(
+                            post("/images/records/upload-complete")
+                                    .contentType(APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(
+                            jsonPath("$.message")
+                                    .value("{\"imageFileExtension\":\"이미지 파일의 확장자는 비워둘 수 없습니다.\"}"))
+                    .andDo(print());
+        }
 
-		@Test
-		void 미션_일지는_NULL_이라도_예외가_발생하지_않는다() throws Exception {
-			MissionRecordImageUploadCompleteRequest request =
-				new MissionRecordImageUploadCompleteRequest(182L, ImageFileExtension.JPEG, null);
+        @Test
+        void 미션_일지는_NULL_이라도_예외가_발생하지_않는다() throws Exception {
+            MissionRecordImageUploadCompleteRequest request =
+                    new MissionRecordImageUploadCompleteRequest(
+                            182L, ImageFileExtension.JPEG, null);
 
-			// when, then
-			mockMvc.perform(
-					post("/images/records/upload-complete")
-						.contentType(APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-				.andDo(print());
-		}
+            // when, then
+            mockMvc.perform(
+                            post("/images/records/upload-complete")
+                                    .contentType(APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andDo(print());
+        }
 
-		@Test
-		void 입력_값이_정상이라면_예외가_발생하지_않는다() throws Exception {
-			// given
-			MissionRecordImageUploadCompleteRequest request =
-				new MissionRecordImageUploadCompleteRequest(182L, ImageFileExtension.JPEG, "미션 일지");
+        @Test
+        void 입력_값이_정상이라면_예외가_발생하지_않는다() throws Exception {
+            // given
+            MissionRecordImageUploadCompleteRequest request =
+                    new MissionRecordImageUploadCompleteRequest(
+                            182L, ImageFileExtension.JPEG, "미션 일지");
 
-			// when, then
-			mockMvc.perform(
-					post("/images/records/upload-url")
-						.contentType(APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
-				.andDo(print());
-		}
-	}
+            // when, then
+            mockMvc.perform(
+                            post("/images/records/upload-url")
+                                    .contentType(APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andDo(print());
+        }
+    }
 }

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -1,0 +1,148 @@
+package com.depromeet.domain.image.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.depromeet.DatabaseCleaner;
+import com.depromeet.domain.image.domain.ImageFileExtension;
+import com.depromeet.domain.image.dto.request.MissionRecordImageCreateRequest;
+import com.depromeet.domain.image.dto.response.PresignedUrlResponse;
+import com.depromeet.domain.member.dao.MemberRepository;
+import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.member.domain.Profile;
+import com.depromeet.domain.mission.dao.MissionRepository;
+import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.domain.mission.domain.MissionCategory;
+import com.depromeet.domain.mission.domain.MissionVisibility;
+import com.depromeet.domain.mission.dto.request.MissionCreateRequest;
+import com.depromeet.domain.mission.dto.response.MissionCreateResponse;
+import com.depromeet.domain.mission.service.MissionService;
+import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
+import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
+import com.depromeet.domain.missionRecord.service.MissionRecordService;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
+import com.depromeet.global.util.MemberUtil;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ImageServiceTest {
+	@Autowired private DatabaseCleaner databaseCleaner;
+	@Autowired private MemberRepository memberRepository;
+	@Autowired private ImageService imageService;
+	@Autowired private MissionRecordService missionRecordService;
+	@Autowired private MissionService missionService;
+
+	@BeforeEach
+	void setUp() {
+		databaseCleaner.execute();
+	}
+
+	@Nested
+	class 미션_기록_이미지_PresignedUrl을_생성할_때 {
+		// TODO: MemberUtil insertMockMemberIfNotExist메서드 제거 후 주석해제 예
+		// @Test
+		// void 회원이_존재하지_않는다면_예외를_발생시킨다() {
+		// 	// given
+		// 	MissionRecordImageCreateRequest request =
+		// 		new MissionRecordImageCreateRequest(192L, ImageFileExtension.JPEG);
+		//
+		// 	// when, then
+		// 	assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
+		// 		.isInstanceOf(CustomException.class)
+		// 		.hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+		// }
+
+		@Test
+		void 미션이_존재하지_않는다면_예외를_발생시킨다() {
+			// given
+			memberRepository.save(Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
+			MissionRecordImageCreateRequest request =
+				new MissionRecordImageCreateRequest(192L, ImageFileExtension.JPEG);
+
+			// when, then
+			assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
+					.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.MISSION_RECORD_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		void 입력_값이_정상이라면_예외가_발생하지_않는다() {
+			// given
+			memberRepository.save(Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
+			MissionCreateRequest missionCreateRequest =
+				new MissionCreateRequest(
+					"testMissionName",
+					"testMissionContent",
+					MissionCategory.STUDY,
+					MissionVisibility.ALL);
+			MissionCreateResponse missionCreateResponse = missionService.createMission(missionCreateRequest);
+
+			LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+			LocalDateTime missionRecordFinishedAt =
+				missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+			MissionRecordCreateRequest missionRecordCreateRequest = new MissionRecordCreateRequest(
+				missionCreateResponse.missionId(),
+				missionRecordStartedAt,
+				missionRecordFinishedAt,
+				32,
+				14
+			);
+			Long missionRecord = missionRecordService.createMissionRecord(missionRecordCreateRequest);
+			MissionRecordImageCreateRequest request =
+				new MissionRecordImageCreateRequest(missionRecord, ImageFileExtension.JPEG);
+
+			// when, then
+			assertThatCode(() -> imageService.createMissionRecordPresignedUrl(request))
+				.doesNotThrowAnyException();
+		}
+
+		@Test
+		void 입력_값이_정상이라면_PresignedUrl이_정상적으로_생성된다() {
+			// given
+			Member member = memberRepository.save(Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
+			MissionCreateRequest missionCreateRequest =
+				new MissionCreateRequest(
+					"testMissionName",
+					"testMissionContent",
+					MissionCategory.STUDY,
+					MissionVisibility.ALL);
+			MissionCreateResponse missionCreateResponse = missionService.createMission(missionCreateRequest);
+
+			LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+			LocalDateTime missionRecordFinishedAt =
+				missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+			MissionRecordCreateRequest missionRecordCreateRequest = new MissionRecordCreateRequest(
+				missionCreateResponse.missionId(),
+				missionRecordStartedAt,
+				missionRecordFinishedAt,
+				32,
+				14
+			);
+			Long missionRecordId = missionRecordService.createMissionRecord(missionRecordCreateRequest);
+			ImageFileExtension imageFileExtension = ImageFileExtension.JPEG;
+			MissionRecordImageCreateRequest request =
+				new MissionRecordImageCreateRequest(missionRecordId, imageFileExtension);
+
+			// when
+			PresignedUrlResponse missionRecordPresignedUrl = imageService.createMissionRecordPresignedUrl(request);
+
+			// then
+			assertThat(missionRecordPresignedUrl.presignedUrl())
+				.startsWith(String.format("https://kr.object.ncloudstorage.com/local/members/%s/mission_record/%s/image.jpeg", member.getId(), missionRecordId));
+		}
+	}
+
+
+
+}

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -3,16 +3,6 @@ package com.depromeet.domain.image.application;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-
 import com.depromeet.DatabaseCleaner;
 import com.depromeet.domain.image.domain.ImageFileExtension;
 import com.depromeet.domain.image.dto.request.MissionRecordImageCreateRequest;
@@ -20,129 +10,141 @@ import com.depromeet.domain.image.dto.response.PresignedUrlResponse;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.Profile;
-import com.depromeet.domain.mission.dao.MissionRepository;
-import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.domain.MissionCategory;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.mission.dto.request.MissionCreateRequest;
 import com.depromeet.domain.mission.dto.response.MissionCreateResponse;
 import com.depromeet.domain.mission.service.MissionService;
-import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
 import com.depromeet.domain.missionRecord.service.MissionRecordService;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
-import com.depromeet.global.util.MemberUtil;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
 class ImageServiceTest {
-	@Autowired private DatabaseCleaner databaseCleaner;
-	@Autowired private MemberRepository memberRepository;
-	@Autowired private ImageService imageService;
-	@Autowired private MissionRecordService missionRecordService;
-	@Autowired private MissionService missionService;
+    @Autowired private DatabaseCleaner databaseCleaner;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private ImageService imageService;
+    @Autowired private MissionRecordService missionRecordService;
+    @Autowired private MissionService missionService;
 
-	@BeforeEach
-	void setUp() {
-		databaseCleaner.execute();
-	}
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+    }
 
-	@Nested
-	class 미션_기록_이미지_PresignedUrl을_생성할_때 {
-		// TODO: MemberUtil insertMockMemberIfNotExist메서드 제거 후 주석해제 예
-		// @Test
-		// void 회원이_존재하지_않는다면_예외를_발생시킨다() {
-		// 	// given
-		// 	MissionRecordImageCreateRequest request =
-		// 		new MissionRecordImageCreateRequest(192L, ImageFileExtension.JPEG);
-		//
-		// 	// when, then
-		// 	assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
-		// 		.isInstanceOf(CustomException.class)
-		// 		.hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
-		// }
+    @Nested
+    class 미션_기록_이미지_PresignedUrl을_생성할_때 {
+        // TODO: MemberUtil insertMockMemberIfNotExist메서드 제거 후 주석해제 예
+        // @Test
+        // void 회원이_존재하지_않는다면_예외를_발생시킨다() {
+        // 	// given
+        // 	MissionRecordImageCreateRequest request =
+        // 		new MissionRecordImageCreateRequest(192L, ImageFileExtension.JPEG);
+        //
+        // 	// when, then
+        // 	assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
+        // 		.isInstanceOf(CustomException.class)
+        // 		.hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+        // }
 
-		@Test
-		void 미션이_존재하지_않는다면_예외를_발생시킨다() {
-			// given
-			memberRepository.save(Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
-			MissionRecordImageCreateRequest request =
-				new MissionRecordImageCreateRequest(192L, ImageFileExtension.JPEG);
+        @Test
+        void 미션이_존재하지_않는다면_예외를_발생시킨다() {
+            // given
+            memberRepository.save(
+                    Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
+            MissionRecordImageCreateRequest request =
+                    new MissionRecordImageCreateRequest(192L, ImageFileExtension.JPEG);
 
-			// when, then
-			assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
-					.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.MISSION_RECORD_NOT_FOUND.getMessage());
-		}
+            // when, then
+            assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.MISSION_RECORD_NOT_FOUND.getMessage());
+        }
 
-		@Test
-		void 입력_값이_정상이라면_예외가_발생하지_않는다() {
-			// given
-			memberRepository.save(Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
-			MissionCreateRequest missionCreateRequest =
-				new MissionCreateRequest(
-					"testMissionName",
-					"testMissionContent",
-					MissionCategory.STUDY,
-					MissionVisibility.ALL);
-			MissionCreateResponse missionCreateResponse = missionService.createMission(missionCreateRequest);
+        @Test
+        void 입력_값이_정상이라면_예외가_발생하지_않는다() {
+            // given
+            memberRepository.save(
+                    Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
+            MissionCreateRequest missionCreateRequest =
+                    new MissionCreateRequest(
+                            "testMissionName",
+                            "testMissionContent",
+                            MissionCategory.STUDY,
+                            MissionVisibility.ALL);
+            MissionCreateResponse missionCreateResponse =
+                    missionService.createMission(missionCreateRequest);
 
-			LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
-			LocalDateTime missionRecordFinishedAt =
-				missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-			MissionRecordCreateRequest missionRecordCreateRequest = new MissionRecordCreateRequest(
-				missionCreateResponse.missionId(),
-				missionRecordStartedAt,
-				missionRecordFinishedAt,
-				32,
-				14
-			);
-			Long missionRecord = missionRecordService.createMissionRecord(missionRecordCreateRequest);
-			MissionRecordImageCreateRequest request =
-				new MissionRecordImageCreateRequest(missionRecord, ImageFileExtension.JPEG);
+            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+            LocalDateTime missionRecordFinishedAt =
+                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+            MissionRecordCreateRequest missionRecordCreateRequest =
+                    new MissionRecordCreateRequest(
+                            missionCreateResponse.missionId(),
+                            missionRecordStartedAt,
+                            missionRecordFinishedAt,
+                            32,
+                            14);
+            Long missionRecord =
+                    missionRecordService.createMissionRecord(missionRecordCreateRequest);
+            MissionRecordImageCreateRequest request =
+                    new MissionRecordImageCreateRequest(missionRecord, ImageFileExtension.JPEG);
 
-			// when, then
-			assertThatCode(() -> imageService.createMissionRecordPresignedUrl(request))
-				.doesNotThrowAnyException();
-		}
+            // when, then
+            assertThatCode(() -> imageService.createMissionRecordPresignedUrl(request))
+                    .doesNotThrowAnyException();
+        }
 
-		@Test
-		void 입력_값이_정상이라면_PresignedUrl이_정상적으로_생성된다() {
-			// given
-			Member member = memberRepository.save(Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
-			MissionCreateRequest missionCreateRequest =
-				new MissionCreateRequest(
-					"testMissionName",
-					"testMissionContent",
-					MissionCategory.STUDY,
-					MissionVisibility.ALL);
-			MissionCreateResponse missionCreateResponse = missionService.createMission(missionCreateRequest);
+        @Test
+        void 입력_값이_정상이라면_PresignedUrl이_정상적으로_생성된다() {
+            // given
+            Member member =
+                    memberRepository.save(
+                            Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
+            MissionCreateRequest missionCreateRequest =
+                    new MissionCreateRequest(
+                            "testMissionName",
+                            "testMissionContent",
+                            MissionCategory.STUDY,
+                            MissionVisibility.ALL);
+            MissionCreateResponse missionCreateResponse =
+                    missionService.createMission(missionCreateRequest);
 
-			LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
-			LocalDateTime missionRecordFinishedAt =
-				missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-			MissionRecordCreateRequest missionRecordCreateRequest = new MissionRecordCreateRequest(
-				missionCreateResponse.missionId(),
-				missionRecordStartedAt,
-				missionRecordFinishedAt,
-				32,
-				14
-			);
-			Long missionRecordId = missionRecordService.createMissionRecord(missionRecordCreateRequest);
-			ImageFileExtension imageFileExtension = ImageFileExtension.JPEG;
-			MissionRecordImageCreateRequest request =
-				new MissionRecordImageCreateRequest(missionRecordId, imageFileExtension);
+            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+            LocalDateTime missionRecordFinishedAt =
+                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+            MissionRecordCreateRequest missionRecordCreateRequest =
+                    new MissionRecordCreateRequest(
+                            missionCreateResponse.missionId(),
+                            missionRecordStartedAt,
+                            missionRecordFinishedAt,
+                            32,
+                            14);
+            Long missionRecordId =
+                    missionRecordService.createMissionRecord(missionRecordCreateRequest);
+            ImageFileExtension imageFileExtension = ImageFileExtension.JPEG;
+            MissionRecordImageCreateRequest request =
+                    new MissionRecordImageCreateRequest(missionRecordId, imageFileExtension);
 
-			// when
-			PresignedUrlResponse missionRecordPresignedUrl = imageService.createMissionRecordPresignedUrl(request);
+            // when
+            PresignedUrlResponse missionRecordPresignedUrl =
+                    imageService.createMissionRecordPresignedUrl(request);
 
-			// then
-			assertThat(missionRecordPresignedUrl.presignedUrl())
-				.startsWith(String.format("https://kr.object.ncloudstorage.com/local/members/%s/mission_record/%s/image.jpeg", member.getId(), missionRecordId));
-		}
-	}
-
-
-
+            // then
+            assertThat(missionRecordPresignedUrl.presignedUrl())
+                    .startsWith(
+                            String.format(
+                                    "https://kr.object.ncloudstorage.com/local/members/%s/mission_record/%s/image.jpeg",
+                                    member.getId(), missionRecordId));
+        }
+    }
 }

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -143,8 +143,8 @@ class ImageServiceTest {
             assertThat(missionRecordPresignedUrl.presignedUrl())
                     .startsWith(
                             String.format(
-                                    "https://kr.object.ncloudstorage.com/local/members/%s/mission_record/%s/image.jpeg",
-                                    member.getId(), missionRecordId));
+                                    "https://kr.object.ncloudstorage.com/local/mission_record/%s/image.jpeg",
+                                    missionRecordId));
         }
     }
 }

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -17,6 +17,7 @@ import com.depromeet.domain.mission.dto.response.MissionCreateResponse;
 import com.depromeet.domain.mission.service.MissionService;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
 import com.depromeet.domain.missionRecord.service.MissionRecordService;
+import com.depromeet.global.config.security.PrincipalDetails;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import java.time.LocalDateTime;
@@ -25,6 +26,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
@@ -43,7 +47,7 @@ class ImageServiceTest {
 
     @Nested
     class 미션_기록_이미지_PresignedUrl을_생성할_때 {
-        // TODO: MemberUtil insertMockMemberIfNotExist메서드 제거 후 주석해제 예
+        // TODO: MemberUtil insertMockMemberIfNotExist메서드 제거 후 주석해제 예정
         // @Test
         // void 회원이_존재하지_않는다면_예외를_발생시킨다() {
         // 	// given
@@ -69,6 +73,50 @@ class ImageServiceTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.MISSION_RECORD_NOT_FOUND.getMessage());
         }
+
+//        TODO: SecurityUtil setMockAuthentication메서드 제거 후 주석해제 예정
+//        @Test
+//        void 미션을_생성한_유저와_로그인_유저가_일치하지_않는다면_예외를_발생시킨다() {
+//            // given
+//            memberRepository.save(
+//                    Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
+//            MissionCreateRequest missionCreateRequest =
+//                    new MissionCreateRequest(
+//                            "testMissionName",
+//                            "testMissionContent",
+//                            MissionCategory.STUDY,
+//                            MissionVisibility.ALL);
+//            MissionCreateResponse missionCreateResponse =
+//                    missionService.createMission(missionCreateRequest);
+//
+//            SecurityContextHolder.clearContext();
+//            PrincipalDetails principal = new PrincipalDetails(2L, "USER");
+//            Authentication authentication =
+//                    new UsernamePasswordAuthenticationToken(
+//                            principal, "password", principal.getAuthorities());
+//            SecurityContextHolder.getContext().setAuthentication(authentication);
+//
+//
+//            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+//            LocalDateTime missionRecordFinishedAt =
+//                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+//            MissionRecordCreateRequest missionRecordCreateRequest =
+//                    new MissionRecordCreateRequest(
+//                            missionCreateResponse.missionId(),
+//                            missionRecordStartedAt,
+//                            missionRecordFinishedAt,
+//                            32,
+//                            14);
+//            Long missionRecord =
+//                    missionRecordService.createMissionRecord(missionRecordCreateRequest);
+//            MissionRecordImageCreateRequest request =
+//                    new MissionRecordImageCreateRequest(missionRecord, ImageFileExtension.JPEG);
+//
+//            // when, then
+//            assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
+//                    .isInstanceOf(CustomException.class)
+//                    .hasMessage(ErrorCode.MISSION_RECORD_USER_MISMATCH.getMessage());
+//        }
 
         @Test
         void 입력_값이_정상이라면_예외가_발생하지_않는다() {

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -17,7 +17,6 @@ import com.depromeet.domain.mission.dto.response.MissionCreateResponse;
 import com.depromeet.domain.mission.service.MissionService;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
 import com.depromeet.domain.missionRecord.service.MissionRecordService;
-import com.depromeet.global.config.security.PrincipalDetails;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import java.time.LocalDateTime;
@@ -26,9 +25,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
@@ -74,49 +70,53 @@ class ImageServiceTest {
                     .hasMessage(ErrorCode.MISSION_RECORD_NOT_FOUND.getMessage());
         }
 
-//        TODO: SecurityUtil setMockAuthentication메서드 제거 후 주석해제 예정
-//        @Test
-//        void 미션을_생성한_유저와_로그인_유저가_일치하지_않는다면_예외를_발생시킨다() {
-//            // given
-//            memberRepository.save(
-//                    Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
-//            MissionCreateRequest missionCreateRequest =
-//                    new MissionCreateRequest(
-//                            "testMissionName",
-//                            "testMissionContent",
-//                            MissionCategory.STUDY,
-//                            MissionVisibility.ALL);
-//            MissionCreateResponse missionCreateResponse =
-//                    missionService.createMission(missionCreateRequest);
-//
-//            SecurityContextHolder.clearContext();
-//            PrincipalDetails principal = new PrincipalDetails(2L, "USER");
-//            Authentication authentication =
-//                    new UsernamePasswordAuthenticationToken(
-//                            principal, "password", principal.getAuthorities());
-//            SecurityContextHolder.getContext().setAuthentication(authentication);
-//
-//
-//            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
-//            LocalDateTime missionRecordFinishedAt =
-//                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-//            MissionRecordCreateRequest missionRecordCreateRequest =
-//                    new MissionRecordCreateRequest(
-//                            missionCreateResponse.missionId(),
-//                            missionRecordStartedAt,
-//                            missionRecordFinishedAt,
-//                            32,
-//                            14);
-//            Long missionRecord =
-//                    missionRecordService.createMissionRecord(missionRecordCreateRequest);
-//            MissionRecordImageCreateRequest request =
-//                    new MissionRecordImageCreateRequest(missionRecord, ImageFileExtension.JPEG);
-//
-//            // when, then
-//            assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
-//                    .isInstanceOf(CustomException.class)
-//                    .hasMessage(ErrorCode.MISSION_RECORD_USER_MISMATCH.getMessage());
-//        }
+        //        TODO: SecurityUtil setMockAuthentication메서드 제거 후 주석해제 예정
+        //        @Test
+        //        void 미션을_생성한_유저와_로그인_유저가_일치하지_않는다면_예외를_발생시킨다() {
+        //            // given
+        //            memberRepository.save(
+        //                    Member.createNormalMember(new Profile("testNickname",
+        // "testImageUrl")));
+        //            MissionCreateRequest missionCreateRequest =
+        //                    new MissionCreateRequest(
+        //                            "testMissionName",
+        //                            "testMissionContent",
+        //                            MissionCategory.STUDY,
+        //                            MissionVisibility.ALL);
+        //            MissionCreateResponse missionCreateResponse =
+        //                    missionService.createMission(missionCreateRequest);
+        //
+        //            SecurityContextHolder.clearContext();
+        //            PrincipalDetails principal = new PrincipalDetails(2L, "USER");
+        //            Authentication authentication =
+        //                    new UsernamePasswordAuthenticationToken(
+        //                            principal, "password", principal.getAuthorities());
+        //            SecurityContextHolder.getContext().setAuthentication(authentication);
+        //
+        //
+        //            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5,
+        // 0);
+        //            LocalDateTime missionRecordFinishedAt =
+        //                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+        //            MissionRecordCreateRequest missionRecordCreateRequest =
+        //                    new MissionRecordCreateRequest(
+        //                            missionCreateResponse.missionId(),
+        //                            missionRecordStartedAt,
+        //                            missionRecordFinishedAt,
+        //                            32,
+        //                            14);
+        //            Long missionRecord =
+        //                    missionRecordService.createMissionRecord(missionRecordCreateRequest);
+        //            MissionRecordImageCreateRequest request =
+        //                    new MissionRecordImageCreateRequest(missionRecord,
+        // ImageFileExtension.JPEG);
+        //
+        //            // when, then
+        //            assertThatThrownBy(() ->
+        // imageService.createMissionRecordPresignedUrl(request))
+        //                    .isInstanceOf(CustomException.class)
+        //                    .hasMessage(ErrorCode.MISSION_RECORD_USER_MISMATCH.getMessage());
+        //        }
 
         @Test
         void 입력_값이_정상이라면_예외가_발생하지_않는다() {

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -24,8 +24,6 @@ import com.depromeet.domain.missionRecord.service.MissionRecordService;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import java.time.LocalDateTime;
-import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -197,9 +195,7 @@ class ImageServiceTest {
             // then
             assertThat(missionRecordPresignedUrl.presignedUrl())
                     .contains(
-                            String.format(
-                                    "/local/mission_record/%s/image.jpeg",
-                                    missionRecordId));
+                            String.format("/local/mission_record/%s/image.jpeg", missionRecordId));
         }
     }
 
@@ -207,25 +203,27 @@ class ImageServiceTest {
     class 미션_기록_이미지_업로드_완료_처리할_때 {
 
         // TODO: MemberUtil insertMockMemberIfNotExist메서드 제거 후 주석해제 예정
-//         @Test
-//         void 회원이_존재하지_않는다면_예외를_발생시킨다() {
-//         	// given
-//             MissionRecordImageUploadCompleteRequest request =
-//         		new MissionRecordImageUploadCompleteRequest(192L, ImageFileExtension.JPEG, "testRemark");
-//
-//         	// when, then
-//         	assertThatThrownBy(() -> imageService.uploadCompleteMissionRecord(request))
-//         		.isInstanceOf(CustomException.class)
-//         		.hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
-//         }
+        //         @Test
+        //         void 회원이_존재하지_않는다면_예외를_발생시킨다() {
+        //         	// given
+        //             MissionRecordImageUploadCompleteRequest request =
+        //         		new MissionRecordImageUploadCompleteRequest(192L, ImageFileExtension.JPEG,
+        // "testRemark");
+        //
+        //         	// when, then
+        //         	assertThatThrownBy(() -> imageService.uploadCompleteMissionRecord(request))
+        //         		.isInstanceOf(CustomException.class)
+        //         		.hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+        //         }
 
         @Test
         void 미션이_존재하지_않는다면_예외를_발생시킨다() {
             // given
             memberRepository.save(
                     Member.createNormalMember(new Profile("testNickname", "testImageUrl")));
-             MissionRecordImageUploadCompleteRequest request =
-         		new MissionRecordImageUploadCompleteRequest(192L, ImageFileExtension.JPEG, "testRemark");
+            MissionRecordImageUploadCompleteRequest request =
+                    new MissionRecordImageUploadCompleteRequest(
+                            192L, ImageFileExtension.JPEG, "testRemark");
 
             // when, then
             assertThatThrownBy(() -> imageService.uploadCompleteMissionRecord(request))
@@ -258,7 +256,8 @@ class ImageServiceTest {
                             missionRecordFinishedAt,
                             32,
                             14);
-            Long missionRecordId = missionRecordService.createMissionRecord(missionRecordCreateRequest);
+            Long missionRecordId =
+                    missionRecordService.createMissionRecord(missionRecordCreateRequest);
 
             ImageFileExtension imageFileExtension = ImageFileExtension.JPEG;
             MissionRecordImageCreateRequest missionRecordImageCreateRequest =
@@ -266,7 +265,8 @@ class ImageServiceTest {
             imageService.createMissionRecordPresignedUrl(missionRecordImageCreateRequest);
 
             MissionRecordImageUploadCompleteRequest request =
-                    new MissionRecordImageUploadCompleteRequest(missionRecordId, imageFileExtension, "testRemark");
+                    new MissionRecordImageUploadCompleteRequest(
+                            missionRecordId, imageFileExtension, "testRemark");
 
             // when
             imageService.uploadCompleteMissionRecord(request);
@@ -277,10 +277,7 @@ class ImageServiceTest {
             assertThat(missionRecord.getRemark()).isEqualTo("testRemark");
             assertThat(missionRecord.getImageUrl())
                     .contains(
-                            String.format(
-                                    "/local/mission_record/%s/image.jpeg",
-                                    missionRecordId));
-
+                            String.format("/local/mission_record/%s/image.jpeg", missionRecordId));
         }
     }
 }

--- a/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
@@ -96,13 +96,12 @@ class MissionRecordTest {
 
                 // when, then
                 assertThatThrownBy(
-                        () ->
-                                missionRecord.updateUploadStatusComplete(
-                                        "testRemark", "testImageUrl"))
+                                () ->
+                                        missionRecord.updateUploadStatusComplete(
+                                                "testRemark", "testImageUrl"))
                         .isInstanceOf(CustomException.class)
                         .hasMessage(
-                                ErrorCode.MISSION_RECORD_UPLOAD_STATUS_IS_NOT_PENDING
-                                        .getMessage());
+                                ErrorCode.MISSION_RECORD_UPLOAD_STATUS_IS_NOT_PENDING.getMessage());
             }
         }
     }

--- a/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
@@ -53,52 +53,57 @@ class MissionRecordTest {
             assertEquals(ImageUploadStatus.NONE, uploadStatus);
         }
 
-        @Test
-        void 업로드_상태를_PENDING으로_변경할때_업로드_상태가_NONE이_아니라면_예외가_발생한다()
-                throws NoSuchFieldException, IllegalAccessException {
-            // given
-            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
-            LocalDateTime missionRecordFinishedAt =
-                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-            Duration duration = Duration.ofMinutes(32).plusSeconds(14);
-            MissionRecord missionRecord =
-                    MissionRecord.createMissionRecord(
-                            duration, missionRecordStartedAt, missionRecordFinishedAt, mission);
+        @Nested
+        class 미션기록의_이미지_업로드_상태를 {
+            @Test
+            void PENDING으로_변경할때_업로드_상태가_NONE이_아니라면_예외가_발생한다()
+                    throws NoSuchFieldException, IllegalAccessException {
+                // given
+                LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+                LocalDateTime missionRecordFinishedAt =
+                        missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+                Duration duration = Duration.ofMinutes(32).plusSeconds(14);
+                MissionRecord missionRecord =
+                        MissionRecord.createMissionRecord(
+                                duration, missionRecordStartedAt, missionRecordFinishedAt, mission);
 
-            Field uploadStatusField = MissionRecord.class.getDeclaredField("uploadStatus");
-            uploadStatusField.setAccessible(true);
-            uploadStatusField.set(missionRecord, ImageUploadStatus.PENDING);
+                Field uploadStatusField = MissionRecord.class.getDeclaredField("uploadStatus");
+                uploadStatusField.setAccessible(true);
+                uploadStatusField.set(missionRecord, ImageUploadStatus.PENDING);
 
-            // when, then
-            assertThatThrownBy(() -> missionRecord.updateUploadStatusPending())
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ErrorCode.MISSION_RECORD_UPLOAD_STATUS_IS_NOT_NONE.getMessage());
-        }
+                // when, then
+                assertThatThrownBy(() -> missionRecord.updateUploadStatusPending())
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                ErrorCode.MISSION_RECORD_UPLOAD_STATUS_IS_NOT_NONE.getMessage());
+            }
 
-        @Test
-        void 업로드_상태를_COMPLETE로_변경할때_업로드_상태가_이미_COMPLETE라면_예외가_발생한다()
-                throws NoSuchFieldException, IllegalAccessException {
-            // given
-            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
-            LocalDateTime missionRecordFinishedAt =
-                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-            Duration duration = Duration.ofMinutes(32).plusSeconds(14);
-            MissionRecord missionRecord =
-                    MissionRecord.createMissionRecord(
-                            duration, missionRecordStartedAt, missionRecordFinishedAt, mission);
+            @Test
+            void COMPLETE로_변경할때_업로드_상태가_PENDING상태가_아니라면_예외가_발생한다()
+                    throws NoSuchFieldException, IllegalAccessException {
+                // given
+                LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
+                LocalDateTime missionRecordFinishedAt =
+                        missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+                Duration duration = Duration.ofMinutes(32).plusSeconds(14);
+                MissionRecord missionRecord =
+                        MissionRecord.createMissionRecord(
+                                duration, missionRecordStartedAt, missionRecordFinishedAt, mission);
 
-            Field uploadStatusField = MissionRecord.class.getDeclaredField("uploadStatus");
-            uploadStatusField.setAccessible(true);
-            uploadStatusField.set(missionRecord, ImageUploadStatus.COMPLETE);
+                Field uploadStatusField = MissionRecord.class.getDeclaredField("uploadStatus");
+                uploadStatusField.setAccessible(true);
+                uploadStatusField.set(missionRecord, ImageUploadStatus.COMPLETE);
 
-            // when, then
-            assertThatThrownBy(
-                            () ->
-                                    missionRecord.updateUploadStatusComplete(
-                                            "testRemark", "testImageUrl"))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(
-                            ErrorCode.MISSION_RECORD_UPLOAD_STATUS_ALREADY_COMPLETED.getMessage());
+                // when, then
+                assertThatThrownBy(
+                        () ->
+                                missionRecord.updateUploadStatusComplete(
+                                        "testRemark", "testImageUrl"))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(
+                                ErrorCode.MISSION_RECORD_UPLOAD_STATUS_IS_NOT_PENDING
+                                        .getMessage());
+            }
         }
     }
 }

--- a/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
@@ -8,13 +8,11 @@ import com.depromeet.domain.member.domain.Profile;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.domain.MissionCategory;
 import com.depromeet.domain.mission.domain.MissionVisibility;
-
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.time.LocalDateTime;
-
-import com.depromeet.global.error.exception.CustomException;
-import com.depromeet.global.error.exception.ErrorCode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -56,7 +54,8 @@ class MissionRecordTest {
         }
 
         @Test
-        void 업로드_상태를_PENDING으로_변경할때_업로드_상태가_NONE이_아니라면_예외가_발생한다() throws NoSuchFieldException, IllegalAccessException {
+        void 업로드_상태를_PENDING으로_변경할때_업로드_상태가_NONE이_아니라면_예외가_발생한다()
+                throws NoSuchFieldException, IllegalAccessException {
             // given
             LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
             LocalDateTime missionRecordFinishedAt =
@@ -77,7 +76,8 @@ class MissionRecordTest {
         }
 
         @Test
-        void 업로드_상태를_COMPLETE로_변경할때_업로드_상태가_이미_COMPLETE라면_예외가_발생한다() throws NoSuchFieldException, IllegalAccessException {
+        void 업로드_상태를_COMPLETE로_변경할때_업로드_상태가_이미_COMPLETE라면_예외가_발생한다()
+                throws NoSuchFieldException, IllegalAccessException {
             // given
             LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5, 0);
             LocalDateTime missionRecordFinishedAt =


### PR DESCRIPTION
## 🌱 관련 이슈
- close #101 

## 📌 작업 내용 및 특이사항
- StorageConfig에서 기존 AWS SDK를 사용해 PresignedUrlRequest를 만들 때 endpoint가 AWS로 되어있어서 endpoint를 환경변수로 추가하고 NCP endpoint를 넣어주었습니다.
- PresignedUrl 생성 시 ExpireTime을 30초로 설정하였습니다
- 파일 디렉토리는 `/환경(ex:local, dev, prod)/ImageType(ex:mission_record)/{targetId}/image.{imageFileExtension(ex:jpeg, jpg, png)}`와 같습니다. 여기서 targetId는 ImageType에 따라 달라집니다.
(추 후 ImageType에 member_profile, member_background가 추가된다면 targetId는 memberId가 됩니다)
- PresignedUrl 생성 시 해당 미션 기록의 이미지 상태를 `PENDING` 상태로 변경
- PresignedUrl 업로드 완료 처리에서 미션 기록의 업데이트상태를 `COMPLETE`로 변경함과 동시에 미션 일지와 이미지를 업데이트합니다.
