### PR TITLE
feat: 미션 내역 상세 조회 구현

### DIFF
--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.missionRecord.api;
 
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
+import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindOneResponse;
 import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindResponse;
 import com.depromeet.domain.missionRecord.service.MissionRecordService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,6 +33,12 @@ public class MissionRecordController {
             @Valid @RequestBody MissionRecordCreateRequest request) {
         Long missionRecordId = missionRecordService.createMissionRecord(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(missionRecordId);
+    }
+
+    @Operation(summary = "미션 기록 조회", description = "미션 기록을 조회합니다.")
+    @GetMapping("/{recordId}")
+    public MissionRecordFindOneResponse missionRecordFindOne(@PathVariable Long recordId) {
+        return missionRecordService.findOneMissionRecord(recordId);
     }
 
     @Operation(summary = "미션 기록 조회 (캘린더 뷰)", description = "미션 기록을 조회합니다.")

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/request/MissionRecordCreateRequest.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/request/MissionRecordCreateRequest.java
@@ -18,7 +18,7 @@ public record MissionRecordCreateRequest(
                         timezone = "Asia/Seoul")
                 @Schema(
                         description = "미션 기록 시작 시간",
-                        defaultValue = "2024-01-03 00:00:00",
+                        defaultValue = "2023-01-03 00:00:00",
                         type = "string")
                 LocalDateTime startedAt,
         @NotNull(message = "미션 기록 종료 시간은 비워둘 수 없습니다.")
@@ -28,7 +28,7 @@ public record MissionRecordCreateRequest(
                         timezone = "Asia/Seoul")
                 @Schema(
                         description = "미션 기록 종료 시간",
-                        defaultValue = "2023-01-03 00:34:00",
+                        defaultValue = "2024-01-03 00:34:00",
                         type = "string")
                 LocalDateTime finishedAt,
         @NotNull(message = "미션 참여 시간(분)은 비워둘 수 없습니다.")

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindOneResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindOneResponse.java
@@ -14,7 +14,7 @@ public record MissionRecordFindOneResponse(
                         description = "미션 기록 인증 사진 Url",
                         defaultValue = "https://ik.imagekit.io/demo/medium_cafe_B1iTdD0C.jpg")
                 String imageUrl,
-        @Schema(description = "미션 기록 수행 시간", defaultValue = "21") long duration,
+        @Schema(description = "미션 수행한 시간", defaultValue = "21") long duration,
         @Schema(description = "미션 시작한 지 N일차", defaultValue = "3") long sinceDay,
         @JsonFormat(
                         shape = JsonFormat.Shape.STRING,

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindOneResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindOneResponse.java
@@ -39,11 +39,8 @@ public record MissionRecordFindOneResponse(
                 missionRecord.getId(),
                 missionRecord.getRemark(),
                 missionRecord.getImageUrl(),
-                missionRecord.getDuration().getSeconds() / 60,
-                Duration.between(
-                                missionRecord.getStartedAt(),
-                                LocalDateTime.now())
-                        .toDays(),
+                missionRecord.getDuration().toMinutes(),
+                Duration.between(missionRecord.getStartedAt(), LocalDateTime.now()).toDays(),
                 missionRecord.getStartedAt(),
                 missionRecord.getFinishedAt());
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindOneResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindOneResponse.java
@@ -3,9 +3,10 @@ package com.depromeet.domain.missionRecord.dto.response;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Duration;
 import java.time.LocalDateTime;
 
-public record MissionRecordFindResponse(
+public record MissionRecordFindOneResponse(
         @Schema(description = "미션 기록 ID", defaultValue = "1") Long recordId,
         @Schema(description = "미션 기록 일지", defaultValue = "default MissionRecord Remark")
                 String remark,
@@ -13,7 +14,8 @@ public record MissionRecordFindResponse(
                         description = "미션 기록 인증 사진 Url",
                         defaultValue = "https://ik.imagekit.io/demo/medium_cafe_B1iTdD0C.jpg")
                 String imageUrl,
-        @Schema(description = "미션 시작 일자", defaultValue = "3") int missionDay,
+        @Schema(description = "미션 기록 수행 시간", defaultValue = "21") long duration,
+        @Schema(description = "미션 시작한 지 N일차", defaultValue = "3") long sinceDay,
         @JsonFormat(
                         shape = JsonFormat.Shape.STRING,
                         pattern = "yyyy-MM-dd HH:mm:ss",
@@ -32,12 +34,16 @@ public record MissionRecordFindResponse(
                         defaultValue = "2024-01-03 00:34:00",
                         type = "string")
                 LocalDateTime finishedAt) {
-    public static MissionRecordFindResponse from(MissionRecord missionRecord) {
-        return new MissionRecordFindResponse(
+    public static MissionRecordFindOneResponse from(MissionRecord missionRecord) {
+        return new MissionRecordFindOneResponse(
                 missionRecord.getId(),
                 missionRecord.getRemark(),
                 missionRecord.getImageUrl(),
-                missionRecord.getStartedAt().getDayOfMonth(),
+                missionRecord.getDuration().getSeconds() / 60,
+                Duration.between(
+                                missionRecord.getStartedAt(),
+                                LocalDateTime.now())
+                        .toDays(),
                 missionRecord.getStartedAt(),
                 missionRecord.getFinishedAt());
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -6,6 +6,7 @@ import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
+import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindOneResponse;
 import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindResponse;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
@@ -41,6 +42,16 @@ public class MissionRecordService {
         return missionRecordRepository.save(missionRecord).getId();
     }
 
+    @Transactional(readOnly = true)
+    public MissionRecordFindOneResponse findOneMissionRecord(Long recordId) {
+        MissionRecord missionRecord =
+                missionRecordRepository
+                        .findById(recordId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.MISSION_RECORD_NOT_FOUND));
+        return MissionRecordFindOneResponse.from(missionRecord);
+    }
+
+    @Transactional(readOnly = true)
     public List<MissionRecordFindResponse> findAllMissionRecord(
             Long missionId, YearMonth yearMonth) {
         List<MissionRecord> missionRecords =

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -27,7 +27,7 @@ public enum ErrorCode {
 
     // MissionRecord
     MISSION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션 기록을 찾을 수 없습니다."),
-    MISSION_RECORD_USER_MISMATCH(HttpStatus.BAD_REQUEST, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
+    MISSION_RECORD_USER_MISMATCH(HttpStatus.FORBIDDEN, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
     MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
     ;
 

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     MISSION_VISIBILITY_NULL(HttpStatus.BAD_REQUEST, "미션 공개 여부가 null입니다."),
 
     // MissionRecord
+    MISSION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션 기록을 찾을 수 없습니다."),
     MISSION_RECORD_USER_MISMATCH(HttpStatus.BAD_REQUEST, "미션을 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
     MISSION_RECORD_DURATION_OVERBALANCE(HttpStatus.BAD_REQUEST, "미션 참여 시간이 지정 된 시간보다 초과하였습니다"),
     ;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #110 

## 📌 작업 내용 및 특이사항
- 미션 내역 상세 조회 구현으로 findById로 구현
- 미션 수행한 시간(분)은 duration 값을 toMinutes()로 구현
- 미션 시작한 지 D+Day는 Duration의 between 메서드를 활용해 toDays()로 Day 값 return

## 📝 참고사항
- MissionRecordFindOneResponse로 단건 조회에 대한 DTO를 생성했습니다.
- 이전 미션 내역 조회 PR(#107) 에서 미처 구현하지 못한 사항도 수정했습니다

## 📚 기타
- 
