### PR TITLE
feat: 소셜 로그인 정보 조회하기 기능 구현

### DIFF
--- a/src/main/java/com/depromeet/domain/auth/application/AuthService.java
+++ b/src/main/java/com/depromeet/domain/auth/application/AuthService.java
@@ -134,6 +134,7 @@ public class AuthService {
     }
 
     private OauthInfo extractOauthInfo(OidcUser oidcUser) {
-        return OauthInfo.createOauthInfo(oidcUser.getName(), oidcUser.getIssuer().toString());
+        return OauthInfo.createOauthInfo(
+                oidcUser.getName(), oidcUser.getIssuer().toString(), oidcUser.getEmail());
     }
 }

--- a/src/main/java/com/depromeet/domain/auth/domain/OauthProvider.java
+++ b/src/main/java/com/depromeet/domain/auth/domain/OauthProvider.java
@@ -2,6 +2,9 @@ package com.depromeet.domain.auth.domain;
 
 import static com.depromeet.global.common.constants.SecurityConstants.*;
 
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,4 +17,11 @@ public enum OauthProvider {
 
     private final String jwkSetUrl;
     private final String issuer;
+
+    public static OauthProvider of(String issuer) {
+        return Arrays.stream(values())
+                .filter(oauthProvider -> oauthProvider.issuer.equals(issuer))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.OAUTH_PROVIDER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/depromeet/domain/member/api/MemberController.java
+++ b/src/main/java/com/depromeet/domain/member/api/MemberController.java
@@ -4,6 +4,7 @@ import com.depromeet.domain.auth.dto.request.UsernameCheckRequest;
 import com.depromeet.domain.member.application.MemberService;
 import com.depromeet.domain.member.dto.request.NicknameCheckRequest;
 import com.depromeet.domain.member.dto.response.MemberFindOneResponse;
+import com.depromeet.domain.member.dto.response.MemberSocialInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -47,5 +48,12 @@ public class MemberController {
     public ResponseEntity<Void> memberWithdrawal(@Valid @RequestBody UsernameCheckRequest request) {
         memberService.withdrawal(request);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "소셜 로그인 정보 조회하기", description = "소셜 로그인 정보를 조회합니다.")
+    @GetMapping("/me/social")
+    public ResponseEntity<MemberSocialInfoResponse> memberSocialInfoFind() {
+        MemberSocialInfoResponse response = memberService.findMemberSocialInfo();
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -6,6 +6,7 @@ import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.dto.request.NicknameCheckRequest;
 import com.depromeet.domain.member.dto.response.MemberFindOneResponse;
+import com.depromeet.domain.member.dto.response.MemberSocialInfoResponse;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
@@ -50,5 +51,17 @@ public class MemberService {
 
         refreshTokenRepository.deleteById(member.getId());
         member.withdrawal();
+    }
+
+    public MemberSocialInfoResponse findMemberSocialInfo() {
+        final Member currentMember = memberUtil.getCurrentMember();
+        validateSocialInfoNotNull(currentMember);
+        return MemberSocialInfoResponse.from(currentMember);
+    }
+
+    private void validateSocialInfoNotNull(Member member) {
+        if (member.getOauthInfo() == null) {
+            throw new CustomException(ErrorCode.MEMBER_SOCIAL_INFO_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/depromeet/domain/member/domain/OauthInfo.java
+++ b/src/main/java/com/depromeet/domain/member/domain/OauthInfo.java
@@ -10,14 +10,21 @@ public class OauthInfo {
 
     private String oauthId;
     private String oauthProvider;
+    private String oauthEmail;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private OauthInfo(String oauthId, String oauthProvider) {
+    private OauthInfo(String oauthId, String oauthProvider, String oauthEmail) {
         this.oauthId = oauthId;
         this.oauthProvider = oauthProvider;
+        this.oauthEmail = oauthEmail;
     }
 
-    public static OauthInfo createOauthInfo(String oauthId, String oauthProvider) {
-        return OauthInfo.builder().oauthId(oauthId).oauthProvider(oauthProvider).build();
+    public static OauthInfo createOauthInfo(
+            String oauthId, String oauthProvider, String oauthEmail) {
+        return OauthInfo.builder()
+                .oauthId(oauthId)
+                .oauthProvider(oauthProvider)
+                .oauthEmail(oauthEmail)
+                .build();
     }
 }

--- a/src/main/java/com/depromeet/domain/member/dto/response/MemberSocialInfoResponse.java
+++ b/src/main/java/com/depromeet/domain/member/dto/response/MemberSocialInfoResponse.java
@@ -1,0 +1,12 @@
+package com.depromeet.domain.member.dto.response;
+
+import com.depromeet.domain.auth.domain.OauthProvider;
+import com.depromeet.domain.member.domain.Member;
+
+public record MemberSocialInfoResponse(OauthProvider provider, String email) {
+    public static MemberSocialInfoResponse from(Member member) {
+        return new MemberSocialInfoResponse(
+                OauthProvider.of(member.getOauthInfo().getOauthProvider()),
+                member.getOauthInfo().getOauthEmail());
+    }
+}

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
     MEMBER_INVALID_NORMAL(HttpStatus.FORBIDDEN, "일반 회원이 아닙니다."),
+    MEMBER_SOCIAL_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "소셜 정보를 찾을 수 없습니다."),
+    OAUTH_PROVIDER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "지원하지 않는 Oauth Provider입니다."),
 
     // Security
     AUTH_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보를 찾을 수 없습니다."),

--- a/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
@@ -1,0 +1,113 @@
+package com.depromeet.domain.member.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.depromeet.DatabaseCleaner;
+import com.depromeet.domain.auth.domain.OauthProvider;
+import com.depromeet.domain.member.dao.MemberRepository;
+import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.member.domain.OauthInfo;
+import com.depromeet.domain.member.dto.response.MemberSocialInfoResponse;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
+import com.depromeet.global.security.PrincipalDetails;
+import com.depromeet.global.util.MemberUtil;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@WithMockUser
+class MemberServiceTest {
+
+    @Autowired EntityManager em;
+    @Autowired DatabaseCleaner databaseCleaner;
+    @Autowired MemberUtil memberUtil;
+    @Autowired MemberService memberService;
+    @Autowired MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+    }
+
+    private void saveAndRegisterMember(OauthInfo oauthInfo) {
+        Member member = Member.createGuestMember(oauthInfo, "testNickname");
+        memberRepository.save(member);
+        member.register("testNickname");
+        PrincipalDetails principalDetails = new PrincipalDetails(1L, "USER");
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                        principalDetails, null, principalDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Nested
+    class 소셜_로그인_정보를_조회할때 {
+        @Test
+        void 성공한다() {
+            // given
+            OauthInfo oauthInfo =
+                    OauthInfo.createOauthInfo(
+                            "testOauthId", OauthProvider.KAKAO.getIssuer(), "testEmail");
+            saveAndRegisterMember(oauthInfo);
+
+            // when
+            MemberSocialInfoResponse response = memberService.findMemberSocialInfo();
+
+            // then
+            assertEquals(OauthProvider.KAKAO, response.provider());
+            assertEquals("testEmail", response.email());
+        }
+
+        @Test
+        void 멤버의_프로바이더_정보와_일치하는_issuer가_없으면_예외가_발생한다() {
+            // given
+            String invalidIssuer = "invalidIssuer";
+            OauthInfo oauthInfo =
+                    OauthInfo.createOauthInfo("testOauthId", invalidIssuer, "testEmail");
+            saveAndRegisterMember(oauthInfo);
+
+            // when & then
+            assertThrows(
+                    CustomException.class,
+                    () -> memberService.findMemberSocialInfo(),
+                    ErrorCode.OAUTH_PROVIDER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 멤버의_프로바이더가_null이면_예외가_발생한다() {
+            // given
+            OauthInfo oauthInfo = OauthInfo.createOauthInfo("testOauthId", null, "testEmail");
+            saveAndRegisterMember(oauthInfo);
+
+            // when & then
+            assertThrows(
+                    CustomException.class,
+                    () -> memberService.findMemberSocialInfo(),
+                    ErrorCode.OAUTH_PROVIDER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 멤버의_OauthInfo가_비어있으면_예외가_발생한다() {
+            // given
+            saveAndRegisterMember(null);
+
+            // when & then
+            assertThrows(
+                    CustomException.class,
+                    () -> memberService.findMemberSocialInfo(),
+                    ErrorCode.MEMBER_SOCIAL_INFO_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/depromeet/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/depromeet/domain/member/domain/MemberTest.java
@@ -23,7 +23,7 @@ class MemberTest {
         // given
         Member member =
                 Member.createGuestMember(
-                        OauthInfo.createOauthInfo("testProvider", "testProviderId"),
+                        OauthInfo.createOauthInfo("testProvider", "testProviderId", "testEmail"),
                         "testNickname");
 
         // when
@@ -38,7 +38,7 @@ class MemberTest {
         // given
         Member member =
                 Member.createGuestMember(
-                        OauthInfo.createOauthInfo("testProvider", "testProviderId"),
+                        OauthInfo.createOauthInfo("testProvider", "testProviderId", "testEmail"),
                         "testNickname");
 
         // when
@@ -53,7 +53,7 @@ class MemberTest {
         // given
         Member member =
                 Member.createGuestMember(
-                        OauthInfo.createOauthInfo("testProvider", "testProviderId"),
+                        OauthInfo.createOauthInfo("testProvider", "testProviderId", "testEmail"),
                         "testNickname");
 
         // when
@@ -68,7 +68,7 @@ class MemberTest {
         // given
         Member member =
                 Member.createGuestMember(
-                        OauthInfo.createOauthInfo("testProvider", "testProviderId"),
+                        OauthInfo.createOauthInfo("testProvider", "testProviderId", "testEmail"),
                         "testNickname");
 
         // when
@@ -83,7 +83,7 @@ class MemberTest {
         // given
         Member member =
                 Member.createGuestMember(
-                        OauthInfo.createOauthInfo("testProvider", "testProviderId"),
+                        OauthInfo.createOauthInfo("testProvider", "testProviderId", "testEmail"),
                         "testNickname");
 
         // when

--- a/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
@@ -43,7 +43,8 @@ class MissionRecordServiceTest {
         databaseCleaner.execute();
         when(securityUtil.getCurrentMemberId()).thenReturn(1L);
 
-        member = Member.createGuestMember(OauthInfo.createOauthInfo("test", "test"), "test");
+        member =
+                Member.createGuestMember(OauthInfo.createOauthInfo("test", "test", "test"), "test");
         memberRepository.save(member);
 
         mission =


### PR DESCRIPTION
## 🌱 관련 이슈
- close #213 

## 📌 작업 내용 및 특이사항
- 멤버 테이블에 oauth_email 필드 추가해서 이메일 정보 저장되도록 함
- id_token에서 이미 이메일 담아 보내주기 때문에 `oidcUser`에서 `getEmail()` 만 해주면 됨
- 소셜 로그인 정보가 아예 없는 경우 jpa가 임베디드 타입을 null로 매핑해주므로, DTO 변환 시 NPE 회피하기 위해 validate 로직 추가해줌
- 일부만 있는 경우 다음과 같이 검증함
    - 응답으로 OauthProvider enum을 직접 내려줌 (e.g. `"provider": "KAKAO"`)
    - 이때 **멤버 테이블의 oauth_provider에는 id_token의 issuer가 저장**되는데, `of` 로 순회하면서 issuer로 프로바이더 enum을 결정함
    - 따라서 각 멤버가 어떤 프로바이더에 해당하는 지 결정할 수 있음
- 테스트 코드 작성함. 테스트 코드 참고하면 로직 이해하는데 도움이 될듯 합니다

## 📝 참고사항
- 

## 📚 기타
- 
