### PR TITLE
fix: 유틸리티에서 픽스처 및 Mock 인증 삽입 로직 제거

### DIFF
--- a/src/main/java/com/depromeet/global/util/MemberUtil.java
+++ b/src/main/java/com/depromeet/global/util/MemberUtil.java
@@ -2,7 +2,6 @@ package com.depromeet.global.util;
 
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
-import com.depromeet.domain.member.domain.Profile;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -15,20 +14,7 @@ public class MemberUtil {
     private final SecurityUtil securityUtil;
     private final MemberRepository memberRepository;
 
-    // TODO: 데이터베이스 연동 및 픽스쳐 데이터 삽입 이후 삭제
-    private void insertMockMemberIfNotExist() {
-        if (memberRepository.count() != 0) {
-            return;
-        }
-
-        Member memeber = Member.createNormalMember(new Profile("testNickname", "testImageUrl"));
-
-        memberRepository.save(memeber);
-    }
-
     public Member getCurrentMember() {
-        insertMockMemberIfNotExist();
-
         return memberRepository
                 .findById(securityUtil.getCurrentMemberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/depromeet/global/util/SecurityUtil.java
+++ b/src/main/java/com/depromeet/global/util/SecurityUtil.java
@@ -1,24 +1,13 @@
 package com.depromeet.global.util;
 
 import com.depromeet.global.security.PrincipalDetails;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SecurityUtil {
 
-    private void setMockAuthentication() {
-        PrincipalDetails principal = new PrincipalDetails(1L, "USER");
-        Authentication authentication =
-                new UsernamePasswordAuthenticationToken(
-                        principal, "password", principal.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
-
     public Long getCurrentMemberId() {
-        setMockAuthentication();
         PrincipalDetails principal =
                 (PrincipalDetails)
                         SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -23,12 +23,16 @@ import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest
 import com.depromeet.domain.missionRecord.dto.response.MissionRecordCreateResponse;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
+import com.depromeet.global.security.PrincipalDetails;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
@@ -44,6 +48,11 @@ class ImageServiceTest {
     @BeforeEach
     void setUp() {
         databaseCleaner.execute();
+        PrincipalDetails principal = new PrincipalDetails(1L, "USER");
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                        principal, "password", principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     @Nested

--- a/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.depromeet.DatabaseCleaner;
+import com.depromeet.domain.member.dao.MemberRepository;
+import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.application.MissionService;
 import com.depromeet.domain.mission.dao.MissionRepository;
 import com.depromeet.domain.mission.domain.Mission;
@@ -15,6 +17,7 @@ import com.depromeet.domain.mission.dto.response.MissionCreateResponse;
 import com.depromeet.domain.mission.dto.response.MissionFindAllResponse;
 import com.depromeet.domain.mission.dto.response.MissionFindResponse;
 import com.depromeet.domain.mission.dto.response.MissionUpdateResponse;
+import com.depromeet.global.security.PrincipalDetails;
 import com.depromeet.global.util.MemberUtil;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
@@ -25,6 +28,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +40,7 @@ class MissionServiceTest {
 
     @Autowired private MissionService missionService;
     @Autowired private MissionRepository missionRepository;
+    @Autowired private MemberRepository memberRepository;
     @Autowired private DatabaseCleaner databaseCleaner;
     @Autowired private EntityManager entityManager;
     @Autowired private MemberUtil memberUtil;
@@ -41,7 +48,13 @@ class MissionServiceTest {
     @BeforeEach
     void setUp() {
         databaseCleaner.execute();
-        missionRepository.deleteAll();
+        PrincipalDetails principal = new PrincipalDetails(1L, "USER");
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                        principal, "password", principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        Member guestMember = Member.createGuestMember("username", "password");
+        memberRepository.save(guestMember);
     }
 
     @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #147 

## 📌 작업 내용 및 특이사항
- Service 테스트 코드에서 Principal이 null 값인 문제
  - principal 객체로 setAuthentication를 하여 설정 후 principal 객체를 읽을 수 있도록 한다.

## 📝 참고사항
- 

## 📚 기타
- 
