### PR TITLE
feat: 이미지 업로드 예외케이스에서 업로드 완료시 Redis TTL 삭제 기능

### DIFF
--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -13,7 +13,9 @@ import com.depromeet.domain.image.dto.response.PresignedUrlResponse;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
+import com.depromeet.domain.missionRecord.dao.MissionRecordTTLRepository;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.global.common.constants.RedisExpireEventConstants;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
@@ -33,6 +35,7 @@ public class ImageService {
     private final StorageProperties storageProperties;
     private final AmazonS3 amazonS3;
     private final MissionRecordRepository missionRecordRepository;
+    private final MissionRecordTTLRepository missionRecordTTLRepository;
 
     public PresignedUrlResponse createMissionRecordPresignedUrl(
             MissionRecordImageCreateRequest request) {
@@ -57,6 +60,9 @@ public class ImageService {
         String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
 
         missionRecord.updateUploadStatusPending();
+        missionRecordTTLRepository.deleteById(
+                RedisExpireEventConstants.EXPIRE_EVENT_IMAGE_UPLOAD_TIME_END.getValue()
+                        + request.missionRecordId());
         return PresignedUrlResponse.from(presignedUrl);
     }
 

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordTTLRepository.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordTTLRepository.java
@@ -3,4 +3,4 @@ package com.depromeet.domain.missionRecord.dao;
 import com.depromeet.domain.missionRecord.domain.MissionRecordTTL;
 import org.springframework.data.repository.CrudRepository;
 
-public interface MissionRecordTTLRepository extends CrudRepository<MissionRecordTTL, Long> {}
+public interface MissionRecordTTLRepository extends CrudRepository<MissionRecordTTL, String> {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #127 

## 📌 작업 내용 및 특이사항
- 이미지 업로드 예외케이스 처리 중 Redis에 TTL이 존재 시 '인증 필요' 대상이므로 이미지 업로드 후 Redis에 저장한 'MissionRecordTTL'을 삭제하여야 합니다.
- MissionRecordTTLRepository에 ID가 Long으로 설정되어있어 String으로 변경하였습니다😥
