### PR TITLE
feat: 닉네임 검색 기능

### DIFF
--- a/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepository.java
+++ b/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepository.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.follow.dao;
 
 import com.depromeet.domain.follow.domain.MemberRelation;
+import com.depromeet.domain.member.domain.Member;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,8 @@ public interface MemberRelationRepository
     Long countByTargetId(Long targetId);
 
     List<MemberRelation> findAllBySourceId(Long memberId);
+
+    List<MemberRelation> findAllBySourceIdAndTargetIn(Long sourceId, List<Member> targetIds);
+
+    List<MemberRelation> findAllByTargetId(Long targetId);
 }

--- a/src/main/java/com/depromeet/domain/follow/domain/MemberRelation.java
+++ b/src/main/java/com/depromeet/domain/follow/domain/MemberRelation.java
@@ -2,15 +2,7 @@ package com.depromeet.domain.follow.domain;
 
 import com.depromeet.domain.common.model.BaseTimeEntity;
 import com.depromeet.domain.member.domain.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/depromeet/domain/member/api/MemberController.java
+++ b/src/main/java/com/depromeet/domain/member/api/MemberController.java
@@ -4,10 +4,12 @@ import com.depromeet.domain.auth.dto.request.UsernameCheckRequest;
 import com.depromeet.domain.member.application.MemberService;
 import com.depromeet.domain.member.dto.request.NicknameCheckRequest;
 import com.depromeet.domain.member.dto.response.MemberFindOneResponse;
+import com.depromeet.domain.member.dto.response.MemberSearchResponse;
 import com.depromeet.domain.member.dto.response.MemberSocialInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -40,6 +42,12 @@ public class MemberController {
             @Valid @RequestBody NicknameCheckRequest request) {
         memberService.checkNickname(request);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "닉네임으로 회원 검색", description = "닉네임으로 회원을 검색합니다.")
+    @GetMapping("/search")
+    public List<MemberSearchResponse> memberNicknameSearch(@RequestParam String nickname) {
+        return memberService.searchMemberNickname(nickname);
     }
 
     // TODO: 테스트 코드 작성 필요

--- a/src/main/java/com/depromeet/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/depromeet/domain/member/dao/MemberRepository.java
@@ -2,8 +2,10 @@ package com.depromeet.domain.member.dao;
 
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.OauthInfo;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -16,4 +18,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
 
     Optional<Member> findByProfileNickname(String nickname);
+
+    @Query(
+            "SELECT m FROM Member m WHERE m.profile.nickname like %:searchNickname% AND m.profile.nickname != :myNickname")
+    List<Member> nicknameSearch(String searchNickname, String myNickname);
 }

--- a/src/main/java/com/depromeet/domain/member/dto/response/MemberSearchResponse.java
+++ b/src/main/java/com/depromeet/domain/member/dto/response/MemberSearchResponse.java
@@ -1,0 +1,31 @@
+package com.depromeet.domain.member.dto.response;
+
+import com.depromeet.domain.follow.dto.response.FollowStatus;
+import com.depromeet.domain.member.domain.Member;
+
+public record MemberSearchResponse(
+        Long memberId, String nickname, String profileImageUrl, FollowStatus followStatus) {
+    public static MemberSearchResponse toFollowingResponse(Member member) {
+        return new MemberSearchResponse(
+                member.getId(),
+                member.getProfile().getNickname(),
+                member.getProfile().getProfileImageUrl(),
+                FollowStatus.FOLLOWING);
+    }
+
+    public static MemberSearchResponse toNotFollowingResponse(Member member) {
+        return new MemberSearchResponse(
+                member.getId(),
+                member.getProfile().getNickname(),
+                member.getProfile().getProfileImageUrl(),
+                FollowStatus.NOT_FOLLOWING);
+    }
+
+    public static MemberSearchResponse toFollowedByMeResponse(Member member) {
+        return new MemberSearchResponse(
+                member.getId(),
+                member.getProfile().getNickname(),
+                member.getProfile().getProfileImageUrl(),
+                FollowStatus.FOLLOWED_BY_ME);
+    }
+}

--- a/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
@@ -1,13 +1,18 @@
 package com.depromeet.domain.member.application;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.depromeet.DatabaseCleaner;
 import com.depromeet.domain.auth.domain.OauthProvider;
+import com.depromeet.domain.follow.dao.MemberRelationRepository;
+import com.depromeet.domain.follow.domain.MemberRelation;
+import com.depromeet.domain.follow.dto.response.FollowStatus;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.OauthInfo;
+import com.depromeet.domain.member.domain.Profile;
+import com.depromeet.domain.member.dto.response.MemberSearchResponse;
 import com.depromeet.domain.member.dto.response.MemberSocialInfoResponse;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
@@ -25,6 +30,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
+
 @SpringBootTest
 @ActiveProfiles("test")
 @WithMockUser
