### PR TITLE
feat: 내가 팔로우 한 사용자들 닉네임,프로필 조회

### DIFF
--- a/src/main/java/com/depromeet/domain/follow/api/FollowController.java
+++ b/src/main/java/com/depromeet/domain/follow/api/FollowController.java
@@ -5,7 +5,7 @@ import com.depromeet.domain.follow.dto.request.FollowCreateRequest;
 import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
 import com.depromeet.domain.follow.dto.response.FollowFindMeInfoResponse;
 import com.depromeet.domain.follow.dto.response.FollowFindTargetInfoResponse;
-import com.depromeet.domain.follow.dto.response.FollowedMemberResponse;
+import com.depromeet.domain.follow.dto.response.MemberFollowedResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -53,7 +53,7 @@ public class FollowController {
     @Operation(
             summary = "내가 팔로우 한 유저 정보(id, 닉네임, 프로필) 리스트 조회",
             description = "팔로우 한 유저들 정보를 조회합니다.")
-    public List<FollowedMemberResponse> followedUserFindAll() {
+    public List<MemberFollowedResponse> followedUserFindAll() {
         return followService.findAllFollowedMember();
     }
 }

--- a/src/main/java/com/depromeet/domain/follow/api/FollowController.java
+++ b/src/main/java/com/depromeet/domain/follow/api/FollowController.java
@@ -5,9 +5,11 @@ import com.depromeet.domain.follow.dto.request.FollowCreateRequest;
 import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
 import com.depromeet.domain.follow.dto.response.FollowFindMeInfoResponse;
 import com.depromeet.domain.follow.dto.response.FollowFindTargetInfoResponse;
+import com.depromeet.domain.follow.dto.response.FollowedMemberResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,5 +47,13 @@ public class FollowController {
     @Operation(summary = "나의 팔로우 카운트 확인", description = "나의 팔로잉/팔로워 카운트를 확인합니다.")
     public FollowFindMeInfoResponse followFindMe() {
         return followService.findMeFollowInfo();
+    }
+
+    @GetMapping("/members")
+    @Operation(
+            summary = "내가 팔로우 한 유저 정보(id, 닉네임, 프로필) 리스트 조회",
+            description = "팔로우 한 유저들 정보를 조회합니다.")
+    public List<FollowedMemberResponse> followedUserFindAll() {
+        return followService.findAllFollowedMember();
     }
 }

--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -7,7 +7,7 @@ import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
 import com.depromeet.domain.follow.dto.response.FollowFindMeInfoResponse;
 import com.depromeet.domain.follow.dto.response.FollowFindTargetInfoResponse;
 import com.depromeet.domain.follow.dto.response.FollowStatus;
-import com.depromeet.domain.follow.dto.response.FollowedMemberResponse;
+import com.depromeet.domain.follow.dto.response.MemberFollowedResponse;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.domain.Mission;
@@ -88,13 +88,13 @@ public class FollowService {
     }
 
     @Transactional(readOnly = true) // TODO: 로직 개선 필요
-    public List<FollowedMemberResponse> findAllFollowedMember() {
+    public List<MemberFollowedResponse> findAllFollowedMember() {
         final Member currentMember = memberUtil.getCurrentMember();
         List<MemberRelation> followedMemberList =
                 memberRelationRepository.findAllBySourceId(currentMember.getId());
 
         // 결과를 반환하는 List
-        List<FollowedMemberResponse> result = new ArrayList<>();
+        List<MemberFollowedResponse> result = new ArrayList<>();
 
         // 당일 미션 기록이 존재하여 미션기록의 순서로 정렬이 될 회원들이 담길 Map
         Map<Member, LocalDateTime> sortedByMemberMissionRecordMap = new HashMap<>();
@@ -137,12 +137,12 @@ public class FollowService {
         // (정렬조건 1번째) 당일 미션 기록이 존재하는 회원들 먼저 result에 저장
         sortedByMemberMissionRecordMap.entrySet().stream()
                 .sorted(Map.Entry.comparingByValue())
-                .forEach(entry -> result.add(FollowedMemberResponse.of(entry.getKey())));
+                .forEach(entry -> result.add(MemberFollowedResponse.of(entry.getKey())));
 
         // (정렬조건 2번째) 미션 기록이 존재하지 않는 회원들은 팔로우 시간으로 result에 저장
         sortedByMemberRelationMap.entrySet().stream()
                 .sorted(Map.Entry.comparingByValue())
-                .forEach(entry -> result.add(FollowedMemberResponse.of(entry.getKey())));
+                .forEach(entry -> result.add(MemberFollowedResponse.of(entry.getKey())));
 
         return result;
     }

--- a/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepository.java
+++ b/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepository.java
@@ -1,10 +1,12 @@
 package com.depromeet.domain.follow.dao;
 
 import com.depromeet.domain.follow.domain.MemberRelation;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRelationRepository extends JpaRepository<MemberRelation, Long> {
+public interface MemberRelationRepository
+        extends JpaRepository<MemberRelation, Long>, MemberRelationRepositoryCustom {
     Optional<MemberRelation> findBySourceIdAndTargetId(Long sourceId, Long targetId);
 
     boolean existsBySourceIdAndTargetId(Long sourceId, Long targetId);
@@ -12,4 +14,6 @@ public interface MemberRelationRepository extends JpaRepository<MemberRelation, 
     Long countBySourceId(Long sourceId);
 
     Long countByTargetId(Long targetId);
+
+    List<MemberRelation> findAllBySourceId(Long memberId);
 }

--- a/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.depromeet.domain.follow.dao;
+
+import com.depromeet.domain.follow.domain.MemberRelation;
+import java.util.List;
+
+public interface MemberRelationRepositoryCustom {
+    List<MemberRelation> findAllBySourceId(Long memberId);
+}

--- a/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.depromeet.domain.follow.dao;
+
+import static com.depromeet.domain.follow.domain.QMemberRelation.memberRelation;
+import static com.depromeet.domain.member.domain.QMember.member;
+import static com.depromeet.domain.mission.domain.QMission.*;
+import static com.depromeet.domain.missionRecord.domain.QMissionRecord.*;
+
+import com.depromeet.domain.follow.domain.MemberRelation;
+import com.querydsl.core.types.dsl.*;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRelationRepositoryImpl implements MemberRelationRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<MemberRelation> findAllBySourceId(Long memberId) {
+        return jpaQueryFactory
+                .selectFrom(memberRelation)
+                .leftJoin(memberRelation.target, member)
+                .leftJoin(memberRelation.target.missions, mission)
+                .leftJoin(mission.missionRecords, missionRecord)
+                .where(memberRelation.source.id.eq(memberId))
+                .fetch();
+    }
+
+    private BooleanExpression sourceIdEq(Long sourceId) {
+        return memberRelation.source.id.eq(sourceId);
+    }
+
+    //    @Override
+    //    public List<Member> findFollowedMemberList(Long memberId) {
+    //        List<Member> memberRelations = jpaQueryFactory
+    //                .selectFrom(member)
+    //                .join(memberRelation.follower)
+    //
+    //                .leftJoin(memberRelation.following, member)
+    //                .fetchJoin()
+    //                .leftJoin(memberRelation.following.missions, mission)
+    //                .on(member.id.eq(mission.member.id))
+    //                .leftJoin(mission.missionRecords, missionRecord)
+    //                .on(mission.id.eq(missionRecord.mission.id))
+    //                .where(memberRelation.follower.id.eq(memberId))
+    //                .orderBy(orderByTest().desc())
+    //                .fetch();
+    //
+    //        return memberRelations;
+    //    }
+    //
+    //    private DateTimeExpression<LocalDateTime> orderByTest() {
+    //        LocalDate now = LocalDate.now();
+    //        return new CaseBuilder().when(
+    //                memberRelation.following.id.isNotNull()
+    //                        .and(Expressions.dateTemplate(LocalDate.class, "DATE_FORMAT({0},
+    // %Y-%m-%d)",missionRecord.startedAt).eq(now))
+    //                )
+    //                .then(missionRecord.startedAt)
+    //                .otherwise(memberRelation.createdAt);
+    //    }
+    //
+    //    private BooleanExpression followerIdEq(Long memberId) {
+    //        return memberId == null ? null : memberRelation.follower.id.eq(memberId);
+    //    }
+}

--- a/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepositoryImpl.java
@@ -24,45 +24,11 @@ public class MemberRelationRepositoryImpl implements MemberRelationRepositoryCus
                 .leftJoin(memberRelation.target, member)
                 .leftJoin(memberRelation.target.missions, mission)
                 .leftJoin(mission.missionRecords, missionRecord)
-                .where(memberRelation.source.id.eq(memberId))
+                .where(sourceIdEq(memberId))
                 .fetch();
     }
 
     private BooleanExpression sourceIdEq(Long sourceId) {
         return memberRelation.source.id.eq(sourceId);
     }
-
-    //    @Override
-    //    public List<Member> findFollowedMemberList(Long memberId) {
-    //        List<Member> memberRelations = jpaQueryFactory
-    //                .selectFrom(member)
-    //                .join(memberRelation.follower)
-    //
-    //                .leftJoin(memberRelation.following, member)
-    //                .fetchJoin()
-    //                .leftJoin(memberRelation.following.missions, mission)
-    //                .on(member.id.eq(mission.member.id))
-    //                .leftJoin(mission.missionRecords, missionRecord)
-    //                .on(mission.id.eq(missionRecord.mission.id))
-    //                .where(memberRelation.follower.id.eq(memberId))
-    //                .orderBy(orderByTest().desc())
-    //                .fetch();
-    //
-    //        return memberRelations;
-    //    }
-    //
-    //    private DateTimeExpression<LocalDateTime> orderByTest() {
-    //        LocalDate now = LocalDate.now();
-    //        return new CaseBuilder().when(
-    //                memberRelation.following.id.isNotNull()
-    //                        .and(Expressions.dateTemplate(LocalDate.class, "DATE_FORMAT({0},
-    // %Y-%m-%d)",missionRecord.startedAt).eq(now))
-    //                )
-    //                .then(missionRecord.startedAt)
-    //                .otherwise(memberRelation.createdAt);
-    //    }
-    //
-    //    private BooleanExpression followerIdEq(Long memberId) {
-    //        return memberId == null ? null : memberRelation.follower.id.eq(memberId);
-    //    }
 }

--- a/src/main/java/com/depromeet/domain/follow/dto/response/FollowedMemberResponse.java
+++ b/src/main/java/com/depromeet/domain/follow/dto/response/FollowedMemberResponse.java
@@ -1,0 +1,12 @@
+package com.depromeet.domain.follow.dto.response;
+
+import com.depromeet.domain.member.domain.Member;
+
+public record FollowedMemberResponse(Long memberId, String nickname, String profileImageUrl) {
+    public static FollowedMemberResponse of(Member member) {
+        return new FollowedMemberResponse(
+                member.getId(),
+                member.getProfile().getNickname(),
+                member.getProfile().getProfileImageUrl());
+    }
+}

--- a/src/main/java/com/depromeet/domain/follow/dto/response/MemberFollowedResponse.java
+++ b/src/main/java/com/depromeet/domain/follow/dto/response/MemberFollowedResponse.java
@@ -2,9 +2,9 @@ package com.depromeet.domain.follow.dto.response;
 
 import com.depromeet.domain.member.domain.Member;
 
-public record FollowedMemberResponse(Long memberId, String nickname, String profileImageUrl) {
-    public static FollowedMemberResponse of(Member member) {
-        return new FollowedMemberResponse(
+public record MemberFollowedResponse(Long memberId, String nickname, String profileImageUrl) {
+    public static MemberFollowedResponse of(Member member) {
+        return new MemberFollowedResponse(
                 member.getId(),
                 member.getProfile().getNickname(),
                 member.getProfile().getProfileImageUrl());

--- a/src/test/java/com/depromeet/domain/follow/api/FollowControllerTest.java
+++ b/src/test/java/com/depromeet/domain/follow/api/FollowControllerTest.java
@@ -157,4 +157,17 @@ class FollowControllerTest {
                     .andDo(print());
         }
     }
+
+    @Nested
+    class 내가_팔로우한_유저_정보_리스트를_조회할_때 {
+        @Test
+        void 입력_값이_정상이라면_예외가_발생하지_않는다() throws Exception {
+            // when, then
+            mockMvc.perform(get("/follows/members"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andDo(print());
+        }
+    }
 }

--- a/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
@@ -11,12 +11,22 @@ import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
 import com.depromeet.domain.follow.dto.response.FollowFindMeInfoResponse;
 import com.depromeet.domain.follow.dto.response.FollowFindTargetInfoResponse;
 import com.depromeet.domain.follow.dto.response.FollowStatus;
+import com.depromeet.domain.follow.dto.response.FollowedMemberResponse;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.Profile;
+import com.depromeet.domain.mission.dao.MissionRepository;
+import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.domain.mission.domain.MissionCategory;
+import com.depromeet.domain.mission.domain.MissionVisibility;
+import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.security.PrincipalDetails;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,6 +43,8 @@ class FollowServiceTest {
     @Autowired private DatabaseCleaner databaseCleaner;
     @Autowired private MemberRepository memberRepository;
     @Autowired private MemberRelationRepository memberRelationRepository;
+    @Autowired private MissionRepository missionRepository;
+    @Autowired private MissionRecordRepository missionRecordRepository;
     @Autowired private FollowService followService;
 
     @BeforeEach
@@ -366,6 +378,122 @@ class FollowServiceTest {
             // then
             assertEquals(0L, response.followingCount());
             assertEquals(1L, response.followerCount());
+        }
+    }
+
+    @Nested
+    class 내가_팔로우한_유저_정보_리스트를_조회할_때 {
+        @Test
+        void 로그인된_회원이_존재하지_않는다면_예외를_발생시킨다() {
+            // when, then
+            assertThatThrownBy(() -> followService.findAllFollowedMember())
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 내가_팔로우한_사람이_없다면_빈_리스트가_조회된다() {
+            // given
+            memberRepository.save(
+                    Member.createNormalMember(
+                            Profile.createProfile("testNickname1", "testImageUrl1")));
+
+            // when
+            List<FollowedMemberResponse> response = followService.findAllFollowedMember();
+
+            // then
+            assertEquals(0, response.size());
+        }
+
+        @Test
+        void 팔로우한_유저가_당일_미션을_완수하였다면_미션을_완수하지_않은_유저보다_먼저_조회된다() {
+            // given
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("currentMember", "currentMember")));
+            Member targetMember1 =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("targetMember1", "targetMember1")));
+            Member targetMember2 =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("targetMember2", "targetMember2")));
+
+            LocalDateTime today = LocalDateTime.now();
+            LocalDateTime missionStartedAt = today;
+            LocalDateTime missionFinishedAt = today.plusWeeks(2);
+            Mission mission =
+                    missionRepository.save(
+                            Mission.createMission(
+                                    "testMissionName",
+                                    "testMissionContent",
+                                    1,
+                                    MissionCategory.ETC,
+                                    MissionVisibility.ALL,
+                                    missionStartedAt,
+                                    missionFinishedAt,
+                                    targetMember2));
+
+            LocalDateTime missionRecordStartedAt = today;
+            LocalDateTime missionRecordFinishedAt =
+                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
+            Duration duration = Duration.ofMinutes(32).plusSeconds(14);
+
+            MissionRecord missionRecord =
+                    missionRecordRepository.save(
+                            MissionRecord.createMissionRecord(
+                                    duration,
+                                    missionRecordStartedAt,
+                                    missionRecordFinishedAt,
+                                    mission));
+            missionRecord.updateUploadStatusPending();
+            missionRecord.updateUploadStatusComplete("remark", "imageUrl");
+            missionRecordRepository.save(missionRecord);
+
+            memberRelationRepository.save(
+                    MemberRelation.createMemberRelation(currentMember, targetMember1));
+            memberRelationRepository.save(
+                    MemberRelation.createMemberRelation(currentMember, targetMember2));
+
+            // when
+            List<FollowedMemberResponse> response = followService.findAllFollowedMember();
+
+            // then
+            assertEquals(2, response.size());
+            assertEquals("targetMember2", response.get(0).nickname());
+            assertEquals("targetMember1", response.get(1).nickname());
+        }
+
+        @Test
+        void 팔로우한_유저가_당일_미션을_완수하지_않았다면_팔로우_시간_기준으로_조회된다() {
+            // given
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("currentMember", "currentMember")));
+            Member targetMember1 =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("targetMember1", "targetMember1")));
+            Member targetMember2 =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("targetMember2", "targetMember2")));
+
+            memberRelationRepository.save(
+                    MemberRelation.createMemberRelation(currentMember, targetMember1));
+            memberRelationRepository.save(
+                    MemberRelation.createMemberRelation(currentMember, targetMember2));
+
+            // when
+            List<FollowedMemberResponse> response = followService.findAllFollowedMember();
+
+            // then
+            assertEquals(2, response.size());
+            assertEquals("targetMember1", response.get(0).nickname());
+            assertEquals("targetMember2", response.get(1).nickname());
         }
     }
 }

