### PR TITLE
hotfix: CORS문제로 UrlConstants에 www 추가

### DIFF
--- a/src/main/java/com/depromeet/global/common/constants/UrlConstants.java
+++ b/src/main/java/com/depromeet/global/common/constants/UrlConstants.java
@@ -10,8 +10,8 @@ public enum UrlConstants {
     DEV_SERVER_URL("https://dev-api.10mm.today"),
     LOCAL_SERVER_URL("http://localhost:8080"),
 
-    PROD_DOMAIN_URL("https://10mm.today"),
-    DEV_DOMAIN_URL("https://dev.10mm.today"),
+    PROD_DOMAIN_URL("https://www.10mm.today"),
+    DEV_DOMAIN_URL("https://www.dev.10mm.today"),
     LOCAL_DOMAIN_URL("http://localhost:3000"),
     ;
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #137 

## 📌 작업 내용 및 특이사항
- 브라우저 기본 접속 시 www가 추가되어 cors 허용이 안되고 있어 UrlConstants에 www를 추가해주었습니다.
- SERVER_URL은 www가 안붙어서 추가해주지 않았어용
