### PR TITLE
chore: 서버 포트를 환경변수로 받도록 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,9 @@ spring:
       dev: "dev, datasource, redis, storage, actuator"
       prod: "prod, datasource, redis, storage, actuator"
 
+server:
+  port: ${SERVER_PORT:8080}
+
 swagger:
   version: 0.0.1
   user: ${SWAGGER_USER:default}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #133 

## 📌 작업 내용 및 특이사항
- 각 서버의 `.env`에 `SERVER_PORT`를 추가하면 됨
- 개발서버 -> 8081, 상용서버 -> 8080으로 설정

## 📝 참고사항
- 

## 📚 기타
- 
