### PR TITLE
feat: 미션 기록 하루에 한개만 처리 가능하도록 기능 추가

### DIFF
--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -61,7 +61,7 @@ public class MissionRecordService {
     }
 
     private void validateMissionRecordExistsToday(Long missionId) {
-        if (missionRecordRepository.existsByMissionIdAndToday(missionId)) {
+        if (missionRecordRepository.isCompletedMissionExistsToday(missionId)) {
             throw new CustomException(ErrorCode.MISSION_RECORD_ALREADY_EXISTS_TODAY);
         }
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -43,6 +43,7 @@ public class MissionRecordService {
 
         validateMissionRecordUserMismatch(mission, member);
         validateMissionRecordDuration(duration);
+        validateMissionRecordExistsToday(mission.getId());
 
         MissionRecord missionRecord =
                 MissionRecord.createMissionRecord(
@@ -57,6 +58,12 @@ public class MissionRecordService {
                 MissionRecordTtl.createMissionRecordTtl(
                         createdMissionRecord.getId(), expirationTime, request.finishedAt()));
         return MissionRecordCreateResponse.from(createdMissionRecord.getId());
+    }
+
+    private void validateMissionRecordExistsToday(Long missionId) {
+        if (missionRecordRepository.existsByMissionIdAndToday(missionId)) {
+            throw new CustomException(ErrorCode.MISSION_RECORD_ALREADY_EXISTS_TODAY);
+        }
     }
 
     private Mission findMissionById(Long missionId) {

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -8,5 +8,5 @@ public interface MissionRecordRepositoryCustom {
 
     List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth);
 
-    boolean existsByMissionIdAndToday(Long missionId);
+    boolean isCompletedMissionExistsToday(Long missionId);
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface MissionRecordRepositoryCustom {
 
     List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth);
+
+    boolean existsByMissionIdAndToday(Long missionId);
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -5,6 +5,7 @@ import static com.depromeet.domain.missionRecord.domain.QMissionRecord.*;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,20 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
                 .fetch();
     }
 
+    @Override
+    public boolean existsByMissionIdAndToday(Long missionId) {
+        LocalDate now = LocalDate.now();
+        return jpaQueryFactory
+                        .selectFrom(missionRecord)
+                        .where(
+                                missionIdEq(missionId),
+                                yearEq(now.getYear()),
+                                monthEq(now.getMonthValue()),
+                                dayEq(now.getDayOfMonth()))
+                        .fetchFirst()
+                != null;
+    }
+
     private BooleanExpression missionIdEq(Long missionId) {
         return missionRecord.mission.id.eq(missionId);
     }
@@ -39,4 +54,12 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     private BooleanExpression monthEq(int month) {
         return missionRecord.startedAt.month().eq(month);
     }
+
+    private BooleanExpression dayEq(int day) {
+        return missionRecord.startedAt.dayOfMonth().eq(day);
+    }
+
+    //    private BooleanExpression startedAtEqNow(LocalDate localDate) {
+    //        return missionRecord.startedAt.da
+    //    }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -58,8 +58,4 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     private BooleanExpression dayEq(int day) {
         return missionRecord.startedAt.dayOfMonth().eq(day);
     }
-
-    //    private BooleanExpression startedAtEqNow(LocalDate localDate) {
-    //        return missionRecord.startedAt.da
-    //    }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -32,15 +32,16 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     @Override
     public boolean existsByMissionIdAndToday(Long missionId) {
         LocalDate now = LocalDate.now();
-        return jpaQueryFactory
+        MissionRecord missionRecordFetchOne =
+                jpaQueryFactory
                         .selectFrom(missionRecord)
                         .where(
                                 missionIdEq(missionId),
                                 yearEq(now.getYear()),
                                 monthEq(now.getMonthValue()),
                                 dayEq(now.getDayOfMonth()))
-                        .fetchFirst()
-                != null;
+                        .fetchFirst();
+        return missionRecordFetchOne != null;
     }
 
     private BooleanExpression missionIdEq(Long missionId) {

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -30,7 +30,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     }
 
     @Override
-    public boolean existsByMissionIdAndToday(Long missionId) {
+    public boolean isCompletedMissionExistsToday(Long missionId) {
         LocalDate now = LocalDate.now();
         MissionRecord missionRecordFetchOne =
                 jpaQueryFactory

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
             HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 NONE이 아닙니다."),
     MISSION_RECORD_UPLOAD_STATUS_IS_NOT_PENDING(
             HttpStatus.BAD_REQUEST, "미션 기록의 이미지 업로드 상태가 PENDING이 아닙니다."),
+    MISSION_RECORD_ALREADY_EXISTS_TODAY(HttpStatus.BAD_REQUEST, "오늘 이미 작성 된 미션 기록이 존재합니다."),
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #121 

## 📌 작업 내용 및 특이사항
- 기획 상 한개의 미션에 미션 기록은 하루에 한개만 가능하여 해당 기능을 추가합니다
- queryDsl에 dayEq 추가하였습니다.
- service 레이어 미션 일지 생성 메서드에서 validate 부분 추가하였습니다

## 📝 참고사항
- @sumi-0011와 배포시점 논의 후 협의되면 배포 진행할 예정 
