### PR TITLE
refactor: Build시 appleboy/scp-action@v0.1.4 속도 개선

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -69,15 +69,27 @@ jobs:
           tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ steps.image-tag.outputs.value }}
 
       # 서버로 docker-compose 파일 전송
-      - name: Copy docker-compose.yml to NCP Server
-        uses: appleboy/scp-action@v0.1.4
+      - name: copy source via ssh key
+        uses: burnett01/rsync-deployments@4.1
         with:
-          host: ${{ secrets.NCP_HOST }}
-          username: ${{ secrets.NCP_USERNAME }}
-          key: ${{ secrets.NCP_PRIVATE_KEY }}
-          port: ${{ secrets.NCP_PORT }}
-          source: docker-compose.yaml
-          target: /home/tenminute/
+          switches: -avzr --delete
+          remote_host: ${{ secrets.NCP_HOST }}
+          remote_user: ${{ secrets.NCP_USERNAME }}
+          remote_port: ${{ secrets.NCP_PORT }}
+          remote_key: ${{ secrets.NCP_PRIVATE_KEY }}
+          path: docker-compose.yaml
+          remote_path: /home/tenminute/
+
+      # 서버로 docker-compose 파일 전송
+#      - name: Copy docker-compose.yml to NCP Server
+#        uses: appleboy/scp-action@v0.1.4
+#        with:
+#          host: ${{ secrets.NCP_HOST }}
+#          username: ${{ secrets.NCP_USERNAME }}
+#          key: ${{ secrets.NCP_PRIVATE_KEY }}
+#          port: ${{ secrets.NCP_PORT }}
+#          source: docker-compose.yaml
+#          target: /home/tenminute/
 
       # 슬랙으로 빌드 스캔 결과 전송
       - name: Send to slack

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,8 +3,6 @@ name: develop Build And Deploy
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   build:
@@ -79,17 +77,6 @@ jobs:
           remote_key: ${{ secrets.NCP_PRIVATE_KEY }}
           path: docker-compose.yaml
           remote_path: /home/tenminute/
-
-      # 서버로 docker-compose 파일 전송
-#      - name: Copy docker-compose.yml to NCP Server
-#        uses: appleboy/scp-action@v0.1.4
-#        with:
-#          host: ${{ secrets.NCP_HOST }}
-#          username: ${{ secrets.NCP_USERNAME }}
-#          key: ${{ secrets.NCP_PRIVATE_KEY }}
-#          port: ${{ secrets.NCP_PORT }}
-#          source: docker-compose.yaml
-#          target: /home/tenminute/
 
       # 슬랙으로 빌드 스캔 결과 전송
       - name: Send to slack

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,6 +3,8 @@ name: develop Build And Deploy
 on:
   push:
     branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/production_build_deploy.yml
+++ b/.github/workflows/production_build_deploy.yml
@@ -68,15 +68,16 @@ jobs:
           tags: ${{ secrets.NCP_CONTAINER_REGISTRY }}/server-spring:${{ steps.image-tag.outputs.value }}
 
       # 서버로 docker-compose 파일 전송
-      - name: Copy docker-compose.yml to NCP Server
-        uses: appleboy/scp-action@v0.1.4
+      - name: copy source via ssh key
+        uses: burnett01/rsync-deployments@4.1
         with:
-          host: ${{ secrets.NCP_HOST }}
-          username: ${{ secrets.NCP_USERNAME }}
-          key: ${{ secrets.NCP_PRIVATE_KEY }}
-          port: ${{ secrets.NCP_PORT }}
-          source: docker-compose.yaml
-          target: /home/tenminute/
+          switches: -avzr --delete
+          remote_host: ${{ secrets.NCP_HOST }}
+          remote_user: ${{ secrets.NCP_USERNAME }}
+          remote_port: ${{ secrets.NCP_PORT }}
+          remote_key: ${{ secrets.NCP_PRIVATE_KEY }}
+          path: docker-compose.yaml
+          remote_path: /home/tenminute/
 
       # 슬랙으로 빌드 스캔 결과 전송
       - name: Send to slack

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,6 @@
 version: "3.8"
 
 services:
-
   backend:
     image: ${NCP_CONTAINER_REGISTRY}/server-spring:${NCP_IMAGE_TAG}
     container_name: server-spring

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.8"
 
 services:
+
   backend:
     image: ${NCP_CONTAINER_REGISTRY}/server-spring:${NCP_IMAGE_TAG}
     container_name: server-spring


### PR DESCRIPTION
## 🌱 관련 이슈
- close #200

## 📌 작업 내용 및 특이사항
![image](https://github.com/depromeet/10mm-server/assets/64088250/dd6aca71-a931-4fe4-8cee-93657e18f61a)
- 현재 Build시에 `appleboy/scp-action@v0.1.4`를 사용하여 `docker-compose.yml`을 항시 복사하고 있습니다.
- 해당 step은 `docker-compose.yml`의 변경과 없이 항상 실행되며 약 30s가 걸린다.
- 파일이 업데이트 되었는지 확인이 가능한 [`burnett01/rsync-deployments`](https://github.com/Burnett01/rsync-deployments) 사용

#### `burnett01/rsync-deployments`의 switches 옵션
-a: archive
-v: verbose
-z: compress
-r: recursive
--delete: delete files that are not in the source directory

## 📝 참고사항
- 약 30s 걸리던 작업 개선 후 약 7s 걸림
- [정상 동작 확인](https://github.com/depromeet/10mm-server/actions/runs/7640375170/job/20815366179)하였습니당 