### PR TITLE
feat: Swagger에 RefresgToekn용 SecuritySchemes 추가

### DIFF
--- a/src/main/java/com/depromeet/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/global/config/swagger/SwaggerConfig.java
@@ -60,13 +60,21 @@ public class SwaggerConfig {
     private Components authSetting() {
         return new Components()
                 .addSecuritySchemes(
-                        "bearer auth",
+                        "accessToken",
                         new SecurityScheme()
                                 .type(Type.HTTP)
                                 .scheme("bearer")
                                 .bearerFormat("JWT")
                                 .in(In.HEADER)
-                                .name("Authorization Token"));
+                                .name("Authorization"))
+                .addSecuritySchemes(
+                        "refreshToken",
+                        new SecurityScheme()
+                                .type(Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(In.HEADER)
+                                .name("Refresh-Token"));
     }
 
     private Info swaggerInfo() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #146 

## 📌 작업 내용 및 특이사항
- 현재 Swagger에 SecuritySchemes는 accessToken을 넣을 수 있는 Authorization헤더만 존재하는데, refresToken을 넣을 수 있는Refresh-Token헤더 스키마 추가