### PR TITLE
refactor: 미션기록 삭제 시 `deleteById` 쿼리가 작동하지 않는 문제 개선

### DIFF
--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -17,19 +17,15 @@ import com.depromeet.domain.missionRecord.dto.response.MissionRecordUpdateRespon
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
-
 import jakarta.persistence.EntityManager;
-
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -17,14 +17,19 @@ import com.depromeet.domain.missionRecord.dto.response.MissionRecordUpdateRespon
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
+
+import jakarta.persistence.EntityManager;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +41,7 @@ public class MissionRecordService {
     private final MissionRepository missionRepository;
     private final MissionRecordRepository missionRecordRepository;
     private final MissionRecordTtlRepository missionRecordTtlRepository;
+    private final EntityManager entityManager;
 
     public MissionRecordCreateResponse createMissionRecord(MissionRecordCreateRequest request) {
         final Mission mission = findMissionById(request.missionId());
@@ -138,7 +144,7 @@ public class MissionRecordService {
 
             if (missionRecordTTL.isPresent()) {
                 missionRecordTtlRepository.deleteById(optionalRecord.get().getId());
-                missionRecordRepository.deleteByMissionRecordId(optionalRecord.get().getId());
+                mission.getMissionRecords().remove(optionalRecord.get()); // use orphanRemoval
             }
         }
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -17,7 +17,6 @@ import com.depromeet.domain.missionRecord.dto.response.MissionRecordUpdateRespon
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
-import jakarta.persistence.EntityManager;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.YearMonth;

--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -37,7 +37,6 @@ public class MissionRecordService {
     private final MissionRepository missionRepository;
     private final MissionRecordRepository missionRecordRepository;
     private final MissionRecordTtlRepository missionRecordTtlRepository;
-    private final EntityManager entityManager;
 
     public MissionRecordCreateResponse createMissionRecord(MissionRecordCreateRequest request) {
         final Mission mission = findMissionById(request.missionId());

--- a/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
@@ -12,9 +12,8 @@ import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.util.SecurityUtil;
-
 import jakarta.persistence.EntityManager;
-
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,8 +22,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @SpringBootTest
 @Transactional

--- a/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
@@ -1,0 +1,82 @@
+package com.depromeet.domain.missionRecord.application;
+
+import static org.mockito.Mockito.when;
+
+import com.depromeet.DatabaseCleaner;
+import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.member.domain.OauthInfo;
+import com.depromeet.domain.mission.application.MissionService;
+import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.domain.mission.domain.MissionCategory;
+import com.depromeet.domain.mission.domain.MissionVisibility;
+import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.util.SecurityUtil;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class MissionRecordServiceTest {
+
+    @Autowired MissionRecordService missionRecordService;
+    @Autowired MissionService missionService;
+    @Autowired DatabaseCleaner databaseCleaner;
+    @MockBean SecurityUtil securityUtil;
+    @Autowired EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+        when(securityUtil.getCurrentMemberId()).thenReturn(1L);
+    }
+
+    @Test
+    void 진행중인_미션기록을_삭제한다() {
+        // given
+        Member member = Member.createGuestMember(OauthInfo.createOauthInfo("test", "test"));
+        entityManager.persist(member);
+
+        LocalDateTime now = LocalDateTime.now();
+        Mission mission =
+                Mission.createMission(
+                        "test",
+                        "test",
+                        1,
+                        MissionCategory.ETC,
+                        MissionVisibility.ALL,
+                        now,
+                        now.plusWeeks(2),
+                        member);
+        entityManager.persist(mission);
+
+        missionRecordService.createMissionRecord(
+                new MissionRecordCreateRequest(mission.getId(), now, now.plusMinutes(10), 10, 0));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        missionRecordService.deleteInProgressMissionRecord();
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        Long missionId = mission.getId();
+
+        Assertions.assertThrows(
+                CustomException.class, () -> missionRecordService.findOneMissionRecord(missionId));
+    }
+}

--- a/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
@@ -46,7 +46,7 @@ class MissionRecordServiceTest {
         member = Member.createGuestMember(OauthInfo.createOauthInfo("test", "test"));
         memberRepository.save(member);
 
-        Mission mission =
+        mission =
                 Mission.createMission(
                         "test",
                         "test",


### PR DESCRIPTION
## 🌱 관련 이슈
- close #172

## 📌 작업 내용 및 특이사항
### 해결
- (AS-IS) querydsl 사용한 쿼리로 변경
- (TO-BE) orphanRemoval 사용하도록 변경 (`mission.getMissionRecords().remove(optionalRecord.get());`)

### 원인
- Mission에서 MissionRecord OneToMany 매핑해두었을 때 CascadeType.ALL로 설정하면 PERSIST할 때 REMOVED된 연관 엔티티를 다시 MANAGED 상태로 변경함

```java
// DefaultPersistEventListender
private void persist(PersistEvent event, PersistContext createCache, Object entity) {
    // ...
    switch ( entityState( event, entity, entityName, entityEntry ) ) {
        case DELETED:
            // 엔트리가 DELETED이면 다시 MANAGED로 변경
            // -> 연관관계 편의 메서드 or 고아객체 제거 필요
            entityEntry.setStatus( Status.MANAGED );
            entityEntry.setDeletedState( null );
            source.getActionQueue().unScheduleDeletion( entityEntry, event.getObject() );
            entityIsDeleted( event, createCache );
            break;
```

### 레퍼런스
- https://velog.io/@park2348190/JPA%EC%9D%98-delete-%EC%BF%BC%EB%A6%AC-%EB%A9%94%EC%84%9C%EB%93%9C
- https://stackoverflow.com/questions/34840903/silently-ignored-remove

## 📝 참고사항
- 

## 📚 기타
- 
