### PR TITLE
hotfix: Profile Image가 null 일 때 timestamp 안붙도록 처리

### DIFF
--- a/src/main/java/com/depromeet/domain/member/domain/Profile.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Profile.java
@@ -22,6 +22,9 @@ public class Profile {
 
     // TODO: 이미지 업로드 로직 개선후 timestamp 제거
     public String getProfileImageUrl() {
+        if (profileImageUrl == null) {
+            return null;
+        }
         return profileImageUrl + "?timestamp=" + System.currentTimeMillis();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #208 

## 📌 작업 내용 및 특이사항
- 현재 이미지 캐싱을 사용하지 않기 위해 timestamp 값을 직접 추가해주고 있는데, null 인경우에도 timestamp가 붙어서 에러 발생하여 Null 체크 진행