### PR TITLE
fix: 토큰 발급 로직 수정 및 발급 토큰을 쿠키로 관리하도록 개선 #171

### DIFF
--- a/src/main/java/com/depromeet/domain/auth/api/AuthController.java
+++ b/src/main/java/com/depromeet/domain/auth/api/AuthController.java
@@ -5,14 +5,10 @@ import com.depromeet.domain.auth.dto.request.MemberRegisterRequest;
 import com.depromeet.domain.auth.dto.request.UsernamePasswordRequest;
 import com.depromeet.domain.auth.dto.response.TokenPairResponse;
 import com.depromeet.global.util.CookieUtil;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import jakarta.validation.Valid;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/depromeet/domain/auth/api/AuthController.java
+++ b/src/main/java/com/depromeet/domain/auth/api/AuthController.java
@@ -4,10 +4,16 @@ import com.depromeet.domain.auth.application.AuthService;
 import com.depromeet.domain.auth.dto.request.MemberRegisterRequest;
 import com.depromeet.domain.auth.dto.request.UsernamePasswordRequest;
 import com.depromeet.domain.auth.dto.response.TokenPairResponse;
+import com.depromeet.global.util.CookieUtil;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final CookieUtil cookieUtil;
 
     @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
     @PostMapping("/register")
@@ -35,7 +42,12 @@ public class AuthController {
     public ResponseEntity<TokenPairResponse> memberTempRegister(
             @Valid @RequestBody UsernamePasswordRequest request) {
         TokenPairResponse response = authService.registerWithUsernameAndPassword(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+
+        String accessToken = response.accessToken();
+        String refreshToken = response.refreshToken();
+        HttpHeaders tokenHeaders = cookieUtil.generateTokenCookies(accessToken, refreshToken);
+
+        return ResponseEntity.status(HttpStatus.CREATED).headers(tokenHeaders).body(response);
     }
 
     @Operation(summary = "로그인", description = "토큰 발급을 위해 로그인을 진행합니다.")
@@ -43,6 +55,11 @@ public class AuthController {
     public ResponseEntity<TokenPairResponse> memberLogin(
             @Valid @RequestBody UsernamePasswordRequest request) {
         TokenPairResponse response = authService.loginMember(request);
-        return ResponseEntity.ok(response);
+
+        String accessToken = response.accessToken();
+        String refreshToken = response.refreshToken();
+        HttpHeaders tokenHeaders = cookieUtil.generateTokenCookies(accessToken, refreshToken);
+
+        return ResponseEntity.ok().headers(tokenHeaders).body(response);
     }
 }

--- a/src/main/java/com/depromeet/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/depromeet/global/config/security/WebSecurityConfig.java
@@ -159,6 +159,7 @@ public class WebSecurityConfig {
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);
+        configuration.addExposedHeader("Set-Cookie");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/depromeet/global/util/CookieUtil.java
+++ b/src/main/java/com/depromeet/global/util/CookieUtil.java
@@ -39,7 +39,7 @@ public class CookieUtil {
                         .maxAge(jwtProperties.refreshTokenExpirationTime())
                         .secure(true)
                         .sameSite(sameSite)
-                        .httpOnly(true)
+                        .httpOnly(false)
                         .build();
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/depromeet/global/util/CookieUtil.java
+++ b/src/main/java/com/depromeet/global/util/CookieUtil.java
@@ -1,0 +1,58 @@
+package com.depromeet.global.util;
+
+import com.depromeet.infra.config.jwt.JwtProperties;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CookieUtil {
+
+    private final SpringEnvironmentUtil springEnvironmentUtil;
+    private final JwtProperties jwtProperties;
+
+    public void addTokenCookies(
+            HttpServletResponse response, String accessToken, String refreshToken) {
+        HttpHeaders headers = generateTokenCookies(accessToken, refreshToken);
+        headers.forEach((key, value) -> response.addHeader(key, value.get(0)));
+    }
+
+    public HttpHeaders generateTokenCookies(String accessToken, String refreshToken) {
+
+        String sameSite = determineSameSitePolicy();
+
+        ResponseCookie accessTokenCookie =
+                ResponseCookie.from("accessToken", accessToken)
+                        .path("/")
+                        .maxAge(jwtProperties.accessTokenExpirationTime())
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(false)
+                        .build();
+
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from("refreshToken", refreshToken)
+                        .path("/")
+                        .maxAge(jwtProperties.refreshTokenExpirationTime())
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+
+    private String determineSameSitePolicy() {
+        if (springEnvironmentUtil.isProdProfile()) {
+            return "Strict";
+        }
+        return "None";
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #171 

## 📌 작업 내용 및 특이사항
- 쿠키 유틸리티 구현
- 토큰 재발급 후 쿠키에 넣도록 세팅
- 기존에 엑세스 토큰, 리프레시 토큰 응답으로 내려주는 API가 이제 쿠키로도 토큰을 내려주도록 함
- `temp-register` 에서 한번 요청 후 재요청 불가하여 토큰 재발급이 불가능한 이슈 수정 -> 첫 회원가입인 경우 저장하고 발급, 아이디 비밀번호 일치하면 저장하지 않고 발급, 아이디 존재하는데 비밀번호 불일치한 예외 발생

## 📝 참고사항
- 기존 API와 호환되므로 머지 가능

## 📚 기타
- 
