### PR TITLE
refactor: 미션 기록 생성 응답 값 response 객체로 Wrapping

### DIFF
--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.missionRecord.api;
 
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
+import com.depromeet.domain.missionRecord.dto.response.MissionRecordCreateResponse;
 import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindOneResponse;
 import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindResponse;
 import com.depromeet.domain.missionRecord.service.MissionRecordService;
@@ -29,10 +30,10 @@ public class MissionRecordController {
 
     @Operation(summary = "미션 기록 생성", description = "미션 기록을 생성하고 생성 된 id를 반환합니다.")
     @PostMapping
-    public ResponseEntity<Long> missionRecordCreate(
+    public ResponseEntity<MissionRecordCreateResponse> missionRecordCreate(
             @Valid @RequestBody MissionRecordCreateRequest request) {
-        Long missionRecordId = missionRecordService.createMissionRecord(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(missionRecordId);
+        MissionRecordCreateResponse response = missionRecordService.createMissionRecord(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @Operation(summary = "미션 기록 조회", description = "미션 기록을 조회합니다.")

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordCreateResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordCreateResponse.java
@@ -1,0 +1,11 @@
+package com.depromeet.domain.missionRecord.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MissionRecordCreateResponse(
+        @Schema(description = "미션 기록 ID", defaultValue = "1") Long missionId) {
+
+    public static MissionRecordCreateResponse from(Long missionId) {
+        return new MissionRecordCreateResponse(missionId);
+    }
+}

--- a/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/service/MissionRecordService.java
@@ -8,6 +8,7 @@ import com.depromeet.domain.missionRecord.dao.MissionRecordTTLRepository;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.domain.missionRecord.domain.MissionRecordTTL;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
+import com.depromeet.domain.missionRecord.dto.response.MissionRecordCreateResponse;
 import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindOneResponse;
 import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindResponse;
 import com.depromeet.global.common.constants.RedisExpireEventConstants;
@@ -32,7 +33,7 @@ public class MissionRecordService {
     private final MissionRecordRepository missionRecordRepository;
     private final MissionRecordTTLRepository missionRecordTTLRepository;
 
-    public Long createMissionRecord(MissionRecordCreateRequest request) {
+    public MissionRecordCreateResponse createMissionRecord(MissionRecordCreateRequest request) {
         final Mission mission = findMissionById(request.missionId());
         final Member member = memberUtil.getCurrentMember();
 
@@ -56,7 +57,7 @@ public class MissionRecordService {
                         RedisExpireEventConstants.EXPIRE_EVENT_IMAGE_UPLOAD_TIME_END.getValue()
                                 + createdMissionRecord.getId(),
                         expirationTime));
-        return createdMissionRecord.getId();
+        return MissionRecordCreateResponse.from(createdMissionRecord.getId());
     }
 
     private Mission findMissionById(Long missionId) {

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -20,6 +20,7 @@ import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.domain.missionRecord.domain.ImageUploadStatus;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
+import com.depromeet.domain.missionRecord.dto.response.MissionRecordCreateResponse;
 import com.depromeet.domain.missionRecord.service.MissionRecordService;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
@@ -147,10 +148,12 @@ class ImageServiceTest {
                             missionRecordFinishedAt,
                             32,
                             14);
-            Long missionRecord =
+
+            MissionRecordCreateResponse missionRecordCreateResponse =
                     missionRecordService.createMissionRecord(missionRecordCreateRequest);
             MissionRecordImageCreateRequest request =
-                    new MissionRecordImageCreateRequest(missionRecord, ImageFileExtension.JPEG);
+                    new MissionRecordImageCreateRequest(
+                            missionRecordCreateResponse.missionId(), ImageFileExtension.JPEG);
 
             // when, then
             assertThatCode(() -> imageService.createMissionRecordPresignedUrl(request))
@@ -182,11 +185,12 @@ class ImageServiceTest {
                             missionRecordFinishedAt,
                             32,
                             14);
-            Long missionRecordId =
+            MissionRecordCreateResponse missionRecordCreateResponse =
                     missionRecordService.createMissionRecord(missionRecordCreateRequest);
             ImageFileExtension imageFileExtension = ImageFileExtension.JPEG;
             MissionRecordImageCreateRequest request =
-                    new MissionRecordImageCreateRequest(missionRecordId, imageFileExtension);
+                    new MissionRecordImageCreateRequest(
+                            missionRecordCreateResponse.missionId(), imageFileExtension);
 
             // when
             PresignedUrlResponse missionRecordPresignedUrl =
@@ -195,7 +199,9 @@ class ImageServiceTest {
             // then
             assertThat(missionRecordPresignedUrl.presignedUrl())
                     .contains(
-                            String.format("/local/mission_record/%s/image.jpeg", missionRecordId));
+                            String.format(
+                                    "/local/mission_record/%s/image.jpeg",
+                                    missionRecordCreateResponse.missionId()));
         }
     }
 
@@ -256,28 +262,34 @@ class ImageServiceTest {
                             missionRecordFinishedAt,
                             32,
                             14);
-            Long missionRecordId =
+            MissionRecordCreateResponse missionRecordCreateResponse =
                     missionRecordService.createMissionRecord(missionRecordCreateRequest);
 
             ImageFileExtension imageFileExtension = ImageFileExtension.JPEG;
             MissionRecordImageCreateRequest missionRecordImageCreateRequest =
-                    new MissionRecordImageCreateRequest(missionRecordId, imageFileExtension);
+                    new MissionRecordImageCreateRequest(
+                            missionRecordCreateResponse.missionId(), imageFileExtension);
             imageService.createMissionRecordPresignedUrl(missionRecordImageCreateRequest);
 
             MissionRecordImageUploadCompleteRequest request =
                     new MissionRecordImageUploadCompleteRequest(
-                            missionRecordId, imageFileExtension, "testRemark");
+                            missionRecordCreateResponse.missionId(),
+                            imageFileExtension,
+                            "testRemark");
 
             // when
             imageService.uploadCompleteMissionRecord(request);
-            MissionRecord missionRecord = missionRecordRepository.findById(missionRecordId).get();
+            MissionRecord missionRecord =
+                    missionRecordRepository.findById(missionRecordCreateResponse.missionId()).get();
 
             // then
             assertThat(missionRecord.getUploadStatus()).isEqualTo(ImageUploadStatus.COMPLETE);
             assertThat(missionRecord.getRemark()).isEqualTo("testRemark");
             assertThat(missionRecord.getImageUrl())
                     .contains(
-                            String.format("/local/mission_record/%s/image.jpeg", missionRecordId));
+                            String.format(
+                                    "/local/mission_record/%s/image.jpeg",
+                                    missionRecordCreateResponse.missionId()));
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #129

## 📌 작업 내용 및 특이사항
- 미션 기록 생성 POST /records의 응답 값이 현재 Long으로 되어있는데, 응답 값을 Response 객체로 Wrapping
- 프론트 담당자 @sumi-0011 와 협의 완료