--- a/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
@@ -11,7 +11,7 @@ import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
 import com.depromeet.domain.follow.dto.response.FollowFindMeInfoResponse;
 import com.depromeet.domain.follow.dto.response.FollowFindTargetInfoResponse;
 import com.depromeet.domain.follow.dto.response.FollowStatus;
-import com.depromeet.domain.follow.dto.response.FollowedMemberResponse;
+import com.depromeet.domain.follow.dto.response.MemberFollowedResponse;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.Profile;
@@ -399,7 +399,7 @@ class FollowServiceTest {
                             Profile.createProfile("testNickname1", "testImageUrl1")));
 
             // when
-            List<FollowedMemberResponse> response = followService.findAllFollowedMember();
+            List<MemberFollowedResponse> response = followService.findAllFollowedMember();
 
             // then
             assertEquals(0, response.size());
@@ -458,7 +458,7 @@ class FollowServiceTest {
                     MemberRelation.createMemberRelation(currentMember, targetMember2));
 
             // when
-            List<FollowedMemberResponse> response = followService.findAllFollowedMember();
+            List<MemberFollowedResponse> response = followService.findAllFollowedMember();
 
             // then
             assertEquals(2, response.size());
@@ -488,7 +488,7 @@ class FollowServiceTest {
                     MemberRelation.createMemberRelation(currentMember, targetMember2));
 
             // when
-            List<FollowedMemberResponse> response = followService.findAllFollowedMember();
+            List<MemberFollowedResponse> response = followService.findAllFollowedMember();
 
             // then
             assertEquals(2, response.size());


### PR DESCRIPTION
## 🌱 관련 이슈
- close #198 

## 📌 작업 내용 및 특이사항
|![image](https://github.com/depromeet/10mm-server/assets/64088250/b070f7b6-ed1f-477d-a8f0-0ed77ad60d13)

- 로그인 된 회원 기준 팔로우 한 사람들을 조회
- 이 때, 정렬 조건은 팔로우 목록 중 최신에 미션을 완료한 사람이 있다면 미션 완료한 시간이 최근인 사람 먼저
- 미션을 완료한 사람이 없다면 디폴트 정렬조건으로 팔로우를 한 시간 최신순으로 정렬

