### PR TITLE
feat: 미션 내역 리스트 조회

### DIFF
--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface MissionRepositoryCustom {
-    Optional<Mission> findByMissionId(Long missionId);
 
     Slice<Mission> findAllMission(Member member, Pageable pageable, Long lastId);
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
@@ -2,7 +2,6 @@ package com.depromeet.domain.mission.dao;
 
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.domain.Mission;
-import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -22,18 +22,6 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Optional<Mission> findByMissionId(Long missionId) {
-        Mission findMission =
-                jpaQueryFactory
-                        .selectFrom(mission)
-                        .leftJoin(mission.missionRecords, missionRecord)
-                        .fetchJoin()
-                        .where(mission.id.eq(missionId))
-                        .fetchOne();
-        return Optional.ofNullable(findMission);
-    }
-
-    @Override
     public Slice<Mission> findAllMission(Member member, Pageable pageable, Long lastId) {
         JPAQuery<Mission> query =
                 jpaQueryFactory

--- a/src/main/java/com/depromeet/domain/mission/service/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/service/MissionService.java
@@ -37,7 +37,7 @@ public class MissionService {
     public MissionFindResponse findOneMission(Long missionId) {
         Mission mission =
                 missionRepository
-                        .findByMissionId(missionId)
+                        .findById(missionId)
                         .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
         return MissionFindResponse.from(mission);
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -1,6 +1,9 @@
 package com.depromeet.domain.missionRecord.api;
 
+import java.util.List;
+
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
+import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindResponse;
 import com.depromeet.domain.missionRecord.service.MissionRecordService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -8,9 +11,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "[미션 기록]", description = "미션 기록 관련 API")
@@ -18,13 +23,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/records")
 @RequiredArgsConstructor
 public class MissionRecordController {
-    private final MissionRecordService missionRecordService;
+	private final MissionRecordService missionRecordService;
 
-    @Operation(summary = "미션 기록 생성", description = "미션 기록을 생성하고 생성 된 id를 반환합니다.")
-    @PostMapping
-    public ResponseEntity<Long> missionRecordCreate(
-            @Valid @RequestBody MissionRecordCreateRequest request) {
-        Long missionRecordId = missionRecordService.createMissionRecord(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(missionRecordId);
-    }
+	@Operation(summary = "미션 기록 생성", description = "미션 기록을 생성하고 생성 된 id를 반환합니다.")
+	@PostMapping
+	public ResponseEntity<Long> missionRecordCreate(
+		@Valid @RequestBody MissionRecordCreateRequest request) {
+		Long missionRecordId = missionRecordService.createMissionRecord(request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(missionRecordId);
+	}
+
+	/*
+	missionDay: 미션 생성 일자의 day 값
+	continuousDay: 연속된 일수는 미션 상세에서 처리함.
+	 */
+	@Operation(summary = "미션 기록 조회", description = "미션 기록을 조회합니다.")
+	@GetMapping
+	public List<MissionRecordFindResponse> missionRecordFind(
+		@RequestParam ("missionId") Long missionId,
+		@RequestParam("yearMonth") String yearMonth
+	) {
+		return missionRecordService.findAllMissionRecord(missionId, yearMonth);
+	}
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -6,6 +6,7 @@ import com.depromeet.domain.missionRecord.service.MissionRecordService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -36,7 +37,7 @@ public class MissionRecordController {
     @GetMapping
     public List<MissionRecordFindResponse> missionRecordFind(
             @RequestParam("missionId") Long missionId,
-            @RequestParam("yearMonth") String yearMonth) {
+            @RequestParam("yearMonth") YearMonth yearMonth) {
         return missionRecordService.findAllMissionRecord(missionId, yearMonth);
     }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -33,7 +33,7 @@ public class MissionRecordController {
         return ResponseEntity.status(HttpStatus.CREATED).body(missionRecordId);
     }
 
-    @Operation(summary = "미션 기록 조회", description = "미션 기록을 조회합니다.")
+    @Operation(summary = "미션 기록 조회 (캘린더 뷰)", description = "미션 기록을 조회합니다.")
     @GetMapping
     public List<MissionRecordFindResponse> missionRecordFind(
             @RequestParam("missionId") Long missionId,

--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -33,10 +33,6 @@ public class MissionRecordController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(missionRecordId);
 	}
 
-	/*
-	missionDay: 미션 생성 일자의 day 값
-	continuousDay: 연속된 일수는 미션 상세에서 처리함.
-	 */
 	@Operation(summary = "미션 기록 조회", description = "미션 기록을 조회합니다.")
 	@GetMapping
 	public List<MissionRecordFindResponse> missionRecordFind(

--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -1,13 +1,12 @@
 package com.depromeet.domain.missionRecord.api;
 
-import java.util.List;
-
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
 import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindResponse;
 import com.depromeet.domain.missionRecord.service.MissionRecordService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,22 +22,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/records")
 @RequiredArgsConstructor
 public class MissionRecordController {
-	private final MissionRecordService missionRecordService;
+    private final MissionRecordService missionRecordService;
 
-	@Operation(summary = "미션 기록 생성", description = "미션 기록을 생성하고 생성 된 id를 반환합니다.")
-	@PostMapping
-	public ResponseEntity<Long> missionRecordCreate(
-		@Valid @RequestBody MissionRecordCreateRequest request) {
-		Long missionRecordId = missionRecordService.createMissionRecord(request);
-		return ResponseEntity.status(HttpStatus.CREATED).body(missionRecordId);
-	}
+    @Operation(summary = "미션 기록 생성", description = "미션 기록을 생성하고 생성 된 id를 반환합니다.")
+    @PostMapping
+    public ResponseEntity<Long> missionRecordCreate(
+            @Valid @RequestBody MissionRecordCreateRequest request) {
+        Long missionRecordId = missionRecordService.createMissionRecord(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(missionRecordId);
+    }
 
-	@Operation(summary = "미션 기록 조회", description = "미션 기록을 조회합니다.")
-	@GetMapping
-	public List<MissionRecordFindResponse> missionRecordFind(
-		@RequestParam ("missionId") Long missionId,
-		@RequestParam("yearMonth") String yearMonth
-	) {
-		return missionRecordService.findAllMissionRecord(missionId, yearMonth);
-	}
+    @Operation(summary = "미션 기록 조회", description = "미션 기록을 조회합니다.")
+    @GetMapping
+    public List<MissionRecordFindResponse> missionRecordFind(
+            @RequestParam("missionId") Long missionId,
+            @RequestParam("yearMonth") String yearMonth) {
+        return missionRecordService.findAllMissionRecord(missionId, yearMonth);
+    }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepository.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepository.java
@@ -3,4 +3,4 @@ package com.depromeet.domain.missionRecord.dao;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MissionRecordRepository extends JpaRepository<MissionRecord, Long> {}
+public interface MissionRecordRepository extends JpaRepository<MissionRecord, Long>, MissionRecordRepositoryCustom {}

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepository.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepository.java
@@ -3,4 +3,5 @@ package com.depromeet.domain.missionRecord.dao;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MissionRecordRepository extends JpaRepository<MissionRecord, Long>, MissionRecordRepositoryCustom {}
+public interface MissionRecordRepository
+        extends JpaRepository<MissionRecord, Long>, MissionRecordRepositoryCustom {}

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.depromeet.domain.missionRecord.dao;
+
+import java.util.List;
+
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
+
+public interface MissionRecordRepositoryCustom {
+
+	List<MissionRecord> findAllByMissionId(Long missionId, String year, String month);
+}

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface MissionRecordRepositoryCustom {
 
-    List<MissionRecord> findAllByMissionId(Long missionId, YearMonth yearMonth);
+    List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth);
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.depromeet.domain.missionRecord.dao;
 
-import java.util.List;
-
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import java.time.YearMonth;
+import java.util.List;
 
 public interface MissionRecordRepositoryCustom {
 
-	List<MissionRecord> findAllByMissionId(Long missionId, String year, String month);
+    List<MissionRecord> findAllByMissionId(Long missionId, YearMonth yearMonth);
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.depromeet.domain.missionRecord.dao;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import static com.depromeet.domain.missionRecord.domain.QMissionRecord.*;
+
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<MissionRecord> findAllByMissionId(Long missionId, String year, String month) {
+		return jpaQueryFactory
+			.selectFrom(missionRecord)
+			.where(missionIdEq(missionId), yearEq(year), monthEq(month))
+			.fetch();
+	}
+
+	private BooleanExpression missionIdEq(Long missionId) {
+		return missionRecord.mission.id.eq(missionId);
+	}
+
+	private BooleanExpression yearEq(String year) {
+		return missionRecord.createdAt.year().stringValue().eq(year);
+	}
+
+	private BooleanExpression monthEq(String month) {
+		return missionRecord.createdAt.month().stringValue().eq(month);
+	}
+}

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -17,7 +17,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<MissionRecord> findAllByMissionId(Long missionId, YearMonth yearMonth) {
+    public List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth) {
         return jpaQueryFactory
                 .selectFrom(missionRecord)
                 .where(missionIdEq(missionId), yearMonthEq(yearMonth))

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -20,7 +20,10 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     public List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth) {
         return jpaQueryFactory
                 .selectFrom(missionRecord)
-                .where(missionIdEq(missionId), yearMonthEq(yearMonth))
+                .where(
+                        missionIdEq(missionId),
+                        yearEq(yearMonth.getYear()),
+                        monthEq(yearMonth.getMonthValue()))
                 .orderBy(missionRecord.startedAt.asc())
                 .fetch();
     }
@@ -29,10 +32,11 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
         return missionRecord.mission.id.eq(missionId);
     }
 
-    private BooleanExpression yearMonthEq(YearMonth yearMonth) {
-        return missionRecord
-                .createdAt
-                .yearMonth()
-                .eq(yearMonth.getYear() * 100 + yearMonth.getMonthValue());
+    private BooleanExpression yearEq(int year) {
+        return missionRecord.startedAt.year().eq(year);
+    }
+
+    private BooleanExpression monthEq(int month) {
+        return missionRecord.startedAt.month().eq(month);
     }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -1,40 +1,38 @@
 package com.depromeet.domain.missionRecord.dao;
 
-import java.util.List;
-
-import org.springframework.stereotype.Repository;
-
 import static com.depromeet.domain.missionRecord.domain.QMissionRecord.*;
 
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
+import java.time.YearMonth;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCustom {
 
-	private final JPAQueryFactory jpaQueryFactory;
+    private final JPAQueryFactory jpaQueryFactory;
 
-	@Override
-	public List<MissionRecord> findAllByMissionId(Long missionId, String year, String month) {
-		return jpaQueryFactory
-			.selectFrom(missionRecord)
-			.where(missionIdEq(missionId), yearEq(year), monthEq(month))
-			.fetch();
-	}
+    @Override
+    public List<MissionRecord> findAllByMissionId(Long missionId, YearMonth yearMonth) {
+        return jpaQueryFactory
+                .selectFrom(missionRecord)
+                .where(missionIdEq(missionId), yearMonthEq(yearMonth))
+                .orderBy(missionRecord.startedAt.asc())
+                .fetch();
+    }
 
-	private BooleanExpression missionIdEq(Long missionId) {
-		return missionRecord.mission.id.eq(missionId);
-	}
+    private BooleanExpression missionIdEq(Long missionId) {
+        return missionRecord.mission.id.eq(missionId);
+    }
 
-	private BooleanExpression yearEq(String year) {
-		return missionRecord.createdAt.year().stringValue().eq(year);
-	}
-
-	private BooleanExpression monthEq(String month) {
-		return missionRecord.createdAt.month().stringValue().eq(month);
-	}
+    private BooleanExpression yearMonthEq(YearMonth yearMonth) {
+        return missionRecord
+                .createdAt
+                .yearMonth()
+                .eq(yearMonth.getYear() * 100 + yearMonth.getMonthValue());
+    }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 
 public record MissionRecordFindResponse(
         Long missionRecordId,
-        String remart,
+        String remark,
         String imageUrl,
         int missionDay,
         LocalDateTime startedAt,

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
@@ -1,0 +1,28 @@
+package com.depromeet.domain.missionRecord.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
+
+public record MissionRecordFindResponse(
+
+	Long missionRecordId,
+	String remart,
+	String imageUrl,
+	int missionDay,
+	LocalDateTime startedAt,
+	LocalDateTime finishedAt,
+	LocalDateTime createdAt
+) {
+	public static MissionRecordFindResponse from(MissionRecord missionRecord) {
+		return new MissionRecordFindResponse(
+			missionRecord.getId(),
+			missionRecord.getRemark(),
+			missionRecord.getImageUrl(),
+			missionRecord.getCreatedAt().getDayOfMonth(),
+			missionRecord.getStartedAt(),
+			missionRecord.getFinishedAt(),
+			missionRecord.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
@@ -4,7 +4,7 @@ import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import java.time.LocalDateTime;
 
 public record MissionRecordFindResponse(
-        Long missionRecordId,
+        Long recordId,
         String remark,
         String imageUrl,
         int missionDay,

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
@@ -1,26 +1,22 @@
 package com.depromeet.domain.missionRecord.dto.response;
 
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import java.time.LocalDateTime;
 
-import com.depromeet.domain.missionRecord.domain.MissionRecord;
-
 public record MissionRecordFindResponse(
-
-	Long missionRecordId,
-	String remart,
-	String imageUrl,
-	int missionDay,
-	LocalDateTime startedAt,
-	LocalDateTime finishedAt
-) {
-	public static MissionRecordFindResponse from(MissionRecord missionRecord) {
-		return new MissionRecordFindResponse(
-			missionRecord.getId(),
-			missionRecord.getRemark(),
-			missionRecord.getImageUrl(),
-			missionRecord.getStartedAt().getDayOfMonth(),
-			missionRecord.getStartedAt(),
-			missionRecord.getFinishedAt()
-		);
-	}
+        Long missionRecordId,
+        String remart,
+        String imageUrl,
+        int missionDay,
+        LocalDateTime startedAt,
+        LocalDateTime finishedAt) {
+    public static MissionRecordFindResponse from(MissionRecord missionRecord) {
+        return new MissionRecordFindResponse(
+                missionRecord.getId(),
+                missionRecord.getRemark(),
+                missionRecord.getImageUrl(),
+                missionRecord.getStartedAt().getDayOfMonth(),
+                missionRecord.getStartedAt(),
+                missionRecord.getFinishedAt());
+    }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
@@ -11,18 +11,16 @@ public record MissionRecordFindResponse(
 	String imageUrl,
 	int missionDay,
 	LocalDateTime startedAt,
-	LocalDateTime finishedAt,
-	LocalDateTime createdAt
+	LocalDateTime finishedAt
 ) {
 	public static MissionRecordFindResponse from(MissionRecord missionRecord) {
 		return new MissionRecordFindResponse(
 			missionRecord.getId(),
 			missionRecord.getRemark(),
 			missionRecord.getImageUrl(),
-			missionRecord.getCreatedAt().getDayOfMonth(),
+			missionRecord.getStartedAt().getDayOfMonth(),
 			missionRecord.getStartedAt(),
-			missionRecord.getFinishedAt(),
-			missionRecord.getCreatedAt()
+			missionRecord.getFinishedAt()
 		);
 	}
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -76,8 +76,8 @@ public class MissionRecordService {
         try {
             // 파싱 가능한지 확인
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
-            LocalDate.parse(yearMonth + "-01", formatter);
-        } catch (DateTimeParseException e) {
+			YearMonth.parse(yearMonth, formatter);
+		} catch (DateTimeParseException e) {
             throw new CustomException(ErrorCode.MiSSION_RECORD_YEAR_MONTH_INVALID);
         }
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -11,7 +11,6 @@ import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -76,8 +75,8 @@ public class MissionRecordService {
         try {
             // 파싱 가능한지 확인
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
-			YearMonth.parse(yearMonth, formatter);
-		} catch (DateTimeParseException e) {
+            YearMonth.parse(yearMonth, formatter);
+        } catch (DateTimeParseException e) {
             throw new CustomException(ErrorCode.MiSSION_RECORD_YEAR_MONTH_INVALID);
         }
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -12,8 +12,6 @@ import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
 import java.time.Duration;
 import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -43,13 +41,10 @@ public class MissionRecordService {
         return missionRecordRepository.save(missionRecord).getId();
     }
 
-    public List<MissionRecordFindResponse> findAllMissionRecord(Long missionId, String yearMonth) {
-        // "yyyy-MM" 형식인지 검증
-        validateYearMonthFormat(yearMonth);
-        YearMonth yearMonthObj = YearMonth.parse(yearMonth);
-
+    public List<MissionRecordFindResponse> findAllMissionRecord(
+            Long missionId, YearMonth yearMonth) {
         List<MissionRecord> missionRecords =
-                missionRecordRepository.findAllByMissionId(missionId, yearMonthObj);
+                missionRecordRepository.findAllByMissionIdAndYearMonth(missionId, yearMonth);
         return missionRecords.stream().map(MissionRecordFindResponse::from).toList();
     }
 
@@ -68,16 +63,6 @@ public class MissionRecordService {
     private void validateMissionRecordDuration(Duration duration) {
         if (duration.getSeconds() > 3600L) {
             throw new CustomException(ErrorCode.MISSION_RECORD_DURATION_OVERBALANCE);
-        }
-    }
-
-    private void validateYearMonthFormat(String yearMonth) {
-        try {
-            // 파싱 가능한지 확인
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
-            YearMonth.parse(yearMonth, formatter);
-        } catch (DateTimeParseException e) {
-            throw new CustomException(ErrorCode.MiSSION_RECORD_YEAR_MONTH_INVALID);
         }
     }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -12,10 +12,10 @@ import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,18 +44,15 @@ public class MissionRecordService {
         return missionRecordRepository.save(missionRecord).getId();
     }
 
-	public List<MissionRecordFindResponse> findAllMissionRecord(Long missionId, String yearMonth) {
-		// "yyyy-MM" 형식인지 검증
-		validateYearMonthFormat(yearMonth);
+    public List<MissionRecordFindResponse> findAllMissionRecord(Long missionId, String yearMonth) {
+        // "yyyy-MM" 형식인지 검증
+        validateYearMonthFormat(yearMonth);
+        YearMonth yearMonthObj = YearMonth.parse(yearMonth);
 
-		// year와 month를 분리
-		String[] parts = yearMonth.split("-");
-		String year = parts[0];
-		String month = parts[1];
-
-		List<MissionRecord> missionRecords = missionRecordRepository.findAllByMissionId(missionId, year, month);
-		return missionRecords.stream().map(MissionRecordFindResponse::from).toList();
-	}
+        List<MissionRecord> missionRecords =
+                missionRecordRepository.findAllByMissionId(missionId, yearMonthObj);
+        return missionRecords.stream().map(MissionRecordFindResponse::from).toList();
+    }
 
     private Mission findMission(MissionRecordCreateRequest request) {
         return missionRepository
@@ -75,14 +72,13 @@ public class MissionRecordService {
         }
     }
 
-
-	private void validateYearMonthFormat(String yearMonth) {
-		try {
-			// 파싱 가능한지 확인
-			DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
-			LocalDate.parse(yearMonth + "-01", formatter);
-		} catch (DateTimeParseException e) {
-			throw new CustomException(ErrorCode.MiSSION_RECORD_YEAR_MONTH_INVALID);
-		}
-	}
+    private void validateYearMonthFormat(String yearMonth) {
+        try {
+            // 파싱 가능한지 확인
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+            LocalDate.parse(yearMonth + "-01", formatter);
+        } catch (DateTimeParseException e) {
+            throw new CustomException(ErrorCode.MiSSION_RECORD_YEAR_MONTH_INVALID);
+        }
+    }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -59,7 +59,7 @@ public class MissionRecordService {
 
     private Mission findMission(MissionRecordCreateRequest request) {
         return missionRepository
-                .findByMissionId(request.missionId())
+                .findById(request.missionId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
     }
 

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     // MissionRecord
     MISSION_RECORD_USER_MISMATCH(HttpStatus.BAD_REQUEST, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
     MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
+	MiSSION_RECORD_YEAR_MONTH_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 년월입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -28,7 +28,6 @@ public enum ErrorCode {
     // MissionRecord
     MISSION_RECORD_USER_MISMATCH(HttpStatus.BAD_REQUEST, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
     MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
-    MiSSION_RECORD_YEAR_MONTH_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 년월입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
     // MissionRecord
     MISSION_RECORD_USER_MISMATCH(HttpStatus.BAD_REQUEST, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
     MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
-	MiSSION_RECORD_YEAR_MONTH_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 년월입니다."),
+    MiSSION_RECORD_YEAR_MONTH_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 년월입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/depromeet/domain/mission/repository/MissionRepositoryTest.java
+++ b/src/test/java/com/depromeet/domain/mission/repository/MissionRepositoryTest.java
@@ -128,7 +128,7 @@ class MissionRepositoryTest {
                                 startedAt.plusWeeks(2),
                                 saveMember));
         // when
-        Optional<Mission> findMission = missionRepository.findByMissionId(saveMission.getId());
+        Optional<Mission> findMission = missionRepository.findById(saveMission.getId());
 
         // then
         assertThat(findMission).isPresent();


### PR DESCRIPTION
## 🌱 관련 이슈
- close #86 

## 📌 작업 내용 및 특이사항
- 캘린더 뷰에 사용할 미션 내역 리스트 조회 API 개발
- yearMonth로 년월 데이터 받아 처리
  - yearMonth를 한 번에 Querydsl로 처리하는 것으로 `year * 100 + month` 추가 연산이 포함되기에 불필요하므로 각각의 and 연산으로 처리
- 미션 내역 리스트 조회 엔드포인트에서 calendar 추가하는 방법은 추후 기획서에서 따로 list content를 받는 영역이 생길 시 `ex) /calendar, /list ` 형식으로 분리하는 방향으로 정의

## 📝 참고사항
- 

## 📚 기타
- 
