### PR TITLE
fix: SpringBoot Server TimeZone Asia/Seoul로 설정

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
     image: ${NCP_CONTAINER_REGISTRY}/server-spring:${NCP_IMAGE_TAG}
     container_name: server-spring
     restart: always
+    environment:
+      - TZ=Asia/Seoul
     network_mode: host
     env_file:
       - .env


### PR DESCRIPTION
## 🌱 관련 이슈
- close #156 

## 📌 작업 내용 및 특이사항
|**서버 인스턴스**|**docker에 올라간 SpringBoot Server**|
|---|---|
|<img src="https://github.com/depromeet/10mm-server/assets/64088250/ed23d1ba-4dd9-4549-8363-20822b47be44" width="600"/>|<img src="https://github.com/depromeet/10mm-server/assets/64088250/41b6fd1e-5f39-4352-a988-e31bf89d1293" width="600"/>|
- 현재 서버 인스턴스는 Asia/Seoul로 설정되어있으나, docker에 띄워진 SpringBoot Server에 TimeZone이 UTC로 되어있어,
Docker environment로 Timezone값을 Asia/Seoul로 설정해주었습니다.
