### PR TITLE
fix: 소셜 로그인 시 카카오 앱 환경인 경우 nonce 검증을 하지 않도록 변경

### DIFF
--- a/src/main/java/com/depromeet/domain/auth/application/IdTokenVerifier.java
+++ b/src/main/java/com/depromeet/domain/auth/application/IdTokenVerifier.java
@@ -55,7 +55,7 @@ public class IdTokenVerifier {
 
     private void validateAudience(OidcIdToken oidcIdToken, OauthProvider provider) {
         String idTokenAudience = oidcIdToken.getAudience().get(0);
-        List<String> targetAudiences = properties.get(provider).audience();
+        List<String> targetAudiences = properties.get(provider).audiences();
 
         if (idTokenAudience == null || !targetAudiences.contains(idTokenAudience)) {
             throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
@@ -101,5 +101,5 @@ public class IdTokenVerifier {
         }
     }
 
-    record PropertyBinder(JwtDecoder decoder, String issuer, List<String> audience) {}
+    record PropertyBinder(JwtDecoder decoder, String issuer, List<String> audiences) {}
 }

--- a/src/main/java/com/depromeet/domain/auth/application/IdTokenVerifier.java
+++ b/src/main/java/com/depromeet/domain/auth/application/IdTokenVerifier.java
@@ -4,12 +4,9 @@ import com.depromeet.domain.auth.domain.OauthProvider;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.infra.config.oidc.OidcProperties;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -19,26 +16,14 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class IdTokenVerifier {
 
     private final OidcProperties oidcProperties;
-    private final Map<OauthProvider, PropertyBinder> properties;
-
-    public IdTokenVerifier(OidcProperties oidcProperties) {
-        this.oidcProperties = oidcProperties;
-        this.properties =
-                Map.of(
-                        OauthProvider.KAKAO,
-                        new PropertyBinder(
-                                buildDecoder(oidcProperties.kakao().jwkSetUri()),
-                                oidcProperties.kakao().issuer(),
-                                oidcProperties.kakao().audience()),
-                        OauthProvider.APPLE,
-                        new PropertyBinder(
-                                buildDecoder(oidcProperties.apple().jwkSetUri()),
-                                oidcProperties.apple().issuer(),
-                                oidcProperties.apple().audience()));
-    }
+    private final Map<OauthProvider, JwtDecoder> decoders =
+            Map.of(
+                    OauthProvider.KAKAO, buildDecoder(OauthProvider.KAKAO.getJwkSetUrl()),
+                    OauthProvider.APPLE, buildDecoder(OauthProvider.APPLE.getJwkSetUrl()));
 
     private JwtDecoder buildDecoder(String jwkUrl) {
         return NimbusJwtDecoder.withJwkSetUri(jwkUrl).build();
@@ -47,33 +32,32 @@ public class IdTokenVerifier {
     public OidcUser getOidcUser(String idToken, OauthProvider provider) {
         Jwt jwt = getJwt(idToken, provider);
         OidcIdToken oidcIdToken = getOidcIdToken(jwt);
-        validateIssuer(oidcIdToken, provider);
-        validateAudience(oidcIdToken, provider);
-        validateNonce(oidcIdToken);
+
+        validateIssuer(oidcIdToken, provider.getIssuer());
+        validateAudience(oidcIdToken, oidcProperties.getAudiences(provider));
+        validateNonce(oidcIdToken, provider);
+
         return new DefaultOidcUser(null, oidcIdToken);
     }
 
-    private void validateAudience(OidcIdToken oidcIdToken, OauthProvider provider) {
+    private Jwt getJwt(String idToken, OauthProvider provider) {
+        return decoders.get(provider).decode(idToken);
+    }
+
+    private void validateAudience(OidcIdToken oidcIdToken, List<String> targetAudiences) {
         String idTokenAudience = oidcIdToken.getAudience().get(0);
-        List<String> targetAudiences = properties.get(provider).audiences();
 
         if (idTokenAudience == null || !targetAudiences.contains(idTokenAudience)) {
             throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
         }
     }
 
-    private void validateIssuer(OidcIdToken oidcIdToken, OauthProvider provider) {
+    private void validateIssuer(OidcIdToken oidcIdToken, String targetIssuer) {
         String idTokenIssuer = oidcIdToken.getIssuer().toString();
-        String targetIssuer = properties.get(provider).issuer();
 
         if (idTokenIssuer == null || !idTokenIssuer.equals(targetIssuer)) {
             throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
         }
-    }
-
-    private Jwt getJwt(String idToken, OauthProvider provider) {
-        JwtDecoder decoder = properties.get(provider).decoder();
-        return decoder.decode(idToken);
     }
 
     private OidcIdToken getOidcIdToken(Jwt jwt) {
@@ -81,25 +65,23 @@ public class IdTokenVerifier {
                 jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims());
     }
 
-    private void validateNonce(OidcIdToken idToken) {
+    private void validateNonce(OidcIdToken idToken, OauthProvider provider) {
         // TODO: 랜덤 nonce 사용하도록 개선
-        String idTokenNonceHash = idToken.getNonce();
-        String targetNonceHash = oidcProperties.nonce();
+        String idTokenNonce = idToken.getNonce();
+        String targetNonce = oidcProperties.nonce();
 
-        if (idTokenNonceHash == null || !idTokenNonceHash.equals(targetNonceHash)) {
+        // 카카오 앱 토큰의 경우 라이브러리 문제로 nonce 검증 생략
+        if (isKakaoAppToken(idToken, provider)) {
+            return;
+        }
+
+        if (idTokenNonce == null || !idTokenNonce.equals(targetNonce)) {
             throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
         }
     }
 
-    private String getNonceHash(String nonce) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            byte[] digest = md.digest(nonce.getBytes(StandardCharsets.US_ASCII));
-            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
-        } catch (NoSuchAlgorithmException e) {
-            throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
-        }
+    private boolean isKakaoAppToken(OidcIdToken idToken, OauthProvider provider) {
+        return provider == OauthProvider.KAKAO
+                && idToken.getAudience().contains(oidcProperties.getKakaoAppAudience());
     }
-
-    record PropertyBinder(JwtDecoder decoder, String issuer, List<String> audiences) {}
 }

--- a/src/main/java/com/depromeet/domain/auth/domain/OauthProvider.java
+++ b/src/main/java/com/depromeet/domain/auth/domain/OauthProvider.java
@@ -8,7 +8,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum OauthProvider {
-    KAKAO,
-    APPLE,
+    KAKAO(KAKAO_JWK_SET_URL, KAKAO_ISSUER),
+    APPLE(APPLE_JWK_SET_URL, APPLE_ISSUER),
     ;
+
+    private final String jwkSetUrl;
+    private final String issuer;
 }

--- a/src/main/java/com/depromeet/global/common/constants/SecurityConstants.java
+++ b/src/main/java/com/depromeet/global/common/constants/SecurityConstants.java
@@ -7,8 +7,8 @@ public final class SecurityConstants {
     public static final String ACCESS_TOKEN_HEADER = "Authorization";
     public static final String REFRESH_TOKEN_HEADER = "Refresh-Token";
     public static final String REGISTER_REQUIRED_HEADER = "Registration-Required";
-    public static final String KAKAO_JWK_URL = "https://kauth.kakao.com/.well-known/jwks.json";
-    public static final String APPLE_JWK_URL = "https://appleid.apple.com/auth/keys";
+    public static final String KAKAO_JWK_SET_URL = "https://kauth.kakao.com/.well-known/jwks.json";
+    public static final String APPLE_JWK_SET_URL = "https://appleid.apple.com/auth/keys";
     public static final String KAKAO_ISSUER = "https://kauth.kakao.com";
     public static final String APPLE_ISSUER = "https://appleid.apple.com";
 

--- a/src/main/java/com/depromeet/infra/config/oidc/OidcProperties.java
+++ b/src/main/java/com/depromeet/infra/config/oidc/OidcProperties.java
@@ -1,11 +1,30 @@
 package com.depromeet.infra.config.oidc;
 
+import com.depromeet.domain.auth.domain.OauthProvider;
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "oidc")
-public record OidcProperties(String nonce, Kakao kakao, Apple apple) {
-    public record Kakao(String jwkSetUri, String issuer, List<String> audience) {}
+@ConfigurationProperties(prefix = "oauth")
+public record OidcProperties(String nonce, Map<OauthProvider, List<Audience>> audience) {
+    record Audience(String key, AudienceType type) {}
 
-    public record Apple(String jwkSetUri, String issuer, List<String> audience) {}
+    public enum AudienceType {
+        WEB,
+        APP,
+        ALL
+    }
+
+    public List<String> getAudiences(OauthProvider provider) {
+        return audience.get(provider).stream().map(Audience::key).toList();
+    }
+
+    public String getKakaoAppAudience() throws NoSuchElementException {
+        return audience.get(OauthProvider.KAKAO).stream()
+                .filter(audience -> audience.type() == AudienceType.APP)
+                .findFirst()
+                .map(Audience::key)
+                .orElseThrow();
+    }
 }

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -18,3 +18,15 @@ oidc:
     issuer: https://appleid.apple.com
     audience:
       - ${APPLE_SERVICE_ID:}
+
+oauth:
+  nonce: ${OIDC_NONCE_SECRET:}
+  audience:
+    KAKAO:
+      - key: ${KAKAO_REST_APP_KEY:}
+        type: WEB
+      - key: ${KAKAO_NATIVE_APP_KEY:}
+        type: APP
+    APPLE:
+      - key: ${APPLE_SERVICE_ID:}
+        type: ALL


### PR DESCRIPTION
## 🌱 관련 이슈
- close #204 

## 📌 작업 내용 및 특이사항
- 프로퍼티 및 토큰 검증 로직 리팩토링
    - 노출되면 안되는 aud 값만 시크릿 처리하고 나머지는 enum 상수의 필드로 넣었습니다.
    - `ConfigurationProperties` 매핑해올 때 Map으로 가져오고 `OauthProvider`를 키로 가지도록 리팩토링했습니다.
    - 카카오 앱 환경인 경우 nonce 검증을 스킵하도록 변경했습니다.

## 📝 참고사항
- 

## 📚 기타
- 
