### PR TITLE
hotfix: 이미지 URL 캐싱 문제로인해 임시로 query 값 추가

### DIFF
--- a/src/main/java/com/depromeet/domain/member/domain/Profile.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Profile.java
@@ -19,4 +19,9 @@ public class Profile {
     public static Profile createProfile(String nickname, String profileImageUrl) {
         return Profile.builder().nickname(nickname).profileImageUrl(profileImageUrl).build();
     }
+
+    // TODO: 이미지 업로드 로직 개선후 timestamp 제거
+    public String getProfileImageUrl() {
+        return profileImageUrl + "?timestamp=" + System.currentTimeMillis();
+    }
 }

--- a/src/main/java/com/depromeet/domain/member/dto/response/MemberFindOneResponse.java
+++ b/src/main/java/com/depromeet/domain/member/dto/response/MemberFindOneResponse.java
@@ -20,7 +20,8 @@ public record MemberFindOneResponse(
         return new MemberFindOneResponse(
                 member.getId(),
                 member.getProfile().getNickname(),
-                member.getProfile().getProfileImageUrl(),
+                // TODO: 이미지 업로드 로직 개선후 timestamp 제거
+                member.getProfile().getProfileImageUrl() + "?timestamp=" + System.currentTimeMillis(),
                 member.getStatus(),
                 member.getRole(),
                 member.getVisibility(),

--- a/src/main/java/com/depromeet/domain/member/dto/response/MemberFindOneResponse.java
+++ b/src/main/java/com/depromeet/domain/member/dto/response/MemberFindOneResponse.java
@@ -21,7 +21,9 @@ public record MemberFindOneResponse(
                 member.getId(),
                 member.getProfile().getNickname(),
                 // TODO: 이미지 업로드 로직 개선후 timestamp 제거
-                member.getProfile().getProfileImageUrl() + "?timestamp=" + System.currentTimeMillis(),
+                member.getProfile().getProfileImageUrl()
+                        + "?timestamp="
+                        + System.currentTimeMillis(),
                 member.getStatus(),
                 member.getRole(),
                 member.getVisibility(),

--- a/src/main/java/com/depromeet/domain/member/dto/response/MemberFindOneResponse.java
+++ b/src/main/java/com/depromeet/domain/member/dto/response/MemberFindOneResponse.java
@@ -20,10 +20,7 @@ public record MemberFindOneResponse(
         return new MemberFindOneResponse(
                 member.getId(),
                 member.getProfile().getNickname(),
-                // TODO: 이미지 업로드 로직 개선후 timestamp 제거
-                member.getProfile().getProfileImageUrl()
-                        + "?timestamp="
-                        + System.currentTimeMillis(),
+                member.getProfile().getProfileImageUrl(),
                 member.getStatus(),
                 member.getRole(),
                 member.getVisibility(),


### PR DESCRIPTION
## 🌱 관련 이슈
- #185 

## 📌 작업 내용 및 특이사항
> CDN 적용 후 속도가 빨라지긴 했으나, 현재 백엔드 이미지 저장 로직에서 같은 파일이름으로 저장되게 되어있는데,
프로필을 변경해도 같은 URL이라 브라우저에서 이미지 캐싱 처리되어 같은 이미지가 문제 존재

- 위와 같은 문제로 브라우저에서 캐싱을 피하기 위해 임시로 timestamp query값 추가
- 이미지 로직 개선 후 제거 예정