@@ -35,6 +42,7 @@ class MemberServiceTest {
     @Autowired MemberUtil memberUtil;
     @Autowired MemberService memberService;
     @Autowired MemberRepository memberRepository;
+    @Autowired MemberRelationRepository memberRelationRepository;
 
     @BeforeEach
     void setUp() {
@@ -108,6 +116,147 @@ class MemberServiceTest {
                     CustomException.class,
                     () -> memberService.findMemberSocialInfo(),
                     ErrorCode.MEMBER_SOCIAL_INFO_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class 닉네임으로_회원을_검색할_때 {
+
+        @BeforeEach
+        void setUp() {
+            databaseCleaner.execute();
+            PrincipalDetails principal = new PrincipalDetails(1L, "USER");
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            principal, "password", principal.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        @Test
+        void 로그인된_회원이_존재하지_않는다면_예외를_발생시킨다() {
+            // given
+            String searchNickname = "도모";
+
+            // when, then
+            assertThatThrownBy(() -> memberService.searchMemberNickname(searchNickname))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 검색_키워드에_해당하는_닉네임이_없다면_빈_리스트가_조회된다() {
+            // given
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(Profile.createProfile("도모", "testImageUrl")));
+
+            String searchNickname = "잘생긴";
+
+            // when
+            List<MemberSearchResponse> responses =
+                    memberService.searchMemberNickname(searchNickname);
+
+            // then
+            assertEquals(0, responses.size());
+        }
+
+        @Test
+        void 검색키워드에_본인이_해당되어도_본인은_검색되지_않아야한다() {
+            // given
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(Profile.createProfile("도모", "도모 이미지 URL")));
+            Member searchMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("도모 바보", "testImageUrl")));
+
+            String searchNickname = "도모";
+
+            // when
+            List<MemberSearchResponse> responses =
+                    memberService.searchMemberNickname(searchNickname);
+
+            // then
+            assertEquals(1, responses.size());
+            assertFalse(responses.contains(currentMember.getProfile().getNickname()));
+        }
+
+        @Test
+        void 정렬조건은_일치하는경우_먼저보여주고_나머지는_사전순에_따른다() {
+            // given
+            String searchNickname = "도모";
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("currentMember", "도모 이미지 URL")));
+
+            Member searchMember1 =
+                    memberRepository.save(
+                            Member.createNormalMember(Profile.createProfile("도모1", "윤범 이미지 URL")));
+            Member searchMember2 =
+                    memberRepository.save(
+                            Member.createNormalMember(Profile.createProfile("ㄱ도모1", "윤범 이미지 URL")));
+            Member searchMember3 =
+                    memberRepository.save(
+                            Member.createNormalMember(Profile.createProfile("도모", "도모 이미지 URL")));
+
+            // when
+            List<MemberSearchResponse> responses =
+                    memberService.searchMemberNickname(searchNickname);
+
+            // then
+            assertEquals(3, responses.size());
+            assertEquals(searchMember3.getProfile().getNickname(), responses.get(0).nickname());
+            assertEquals(searchMember2.getProfile().getNickname(), responses.get(1).nickname());
+            assertEquals(searchMember1.getProfile().getNickname(), responses.get(2).nickname());
+        }
+
+        @Test
+        void 검색된_회원의_팔로우_상태를_확인할_수_있다() {
+            // given
+            String searchNickname = "잘생긴";
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(Profile.createProfile("도모", "도모 이미지 URL")));
+            Member searchMember1 =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("잘생긴 윤범", "윤범 이미지 URL")));
+            Member searchMember2 =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("잘생긴 재현", "재현 이미지 URL")));
+            Member searchMember3 =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("잘생긴 우병", "우병 이미지 URL")));
+
+            // 도모가 윤범이만 팔로우
+            memberRelationRepository.save(
+                    MemberRelation.createMemberRelation(currentMember, searchMember1));
+
+            // 도모와 재현이는 맞팔로우
+            memberRelationRepository.save(
+                    MemberRelation.createMemberRelation(currentMember, searchMember2));
+            memberRelationRepository.save(
+                    MemberRelation.createMemberRelation(searchMember2, currentMember));
+
+            // when
+            List<MemberSearchResponse> responses =
+                    memberService.searchMemberNickname(searchNickname);
+
+            // then
+            assertEquals(3, responses.size());
+
+            // 도모와 우병은 팔로우관계가 아니다.
+            assertEquals(FollowStatus.NOT_FOLLOWING, responses.get(0).followStatus());
+
+            // 도모만 윤범이를 팔로우하고있다.
+            assertEquals(FollowStatus.FOLLOWING, responses.get(1).followStatus());
+
+            // 도모는 재현이와 맞팔로우 관계이다.
+            assertEquals(FollowStatus.FOLLOWED_BY_ME, responses.get(2).followStatus());
         }
     }
 }

--- a/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
@@ -19,6 +19,7 @@ import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.security.PrincipalDetails;
 import com.depromeet.global.util.MemberUtil;
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,8 +30,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.util.List;
 
 @SpringBootTest
 @ActiveProfiles("test")


### PR DESCRIPTION
## 🌱 관련 이슈
- close #217 

## 📌 작업 내용 및 특이사항
<img src="https://github.com/depromeet/10mm-server/assets/64088250/7d3bc7bf-dd9a-4d45-afef-affc602f7673" width="300"/>

- 닉네임으로 유저 검색하는 기능을 추가합니다
- 닉네임 검색 시 해당 유저의 프로필 이미지, 닉네임, 팔로우 상태를 응답합니다.
- 검색 정렬조건에 키워드가 일치하는경우 최상단이고 그 이후로는 사전순 입니다.
- 비지니스 로직 테스트코드 작성해놓았으니 참고 부탁드립니당


## 📚 기타
- 검색 특이 케이스 자음에 받침이 들어간 경우는 형태소 분석이 필요하다고 판단하였고 리소스를 고려하여 우선순위 낮다고 판단
<img src="https://github.com/depromeet/10mm-server/assets/64088250/2d76088b-690d-4c60-a27c-c0f7acf6ffa2"  width="300"/>
