### PR TITLE
fix: 회원 정보 수정할 때 이미지 nullable 처리

### DIFF
--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -102,12 +102,14 @@ public class ImageService {
 
     public void uploadCompleteMemberProfile(MemberProfileImageUploadCompleteRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
-
-        String imageUrl =
-                createImageUrl(
-                        ImageType.MEMBER_PROFILE,
-                        currentMember.getId(),
-                        request.imageFileExtension());
+        String imageUrl = null;
+        if (request.imageFileExtension() != null) {
+            imageUrl =
+                    createImageUrl(
+                            ImageType.MEMBER_PROFILE,
+                            currentMember.getId(),
+                            request.imageFileExtension());
+        }
         currentMember.updateProfile(Profile.createProfile(request.nickname(), imageUrl));
     }
 

--- a/src/main/java/com/depromeet/domain/image/dto/request/MemberProfileImageUploadCompleteRequest.java
+++ b/src/main/java/com/depromeet/domain/image/dto/request/MemberProfileImageUploadCompleteRequest.java
@@ -7,5 +7,5 @@ import jakarta.validation.constraints.NotNull;
 public record MemberProfileImageUploadCompleteRequest(
         @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension,
-        @NotNull(message = "닉네임은 비워둘 수 없습니다.")
-        @Schema(description = "닉네임", defaultValue = "당근조이") String nickname) {}
+        @NotNull(message = "닉네임은 비워둘 수 없습니다.") @Schema(description = "닉네임", defaultValue = "당근조이")
+                String nickname) {}

--- a/src/main/java/com/depromeet/domain/image/dto/request/MemberProfileImageUploadCompleteRequest.java
+++ b/src/main/java/com/depromeet/domain/image/dto/request/MemberProfileImageUploadCompleteRequest.java
@@ -2,8 +2,10 @@ package com.depromeet.domain.image.dto.request;
 
 import com.depromeet.domain.image.domain.ImageFileExtension;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 public record MemberProfileImageUploadCompleteRequest(
         @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension,
+        @NotNull(message = "닉네임은 비워둘 수 없습니다.")
         @Schema(description = "닉네임", defaultValue = "당근조이") String nickname) {}

--- a/src/main/java/com/depromeet/domain/image/dto/request/MemberProfileImageUploadCompleteRequest.java
+++ b/src/main/java/com/depromeet/domain/image/dto/request/MemberProfileImageUploadCompleteRequest.java
@@ -2,10 +2,8 @@ package com.depromeet.domain.image.dto.request;
 
 import com.depromeet.domain.image.domain.ImageFileExtension;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record MemberProfileImageUploadCompleteRequest(
-        @NotNull(message = "이미지 파일의 확장자는 비워둘 수 없습니다.")
-                @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
+        @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension,
         @Schema(description = "닉네임", defaultValue = "당근조이") String nickname) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #165 

## 📌 작업 내용 및 특이사항
- 회원 가입 후 이미지가 null 인 상태에서 이미지 변경을 하지 않았을 경우 null로 넘어오기에 nullable 처리합니다.
- 닉네임은 항상 값이 존재해야 하기 때문에 NotNull 추가