### PR TITLE
feat: 미션 목록 조회 시 인증필요인 경우 MissionRecordId도 같이 응답

### DIFF
--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -64,13 +64,13 @@ public class MissionService {
 
             // 당일 수행한 미션기록이 없으면 NONE
             if (optionalRecord.isEmpty()) {
-                results.add(MissionFindAllResponse.of(mission, MissionStatus.NONE, null));
+                results.add(MissionFindAllResponse.of(mission, MissionStatus.NONE, null, null));
                 continue;
             }
 
             // 당일 수행한 미션기록의 인증사진이 존재하면 COMPLETE
             if (optionalRecord.get().getUploadStatus() == ImageUploadStatus.COMPLETE) {
-                results.add(MissionFindAllResponse.of(mission, MissionStatus.COMPLETED, null));
+                results.add(MissionFindAllResponse.of(mission, MissionStatus.COMPLETED, null, null));
                 continue;
             }
 
@@ -83,7 +83,8 @@ public class MissionService {
                         MissionFindAllResponse.of(
                                 mission,
                                 MissionStatus.REQUIRED,
-                                missionRecordTTL.get().getTtlFinishedAt()));
+                                missionRecordTTL.get().getTtlFinishedAt(),
+                                optionalRecord.get().getId()));
                 continue;
             }
 

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -70,7 +70,8 @@ public class MissionService {
 
             // 당일 수행한 미션기록의 인증사진이 존재하면 COMPLETE
             if (optionalRecord.get().getUploadStatus() == ImageUploadStatus.COMPLETE) {
-                results.add(MissionFindAllResponse.of(mission, MissionStatus.COMPLETED, null, null));
+                results.add(
+                        MissionFindAllResponse.of(mission, MissionStatus.COMPLETED, null, null));
                 continue;
             }
 

--- a/src/main/java/com/depromeet/domain/mission/dto/response/MissionFindAllResponse.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/response/MissionFindAllResponse.java
@@ -17,11 +17,13 @@ public record MissionFindAllResponse(
         @Schema(description = "미션 정렬 값", defaultValue = "1") Integer sort,
         @Schema(description = "미션 상태", defaultValue = "1") MissionStatus missionStatus,
         @Schema(description = "인증 TTL 종료 시간", defaultValue = "NONE") LocalDateTime ttlFinishedAt,
-        @Schema(description = "인증필요인경우 recordId", defaultValue = "1") Long missionRecordId)
-{
+        @Schema(description = "인증필요인경우 recordId", defaultValue = "1") Long missionRecordId) {
 
     public static MissionFindAllResponse of(
-            Mission mission, MissionStatus missionStatus, LocalDateTime ttlFinishedAt, Long missionRecordId) {
+            Mission mission,
+            MissionStatus missionStatus,
+            LocalDateTime ttlFinishedAt,
+            Long missionRecordId) {
         return new MissionFindAllResponse(
                 mission.getId(),
                 mission.getName(),
@@ -32,7 +34,6 @@ public record MissionFindAllResponse(
                 mission.getSort(),
                 missionStatus,
                 ttlFinishedAt,
-                missionRecordId
-                );
+                missionRecordId);
     }
 }

--- a/src/main/java/com/depromeet/domain/mission/dto/response/MissionFindAllResponse.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/response/MissionFindAllResponse.java
@@ -16,10 +16,12 @@ public record MissionFindAllResponse(
         @Schema(description = "미션 아카이빙 상태", defaultValue = "NONE") ArchiveStatus archiveStatus,
         @Schema(description = "미션 정렬 값", defaultValue = "1") Integer sort,
         @Schema(description = "미션 상태", defaultValue = "1") MissionStatus missionStatus,
-        @Schema(description = "인증 TTL 종료 시간", defaultValue = "NONE") LocalDateTime ttlFinishedAt) {
+        @Schema(description = "인증 TTL 종료 시간", defaultValue = "NONE") LocalDateTime ttlFinishedAt,
+        @Schema(description = "인증필요인경우 recordId", defaultValue = "1") Long missionRecordId)
+{
 
     public static MissionFindAllResponse of(
-            Mission mission, MissionStatus missionStatus, LocalDateTime ttlFinishedAt) {
+            Mission mission, MissionStatus missionStatus, LocalDateTime ttlFinishedAt, Long missionRecordId) {
         return new MissionFindAllResponse(
                 mission.getId(),
                 mission.getName(),
@@ -29,6 +31,8 @@ public record MissionFindAllResponse(
                 mission.getArchiveStatus(),
                 mission.getSort(),
                 missionStatus,
-                ttlFinishedAt);
+                ttlFinishedAt,
+                missionRecordId
+                );
     }
 }

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -161,9 +161,9 @@ class MissionControllerTest {
 
         List<MissionFindAllResponse> missionList =
                 Arrays.asList(
-                        MissionFindAllResponse.of(mission, MissionStatus.NONE, ttlFinishedAt),
-                        MissionFindAllResponse.of(mission, MissionStatus.COMPLETED, ttlFinishedAt),
-                        MissionFindAllResponse.of(mission, MissionStatus.REQUIRED, ttlFinishedAt));
+                        MissionFindAllResponse.of(mission, MissionStatus.NONE, null, null),
+                        MissionFindAllResponse.of(mission, MissionStatus.COMPLETED, null, null),
+                        MissionFindAllResponse.of(mission, MissionStatus.REQUIRED, ttlFinishedAt, null));
         given(missionService.findAllMission()).willReturn(missionList);
 
         // when, then

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -163,7 +163,8 @@ class MissionControllerTest {
                 Arrays.asList(
                         MissionFindAllResponse.of(mission, MissionStatus.NONE, null, null),
                         MissionFindAllResponse.of(mission, MissionStatus.COMPLETED, null, null),
-                        MissionFindAllResponse.of(mission, MissionStatus.REQUIRED, ttlFinishedAt, null));
+                        MissionFindAllResponse.of(
+                                mission, MissionStatus.REQUIRED, ttlFinishedAt, null));
         given(missionService.findAllMission()).willReturn(missionList);
 
         // when, then


### PR DESCRIPTION
## 🌱 관련 이슈
- close #167 

## 📌 작업 내용 및 특이사항
- 인증 필요인 미션의 경우 클릭 했을 때 해당 미션을 완료(이미지업로드와 일지작성)하는 화면으로 넘어가는데, 이 때 MissionRecordId도 필요하여 응답객체에 필드 추가