### PR TITLE
feat: 나와 타인의 팔로우/팔로잉 카운트 조회

### DIFF
--- a/src/main/java/com/depromeet/domain/follow/api/FollowController.java
+++ b/src/main/java/com/depromeet/domain/follow/api/FollowController.java
@@ -3,6 +3,8 @@ package com.depromeet.domain.follow.api;
 import com.depromeet.domain.follow.application.FollowService;
 import com.depromeet.domain.follow.dto.request.FollowCreateRequest;
 import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
+import com.depromeet.domain.follow.dto.response.FollowFindMeInfoResponse;
+import com.depromeet.domain.follow.dto.response.FollowFindTargetInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -29,5 +31,19 @@ public class FollowController {
     @Operation(summary = "팔로우 취소", description = "팔로우를 취소합니다.")
     public void followDelete(@Valid @RequestBody FollowDeleteRequest request) {
         followService.deleteFollow(request);
+    }
+
+    @GetMapping("/{targetId}")
+    @Operation(
+            summary = "타인의 팔로우 카운트 확인",
+            description = "타인의 팔로잉/팔로워 카운트와 내가 타인을 팔로우를 하고있는지 확인합니다.")
+    public FollowFindTargetInfoResponse followFindTarget(@PathVariable Long targetId) {
+        return followService.findTargetFollowInfo(targetId);
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "나의 팔로우 카운트 확인", description = "나의 팔로잉/팔로워 카운트를 확인합니다.")
+    public FollowFindMeInfoResponse followFindMe() {
+        return followService.findMeFollowInfo();
     }
 }

