### PR TITLE
refactor: Image 업로드 시 ImageKey 관리

### DIFF
--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -28,7 +28,6 @@ import com.depromeet.global.util.SpringEnvironmentUtil;
 import com.depromeet.infra.config.storage.StorageProperties;
 import java.util.Date;
 import java.util.UUID;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,7 +70,12 @@ public class ImageService {
 
         missionRecord.updateUploadStatusPending();
         missionRecordTtlRepository.deleteById(request.missionRecordId());
-        imageRepository.save(Image.createImage(ImageType.MISSION_RECORD, request.missionRecordId(), imageKey, request.imageFileExtension()));
+        imageRepository.save(
+                Image.createImage(
+                        ImageType.MISSION_RECORD,
+                        request.missionRecordId(),
+                        imageKey,
+                        request.imageFileExtension()));
         return PresignedUrlResponse.from(presignedUrl);
     }
 
@@ -82,7 +86,11 @@ public class ImageService {
         Mission mission = missionRecord.getMission();
         validateMissionRecordUserMismatch(mission, currentMember);
 
-        Image image = findImage(ImageType.MISSION_RECORD, request.missionRecordId(), request.imageFileExtension());
+        Image image =
+                findImage(
+                        ImageType.MISSION_RECORD,
+                        request.missionRecordId(),
+                        request.imageFileExtension());
         String imageUrl =
                 createReadImageUrl(
                         ImageType.MISSION_RECORD,
@@ -117,7 +125,11 @@ public class ImageService {
         final Member currentMember = memberUtil.getCurrentMember();
         String imageUrl = null;
         if (request.imageFileExtension() != null) {
-            Image image = findImage(ImageType.MEMBER_PROFILE, currentMember.getId(), request.imageFileExtension());
+            Image image =
+                    findImage(
+                            ImageType.MEMBER_PROFILE,
+                            currentMember.getId(),
+                            request.imageFileExtension());
             imageUrl =
                     createReadImageUrl(
                             ImageType.MEMBER_PROFILE,
@@ -128,8 +140,10 @@ public class ImageService {
         currentMember.updateProfile(Profile.createProfile(request.nickname(), imageUrl));
     }
 
-    private Image findImage(ImageType imageType, Long targetId, ImageFileExtension imageFileExtension) {
-        return imageRepository.queryImageKey(imageType, targetId, imageFileExtension)
+    private Image findImage(
+            ImageType imageType, Long targetId, ImageFileExtension imageFileExtension) {
+        return imageRepository
+                .queryImageKey(imageType, targetId, imageFileExtension)
                 .orElseThrow(() -> new CustomException(ErrorCode.IMAGE_KEY_NOT_FOUND));
     }
 
@@ -144,7 +158,10 @@ public class ImageService {
     }
 
     private String createFileName(
-            ImageType imageType, Long targetId, String imageKey, ImageFileExtension imageFileExtension) {
+            ImageType imageType,
+            Long targetId,
+            String imageKey,
+            ImageFileExtension imageFileExtension) {
         return springEnvironmentUtil.getCurrentProfile()
                 + "/"
                 + imageType.getValue()
@@ -157,7 +174,10 @@ public class ImageService {
     }
 
     private String createUploadImageUrl(
-            ImageType imageType, Long targetId, String imageKey, ImageFileExtension imageFileExtension) {
+            ImageType imageType,
+            Long targetId,
+            String imageKey,
+            ImageFileExtension imageFileExtension) {
         return storageProperties.endpoint()
                 + "/"
                 + storageProperties.bucket()
@@ -174,7 +194,10 @@ public class ImageService {
     }
 
     private String createReadImageUrl(
-            ImageType imageType, Long targetId, String imageKey, ImageFileExtension imageFileExtension) {
+            ImageType imageType,
+            Long targetId,
+            String imageKey,
+            ImageFileExtension imageFileExtension) {
         return UrlConstants.IMAGE_DOMAIN_URL.getValue()
                 + "/"
                 + springEnvironmentUtil.getCurrentProfile()

--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.depromeet.domain.image.dao.ImageRepository;
+import com.depromeet.domain.image.domain.Image;
 import com.depromeet.domain.image.domain.ImageFileExtension;
 import com.depromeet.domain.image.domain.ImageType;
 import com.depromeet.domain.image.dto.request.MemberProfileImageCreateRequest;
@@ -18,12 +20,15 @@ import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.domain.missionRecord.dao.MissionRecordTtlRepository;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.global.common.constants.UrlConstants;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
 import com.depromeet.global.util.SpringEnvironmentUtil;
 import com.depromeet.infra.config.storage.StorageProperties;
 import java.util.Date;
+import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,6 +43,7 @@ public class ImageService {
     private final AmazonS3 amazonS3;
     private final MissionRecordRepository missionRecordRepository;
     private final MissionRecordTtlRepository missionRecordTtlRepository;
+    private final ImageRepository imageRepository;
 
     public PresignedUrlResponse createMissionRecordPresignedUrl(
             MissionRecordImageCreateRequest request) {
@@ -48,10 +54,12 @@ public class ImageService {
         Mission mission = missionRecord.getMission();
         validateMissionRecordUserMismatch(mission, currentMember);
 
+        String imageKey = generateUUID();
         String fileName =
                 createFileName(
                         ImageType.MISSION_RECORD,
                         request.missionRecordId(),
+                        imageKey,
                         request.imageFileExtension());
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 createGeneratePreSignedUrlRequest(
@@ -63,6 +71,7 @@ public class ImageService {
 
         missionRecord.updateUploadStatusPending();
         missionRecordTtlRepository.deleteById(request.missionRecordId());
+        imageRepository.save(Image.createImage(ImageType.MISSION_RECORD, request.missionRecordId(), imageKey, request.imageFileExtension()));
         return PresignedUrlResponse.from(presignedUrl);
     }
 
@@ -73,10 +82,12 @@ public class ImageService {
         Mission mission = missionRecord.getMission();
         validateMissionRecordUserMismatch(mission, currentMember);
 
+        Image image = findImage(ImageType.MISSION_RECORD, request.missionRecordId(), request.imageFileExtension());
         String imageUrl =
-                createImageUrl(
+                createReadImageUrl(
                         ImageType.MISSION_RECORD,
                         request.missionRecordId(),
+                        image.getImageKey(),
                         request.imageFileExtension());
         missionRecord.updateUploadStatusComplete(request.remark(), imageUrl);
     }
@@ -85,10 +96,12 @@ public class ImageService {
             MemberProfileImageCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
 
+        String imageKey = generateUUID();
         String fileName =
                 createFileName(
                         ImageType.MEMBER_PROFILE,
                         currentMember.getId(),
+                        imageKey,
                         request.imageFileExtension());
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 createGeneratePreSignedUrlRequest(
@@ -104,13 +117,24 @@ public class ImageService {
         final Member currentMember = memberUtil.getCurrentMember();
         String imageUrl = null;
         if (request.imageFileExtension() != null) {
+            Image image = findImage(ImageType.MEMBER_PROFILE, currentMember.getId(), request.imageFileExtension());
             imageUrl =
-                    createImageUrl(
+                    createReadImageUrl(
                             ImageType.MEMBER_PROFILE,
                             currentMember.getId(),
+                            image.getImageKey(),
                             request.imageFileExtension());
         }
         currentMember.updateProfile(Profile.createProfile(request.nickname(), imageUrl));
+    }
+
+    private Image findImage(ImageType imageType, Long targetId, ImageFileExtension imageFileExtension) {
+        return imageRepository.queryImageKey(imageType, targetId, imageFileExtension)
+                .orElseThrow(() -> new CustomException(ErrorCode.IMAGE_KEY_NOT_FOUND));
+    }
+
+    private String generateUUID() {
+        return UUID.randomUUID().toString();
     }
 
     private MissionRecord findMissionRecordById(Long request) {
@@ -120,18 +144,20 @@ public class ImageService {
     }
 
     private String createFileName(
-            ImageType imageType, Long targetId, ImageFileExtension imageFileExtension) {
+            ImageType imageType, Long targetId, String imageKey, ImageFileExtension imageFileExtension) {
         return springEnvironmentUtil.getCurrentProfile()
                 + "/"
                 + imageType.getValue()
                 + "/"
                 + targetId
-                + "/image."
+                + "/"
+                + imageKey
+                + "."
                 + imageFileExtension.getUploadExtension();
     }
 
-    private String createImageUrl(
-            ImageType imageType, Long targetId, ImageFileExtension imageFileExtension) {
+    private String createUploadImageUrl(
+            ImageType imageType, Long targetId, String imageKey, ImageFileExtension imageFileExtension) {
         return storageProperties.endpoint()
                 + "/"
                 + storageProperties.bucket()
@@ -141,7 +167,24 @@ public class ImageService {
                 + imageType.getValue()
                 + "/"
                 + targetId
-                + "/image."
+                + "/"
+                + imageKey
+                + "."
+                + imageFileExtension.getUploadExtension();
+    }
+
+    private String createReadImageUrl(
+            ImageType imageType, Long targetId, String imageKey, ImageFileExtension imageFileExtension) {
+        return UrlConstants.IMAGE_DOMAIN_URL.getValue()
+                + "/"
+                + springEnvironmentUtil.getCurrentProfile()
+                + "/"
+                + imageType.getValue()
+                + "/"
+                + targetId
+                + "/"
+                + imageKey
+                + "."
                 + imageFileExtension.getUploadExtension();
     }
 

--- a/src/main/java/com/depromeet/domain/image/dao/ImageRepository.java
+++ b/src/main/java/com/depromeet/domain/image/dao/ImageRepository.java
@@ -3,12 +3,13 @@ package com.depromeet.domain.image.dao;
 import com.depromeet.domain.image.domain.Image;
 import com.depromeet.domain.image.domain.ImageFileExtension;
 import com.depromeet.domain.image.domain.ImageType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.Optional;
-
 public interface ImageRepository extends JpaRepository<Image, Long> {
-    @Query("select i from Image i where i.imageType = :imageType and i.targetId = :targetId and i.imageFileExtension = :imageFileExtension order by i.id desc limit 1")
-    Optional<Image> queryImageKey(ImageType imageType, Long targetId, ImageFileExtension imageFileExtension);
+    @Query(
+            "select i from Image i where i.imageType = :imageType and i.targetId = :targetId and i.imageFileExtension = :imageFileExtension order by i.id desc limit 1")
+    Optional<Image> queryImageKey(
+            ImageType imageType, Long targetId, ImageFileExtension imageFileExtension);
 }

--- a/src/main/java/com/depromeet/domain/image/dao/ImageRepository.java
+++ b/src/main/java/com/depromeet/domain/image/dao/ImageRepository.java
@@ -1,0 +1,14 @@
+package com.depromeet.domain.image.dao;
+
+import com.depromeet.domain.image.domain.Image;
+import com.depromeet.domain.image.domain.ImageFileExtension;
+import com.depromeet.domain.image.domain.ImageType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    @Query("select i from Image i where i.imageType = :imageType and i.targetId = :targetId and i.imageFileExtension = :imageFileExtension order by i.id desc limit 1")
+    Optional<Image> queryImageKey(ImageType imageType, Long targetId, ImageFileExtension imageFileExtension);
+}

--- a/src/main/java/com/depromeet/domain/image/domain/Image.java
+++ b/src/main/java/com/depromeet/domain/image/domain/Image.java
@@ -1,0 +1,55 @@
+package com.depromeet.domain.image.domain;
+
+import com.depromeet.domain.common.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ImageType imageType;
+
+    private Long targetId;
+
+    private String imageKey;
+
+    @Enumerated(EnumType.STRING)
+    private ImageFileExtension imageFileExtension;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Image(
+            Long id,
+            ImageType imageType,
+            Long targetId,
+            String imageKey,
+            ImageFileExtension imageFileExtension) {
+        this.id = id;
+        this.imageType = imageType;
+        this.targetId = targetId;
+        this.imageKey = imageKey;
+        this.imageFileExtension = imageFileExtension;
+    }
+
+    public static Image createImage(
+            ImageType imageType,
+            Long targetId,
+            String imageKey,
+            ImageFileExtension imageFileExtension) {
+        return Image.builder()
+                .imageType(imageType)
+                .targetId(targetId)
+                .imageKey(imageKey)
+                .imageFileExtension(imageFileExtension)
+                .build();
+    }
+}

--- a/src/main/java/com/depromeet/domain/image/domain/Image.java
+++ b/src/main/java/com/depromeet/domain/image/domain/Image.java
@@ -21,6 +21,7 @@ public class Image extends BaseTimeEntity {
 
     private Long targetId;
 
+    @Column(length = 36)
     private String imageKey;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/depromeet/domain/member/domain/Profile.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Profile.java
@@ -8,8 +8,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
     private String nickname;
-    @Getter
-    private String profileImageUrl;
+    @Getter private String profileImageUrl;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Profile(String nickname, String profileImageUrl) {

--- a/src/main/java/com/depromeet/domain/member/domain/Profile.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Profile.java
@@ -8,6 +8,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
     private String nickname;
+    @Getter
     private String profileImageUrl;
 
     @Builder(access = AccessLevel.PRIVATE)
@@ -18,13 +19,5 @@ public class Profile {
 
     public static Profile createProfile(String nickname, String profileImageUrl) {
         return Profile.builder().nickname(nickname).profileImageUrl(profileImageUrl).build();
-    }
-
-    // TODO: 이미지 업로드 로직 개선후 timestamp 제거
-    public String getProfileImageUrl() {
-        if (profileImageUrl == null) {
-            return null;
-        }
-        return profileImageUrl + "?timestamp=" + System.currentTimeMillis();
     }
 }

--- a/src/main/java/com/depromeet/global/common/constants/UrlConstants.java
+++ b/src/main/java/com/depromeet/global/common/constants/UrlConstants.java
@@ -13,6 +13,8 @@ public enum UrlConstants {
     PROD_DOMAIN_URL("https://www.10mm.today"),
     DEV_DOMAIN_URL("https://www.dev.10mm.today"),
     LOCAL_DOMAIN_URL("http://localhost:3000"),
+
+    IMAGE_DOMAIN_URL("https://image.10mm.today"),
     ;
 
     private String value;

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -52,6 +52,9 @@ public enum ErrorCode {
     FOLLOW_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "타겟 유저을 찾을 수 없습니다."),
     FOLLOW_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 팔로우 중인 회원입니다."),
     FOLLOW_NOT_EXIST(HttpStatus.BAD_REQUEST, "팔로우 중인 회원만 팔로우 취소가 가능합니다."),
+
+    // Image
+    IMAGE_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지 키를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -57,18 +57,17 @@ class ImageServiceTest {
 
     @Nested
     class 미션_기록_이미지_PresignedUrl을_생성할_때 {
-        // TODO: MemberUtil insertMockMemberIfNotExist메서드 제거 후 주석해제 예정
-        // @Test
-        // void 회원이_존재하지_않는다면_예외를_발생시킨다() {
-        // 	// given
-        // 	MissionRecordImageCreateRequest request =
-        // 		new MissionRecordImageCreateRequest(192L, ImageFileExtension.JPEG);
-        //
-        // 	// when, then
-        // 	assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
-        // 		.isInstanceOf(CustomException.class)
-        // 		.hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
-        // }
+         @Test
+         void 회원이_존재하지_않는다면_예외를_발생시킨다() {
+         	// given
+         	MissionRecordImageCreateRequest request =
+         		new MissionRecordImageCreateRequest(192L, ImageFileExtension.JPEG);
+
+         	// when, then
+         	assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
+         		.isInstanceOf(CustomException.class)
+         		.hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+         }
 
         @Test
         void 미션이_존재하지_않는다면_예외를_발생시킨다() {
@@ -84,54 +83,6 @@ class ImageServiceTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.MISSION_RECORD_NOT_FOUND.getMessage());
         }
-
-        //        TODO: SecurityUtil setMockAuthentication메서드 제거 후 주석해제 예정
-        //        @Test
-        //        void 미션을_생성한_유저와_로그인_유저가_일치하지_않는다면_예외를_발생시킨다() {
-        //            // given
-        //            memberRepository.save(
-        //                    Member.createNormalMember(new Profile("testNickname",
-        // "testImageUrl")));
-        //            MissionCreateRequest missionCreateRequest =
-        //                    new MissionCreateRequest(
-        //                            "testMissionName",
-        //                            "testMissionContent",
-        //                            MissionCategory.STUDY,
-        //                            MissionVisibility.ALL);
-        //            MissionCreateResponse missionCreateResponse =
-        //                    missionService.createMission(missionCreateRequest);
-        //
-        //            SecurityContextHolder.clearContext();
-        //            PrincipalDetails principal = new PrincipalDetails(2L, "USER");
-        //            Authentication authentication =
-        //                    new UsernamePasswordAuthenticationToken(
-        //                            principal, "password", principal.getAuthorities());
-        //            SecurityContextHolder.getContext().setAuthentication(authentication);
-        //
-        //
-        //            LocalDateTime missionRecordStartedAt = LocalDateTime.of(2023, 12, 15, 1, 5,
-        // 0);
-        //            LocalDateTime missionRecordFinishedAt =
-        //                    missionRecordStartedAt.plusMinutes(32).plusSeconds(14);
-        //            MissionRecordCreateRequest missionRecordCreateRequest =
-        //                    new MissionRecordCreateRequest(
-        //                            missionCreateResponse.missionId(),
-        //                            missionRecordStartedAt,
-        //                            missionRecordFinishedAt,
-        //                            32,
-        //                            14);
-        //            Long missionRecord =
-        //                    missionRecordService.createMissionRecord(missionRecordCreateRequest);
-        //            MissionRecordImageCreateRequest request =
-        //                    new MissionRecordImageCreateRequest(missionRecord,
-        // ImageFileExtension.JPEG);
-        //
-        //            // when, then
-        //            assertThatThrownBy(() ->
-        // imageService.createMissionRecordPresignedUrl(request))
-        //                    .isInstanceOf(CustomException.class)
-        //                    .hasMessage(ErrorCode.MISSION_RECORD_USER_MISMATCH.getMessage());
-        //        }
 
         @Test
         void 입력_값이_정상이라면_예외가_발생하지_않는다() {
@@ -209,29 +160,27 @@ class ImageServiceTest {
 
             // then
             assertThat(missionRecordPresignedUrl.presignedUrl())
-                    .contains(
+                    .containsPattern(
                             String.format(
-                                    "/local/mission_record/%s/image.jpeg",
+                                    "/local/mission_record/%s/.*\\.jpeg",
                                     missionRecordCreateResponse.missionId()));
         }
     }
 
     @Nested
     class 미션_기록_이미지_업로드_완료_처리할_때 {
+         @Test
+         void 회원이_존재하지_않는다면_예외를_발생시킨다() {
+            // given
+             MissionRecordImageUploadCompleteRequest request =
+                new MissionRecordImageUploadCompleteRequest(192L, ImageFileExtension.JPEG,
+ "testRemark");
 
-        // TODO: MemberUtil insertMockMemberIfNotExist메서드 제거 후 주석해제 예정
-        //         @Test
-        //         void 회원이_존재하지_않는다면_예외를_발생시킨다() {
-        //         	// given
-        //             MissionRecordImageUploadCompleteRequest request =
-        //         		new MissionRecordImageUploadCompleteRequest(192L, ImageFileExtension.JPEG,
-        // "testRemark");
-        //
-        //         	// when, then
-        //         	assertThatThrownBy(() -> imageService.uploadCompleteMissionRecord(request))
-        //         		.isInstanceOf(CustomException.class)
-        //         		.hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
-        //         }
+            // when, then
+            assertThatThrownBy(() -> imageService.uploadCompleteMissionRecord(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+         }
 
         @Test
         void 미션이_존재하지_않는다면_예외를_발생시킨다() {
@@ -299,9 +248,9 @@ class ImageServiceTest {
             assertThat(missionRecord.getUploadStatus()).isEqualTo(ImageUploadStatus.COMPLETE);
             assertThat(missionRecord.getRemark()).isEqualTo("testRemark");
             assertThat(missionRecord.getImageUrl())
-                    .contains(
+                    .containsPattern(
                             String.format(
-                                    "/local/mission_record/%s/image.jpeg",
+                                    "/local/mission_record/%s/.*\\.jpeg",
                                     missionRecordCreateResponse.missionId()));
         }
     }

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -57,17 +57,17 @@ class ImageServiceTest {
 
     @Nested
     class 미션_기록_이미지_PresignedUrl을_생성할_때 {
-         @Test
-         void 회원이_존재하지_않는다면_예외를_발생시킨다() {
-         	// given
-         	MissionRecordImageCreateRequest request =
-         		new MissionRecordImageCreateRequest(192L, ImageFileExtension.JPEG);
+        @Test
+        void 회원이_존재하지_않는다면_예외를_발생시킨다() {
+            // given
+            MissionRecordImageCreateRequest request =
+                    new MissionRecordImageCreateRequest(192L, ImageFileExtension.JPEG);
 
-         	// when, then
-         	assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
-         		.isInstanceOf(CustomException.class)
-         		.hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
-         }
+            // when, then
+            assertThatThrownBy(() -> imageService.createMissionRecordPresignedUrl(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
 
         @Test
         void 미션이_존재하지_않는다면_예외를_발생시킨다() {
@@ -169,18 +169,18 @@ class ImageServiceTest {
 
     @Nested
     class 미션_기록_이미지_업로드_완료_처리할_때 {
-         @Test
-         void 회원이_존재하지_않는다면_예외를_발생시킨다() {
+        @Test
+        void 회원이_존재하지_않는다면_예외를_발생시킨다() {
             // given
-             MissionRecordImageUploadCompleteRequest request =
-                new MissionRecordImageUploadCompleteRequest(192L, ImageFileExtension.JPEG,
- "testRemark");
+            MissionRecordImageUploadCompleteRequest request =
+                    new MissionRecordImageUploadCompleteRequest(
+                            192L, ImageFileExtension.JPEG, "testRemark");
 
             // when, then
             assertThatThrownBy(() -> imageService.uploadCompleteMissionRecord(request))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
-         }
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
 
         @Test
         void 미션이_존재하지_않는다면_예외를_발생시킨다() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #185 

## 📌 작업 내용 및 특이사항
- Image Key를 담을 Image Domain을 생성하였습니다.
- 이미지 업로드 시 UUID를 통해 이미지 키를 생성하고 저장합니다.
- 이미지 업로드 처리 완료시에 이미지 키를 조회하고 해당 이미지 키 값을 사용하여 ImageUrl을 설정합니다.
- ImageUrl을 설정하는 부분에서 CDN 주소를 사용하도록 추가하였습니다.
- 테스트코드에 파일명 이스케이프 처리하였습니다.
