### PR TITLE
fix: 진행중인 미션기록 삭제할 때 QueryDsl 메소드 사용하도록 변경

### DIFF
--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -109,7 +109,7 @@ public class MissionRecordService {
     }
 
     public void deleteInProgressMissionRecord() {
-        final Member currentMember = memberUtil.getCurrentMember();
+        Member currentMember = memberUtil.getCurrentMember();
         final LocalDate today = LocalDate.now();
 
         List<Mission> missions = missionRepository.findMissionsWithRecords(currentMember.getId());
@@ -138,7 +138,7 @@ public class MissionRecordService {
 
             if (missionRecordTTL.isPresent()) {
                 missionRecordTtlRepository.deleteById(optionalRecord.get().getId());
-                missionRecordRepository.deleteById(optionalRecord.get().getId());
+                missionRecordRepository.deleteByMissionRecordId(optionalRecord.get().getId());
             }
         }
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -109,7 +109,7 @@ public class MissionRecordService {
     }
 
     public void deleteInProgressMissionRecord() {
-        Member currentMember = memberUtil.getCurrentMember();
+        final Member currentMember = memberUtil.getCurrentMember();
         final LocalDate today = LocalDate.now();
 
         List<Mission> missions = missionRepository.findMissionsWithRecords(currentMember.getId());

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface MissionRecordRepositoryCustom {
     List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth);
 
     boolean isCompletedMissionExistsToday(Long missionId);
+
+    void deleteByMissionRecordId(Long missionRecordId);
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -44,6 +44,11 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
         return missionRecordFetchOne != null;
     }
 
+    @Override
+    public void deleteByMissionRecordId(Long missionRecordId) {
+        jpaQueryFactory.delete(missionRecord).where(missionRecord.id.eq(missionRecordId)).execute();
+    }
+
     private BooleanExpression missionIdEq(Long missionId) {
         return missionRecord.mission.id.eq(missionId);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #161 

## 📌 작업 내용 및 특이사항
- `DELETE /records/in-progress` 이미 진행중인 미션 기록들 삭제 API에서 Redis에 있는 MissionRecordTtl은 정상적으로 삭제되나, DB에 저장되어있는 MissionRecord가 삭제되지 않는 이슈가 있습니다.
- MissionRecordRepository가 DI 될 때, MissionRecordRepositoryImple이 주입되어 발생하는 문제였습니다.
- MissionRecordRepositoryImpl에 `deleteByMissionId` 메소드 생성하여 처리