--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -26,7 +26,7 @@ public class FollowService {
         Member targetMember = getTargetMember(request.targetId());
 
         boolean existMemberRelation =
-                memberRelationRepository.existsByFollowerIdAndFollowingId(
+                memberRelationRepository.existsBySourceIdAndTargetId(
                         currentMember.getId(), targetMember.getId());
         if (existMemberRelation) {
             throw new CustomException(ErrorCode.FOLLOW_ALREADY_EXIST);
@@ -43,7 +43,7 @@ public class FollowService {
 
         MemberRelation memberRelation =
                 memberRelationRepository
-                        .findByFollowerIdAndFollowingId(currentMember.getId(), targetMember.getId())
+                        .findBySourceIdAndTargetId(currentMember.getId(), targetMember.getId())
                         .orElseThrow(() -> new CustomException(ErrorCode.FOLLOW_NOT_EXIST));
 
         memberRelationRepository.delete(memberRelation);

--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -4,6 +4,9 @@ import com.depromeet.domain.follow.dao.MemberRelationRepository;
 import com.depromeet.domain.follow.domain.MemberRelation;
 import com.depromeet.domain.follow.dto.request.FollowCreateRequest;
 import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
+import com.depromeet.domain.follow.dto.response.FollowFindMeInfoResponse;
+import com.depromeet.domain.follow.dto.response.FollowFindTargetInfoResponse;
+import com.depromeet.domain.follow.dto.response.FollowStatus;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.global.error.exception.CustomException;
@@ -47,6 +50,43 @@ public class FollowService {
                         .orElseThrow(() -> new CustomException(ErrorCode.FOLLOW_NOT_EXIST));
 
         memberRelationRepository.delete(memberRelation);
+    }
+
+    public FollowFindTargetInfoResponse findTargetFollowInfo(Long targetId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Member targetMember = getTargetMember(targetId);
+
+        Long followingCount = memberRelationRepository.countBySourceId(targetMember.getId());
+        Long followerCount = memberRelationRepository.countByTargetId(targetMember.getId());
+
+        boolean isFollowing =
+                memberRelationRepository.existsBySourceIdAndTargetId(
+                        currentMember.getId(), targetMember.getId());
+        boolean isFollowedByMe =
+                memberRelationRepository.existsBySourceIdAndTargetId(
+                        targetMember.getId(), currentMember.getId());
+        FollowStatus followStatus = determineFollowStatus(isFollowing, isFollowedByMe);
+
+        return FollowFindTargetInfoResponse.of(followingCount, followerCount, followStatus);
+    }
+
+    public FollowFindMeInfoResponse findMeFollowInfo() {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        Long followingCount = memberRelationRepository.countBySourceId(currentMember.getId());
+        Long followerCount = memberRelationRepository.countByTargetId(currentMember.getId());
+
+        return FollowFindMeInfoResponse.of(followingCount, followerCount);
+    }
+
+    private FollowStatus determineFollowStatus(boolean isFollowing, boolean isFollowedByMe) {
+        if (!isFollowing) {
+            if (isFollowedByMe) {
+                return FollowStatus.FOLLOWED_BY_ME;
+            }
+            return FollowStatus.NOT_FOLLOWING;
+        }
+        return FollowStatus.FOLLOWING;
     }
 
     private Member getTargetMember(Long targetId) {

--- a/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepository.java
+++ b/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRelationRepository extends JpaRepository<MemberRelation, Long> {
-    Optional<MemberRelation> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
+    Optional<MemberRelation> findBySourceIdAndTargetId(Long sourceId, Long targetId);
 
-    boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
+    boolean existsBySourceIdAndTargetId(Long sourceId, Long targetId);
 }

--- a/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepository.java
+++ b/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepository.java
@@ -8,4 +8,8 @@ public interface MemberRelationRepository extends JpaRepository<MemberRelation, 
     Optional<MemberRelation> findBySourceIdAndTargetId(Long sourceId, Long targetId);
 
     boolean existsBySourceIdAndTargetId(Long sourceId, Long targetId);
+
+    Long countBySourceId(Long sourceId);
+
+    Long countByTargetId(Long targetId);
 }

--- a/src/main/java/com/depromeet/domain/follow/domain/MemberRelation.java
+++ b/src/main/java/com/depromeet/domain/follow/domain/MemberRelation.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
         uniqueConstraints = {
             @UniqueConstraint(
                     name = "member_relation_uk",
-                    columnNames = {"follower_id", "following_id"})
+                    columnNames = {"source_id", "target_id"})
         })
 public class MemberRelation extends BaseTimeEntity {
     @Id
@@ -32,21 +32,21 @@ public class MemberRelation extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "follower_id")
-    private Member follower;
+    @JoinColumn(name = "source_id")
+    private Member source;
 
     @ManyToOne
-    @JoinColumn(name = "following_id")
-    private Member following;
+    @JoinColumn(name = "target_id")
+    private Member target;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private MemberRelation(Long id, Member follower, Member following) {
+    private MemberRelation(Long id, Member source, Member target) {
         this.id = id;
-        this.follower = follower;
-        this.following = following;
+        this.source = source;
+        this.target = target;
     }
 
-    public static MemberRelation createMemberRelation(Member follower, Member following) {
-        return MemberRelation.builder().follower(follower).following(following).build();
+    public static MemberRelation createMemberRelation(Member source, Member target) {
+        return MemberRelation.builder().source(source).target(target).build();
     }
 }

--- a/src/main/java/com/depromeet/domain/follow/dto/response/FollowFindMeInfoResponse.java
+++ b/src/main/java/com/depromeet/domain/follow/dto/response/FollowFindMeInfoResponse.java
@@ -1,0 +1,7 @@
+package com.depromeet.domain.follow.dto.response;
+
+public record FollowFindMeInfoResponse(Long followingCount, Long followerCount) {
+    public static FollowFindMeInfoResponse of(Long followingCount, Long followerCount) {
+        return new FollowFindMeInfoResponse(followingCount, followerCount);
+    }
+}

--- a/src/main/java/com/depromeet/domain/follow/dto/response/FollowFindTargetInfoResponse.java
+++ b/src/main/java/com/depromeet/domain/follow/dto/response/FollowFindTargetInfoResponse.java
@@ -1,0 +1,9 @@
+package com.depromeet.domain.follow.dto.response;
+
+public record FollowFindTargetInfoResponse(
+        Long followingCount, Long followerCount, FollowStatus followStatus) {
+    public static FollowFindTargetInfoResponse of(
+            Long followingCount, Long followerCount, FollowStatus followStatus) {
+        return new FollowFindTargetInfoResponse(followingCount, followerCount, followStatus);
+    }
+}

--- a/src/main/java/com/depromeet/domain/follow/dto/response/FollowStatus.java
+++ b/src/main/java/com/depromeet/domain/follow/dto/response/FollowStatus.java
@@ -1,0 +1,17 @@
+package com.depromeet.domain.follow.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum FollowStatus {
+    FOLLOWING("팔로잉"), // A가 이미 B를 팔로우 중일때 (팔로우 취소)
+    FOLLOWED_BY_ME("맞팔로우 하기"), // B가 A를 팔로우 중일때 (맞팔로우 하기)
+    NOT_FOLLOWING("팔로우"), // A가 B를 팔로우하지 않고, B도 A를 팔로우하지 않을 때 (팔로우 추가)
+    ;
+
+    private final String value;
+}

--- a/src/main/java/com/depromeet/domain/follow/dto/response/FollowStatus.java
+++ b/src/main/java/com/depromeet/domain/follow/dto/response/FollowStatus.java
@@ -1,12 +1,10 @@
 package com.depromeet.domain.follow.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum FollowStatus {
     FOLLOWING("팔로잉"), // A가 이미 B를 팔로우 중일때 (팔로우 취소)
     FOLLOWED_BY_ME("맞팔로우"), // B가 A를 팔로우 중일때 (맞팔로우)

--- a/src/main/java/com/depromeet/domain/follow/dto/response/FollowStatus.java
+++ b/src/main/java/com/depromeet/domain/follow/dto/response/FollowStatus.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum FollowStatus {
     FOLLOWING("팔로잉"), // A가 이미 B를 팔로우 중일때 (팔로우 취소)
-    FOLLOWED_BY_ME("맞팔로우 하기"), // B가 A를 팔로우 중일때 (맞팔로우 하기)
+    FOLLOWED_BY_ME("맞팔로우"), // B가 A를 팔로우 중일때 (맞팔로우)
     NOT_FOLLOWING("팔로우"), // A가 B를 팔로우하지 않고, B도 A를 팔로우하지 않을 때 (팔로우 추가)
     ;
 

--- a/src/main/java/com/depromeet/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/depromeet/global/error/GlobalExceptionHandler.java
@@ -89,7 +89,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
-    /** enum type 일치하지 않아 binding 못할 경우 발생 주로 @RequestParam enum으로 binding 못했을 경우 발생 */
+    /** PathVariable, RequestParam, RequestHeader, RequestBody 에서 타입이 일치하지 않을 경우 발생 */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     protected ResponseEntity<GlobalResponse> handleMethodArgumentTypeMismatchException(
             MethodArgumentTypeMismatchException e) {

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -10,7 +10,7 @@ public enum ErrorCode {
     SAMPLE_ERROR(HttpStatus.BAD_REQUEST, "Sample Error Message"),
 
     // Common
-    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "Enum Type이 일치하지 않아 Binding에 실패하였습니다."),
+    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청 한 값 타입이 잘못되어 binding에 실패하였습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP method 입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류, 관리자에게 문의하세요"),
 

--- a/src/test/java/com/depromeet/domain/follow/api/FollowControllerTest.java
+++ b/src/test/java/com/depromeet/domain/follow/api/FollowControllerTest.java
@@ -2,8 +2,7 @@ package com.depromeet.domain.follow.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -11,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.depromeet.domain.follow.application.FollowService;
 import com.depromeet.domain.follow.dto.request.FollowCreateRequest;
 import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
+import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.security.JwtAuthenticationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Nested;
@@ -102,6 +102,55 @@ class FollowControllerTest {
                             delete("/follows")
                                     .contentType(APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    class 타인의_팔로우_카운트를_확인할_때 {
+        @Test
+        void targetId_타입이_일치하지_않은경우_예외가_발생한다() throws Exception {
+            // given
+            String targetId = "targetId";
+
+            // when, then
+            mockMvc.perform(get("/follows/{targetId}", targetId))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(
+                            jsonPath("$.data.errorClassName")
+                                    .value("MethodArgumentTypeMismatchException"))
+                    .andExpect(
+                            jsonPath("$.data.message")
+                                    .value(ErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH.getMessage()))
+                    .andDo(print());
+        }
+
+        @Test
+        void 입력_값이_정상이라면_예외가_발생하지_않는다() throws Exception {
+            // given
+            Long targetId = 215L;
+
+            // when, then
+            mockMvc.perform(get("/follows/{targetId}", targetId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    class 나의_팔로우_카운트를_확인할_때 {
+
+        @Test
+        void 입력_값이_정상이라면_예외가_발생하지_않는다() throws Exception {
+            // when, then
+            mockMvc.perform(get("/follows/me"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))

--- a/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
@@ -113,10 +113,10 @@ class FollowServiceTest {
             assertEquals(1, memberRelationRepository.count());
             assertEquals(
                     currentMember.getId(),
-                    memberRelationRepository.findAll().get(0).getFollower().getId());
+                    memberRelationRepository.findAll().get(0).getSource().getId());
             assertEquals(
                     targetMember.getId(),
-                    memberRelationRepository.findAll().get(0).getFollowing().getId());
+                    memberRelationRepository.findAll().get(0).getTarget().getId());
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #192 

## 📌 작업 내용 및 특이사항
![image](https://github.com/depromeet/10mm-server/assets/64088250/f01147e2-bf99-4b2e-ad7b-381847135847)
- `GET /follows/{targetId}` 타인의 팔로우 카운트 확인
해당 API 응답에는 `팔로잉`, `팔로우`, `맞팔로우`인지 확인해야되기 때문에 response에 FollowStatus를 추가하였습니다.

- `GET /follows/me` 나의 팔로우 카운트 확인
로그인 된 회원 기준으로 카운트 정보를 확인합니다.

## 📝 참고사항
- `MemberRelation` Entity에서 follower, following의 단어 혼동이 있어 `source`, `target`으로 변경하였습니다.
- ExceptionHandler에서 `MethodArgumentTypeMismatchException`의 경우 `@PathVariable`에서 binding 실패하였을 경우에도 발생하여 에러메세지와 주석 변경하였습니다.

## 📚 기타
- 
