### PR TITLE
hotfix: 회원 정보 조회 시 ImageFileExtension도 같이 응답하도록 수정

### DIFF
--- a/src/main/java/com/depromeet/domain/image/domain/ImageFileExtension.java
+++ b/src/main/java/com/depromeet/domain/image/domain/ImageFileExtension.java
@@ -1,7 +1,12 @@
 package com.depromeet.domain.image.domain;
 
+import com.depromeet.domain.auth.domain.OauthProvider;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.Arrays;
 
 @Getter
 @AllArgsConstructor
@@ -12,4 +17,11 @@ public enum ImageFileExtension {
     ;
 
     private final String uploadExtension;
+
+            public static ImageFileExtension of(String uploadExtension) {
+            return Arrays.stream(values())
+                    .filter(imageFileExtension -> imageFileExtension.uploadExtension.equals(uploadExtension))
+                    .findFirst()
+                    .orElseThrow(() -> new CustomException(ErrorCode.IMAGE_FILE_EXTENSION_NOT_FOUND));
+        }
 }

--- a/src/main/java/com/depromeet/domain/image/domain/ImageFileExtension.java
+++ b/src/main/java/com/depromeet/domain/image/domain/ImageFileExtension.java
@@ -1,12 +1,10 @@
 package com.depromeet.domain.image.domain;
 
-import com.depromeet.domain.auth.domain.OauthProvider;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import java.util.Arrays;
 
 @Getter
 @AllArgsConstructor
@@ -18,10 +16,12 @@ public enum ImageFileExtension {
 
     private final String uploadExtension;
 
-            public static ImageFileExtension of(String uploadExtension) {
-            return Arrays.stream(values())
-                    .filter(imageFileExtension -> imageFileExtension.uploadExtension.equals(uploadExtension))
-                    .findFirst()
-                    .orElseThrow(() -> new CustomException(ErrorCode.IMAGE_FILE_EXTENSION_NOT_FOUND));
-        }
+    public static ImageFileExtension of(String uploadExtension) {
+        return Arrays.stream(values())
+                .filter(
+                        imageFileExtension ->
+                                imageFileExtension.uploadExtension.equals(uploadExtension))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.IMAGE_FILE_EXTENSION_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -4,8 +4,10 @@ import com.depromeet.domain.auth.dao.RefreshTokenRepository;
 import com.depromeet.domain.auth.dto.request.UsernameCheckRequest;
 import com.depromeet.domain.follow.dao.MemberRelationRepository;
 import com.depromeet.domain.follow.domain.MemberRelation;
+import com.depromeet.domain.image.domain.ImageFileExtension;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.member.domain.Profile;
 import com.depromeet.domain.member.dto.request.NicknameCheckRequest;
 import com.depromeet.domain.member.dto.response.MemberFindOneResponse;
 import com.depromeet.domain.member.dto.response.MemberSearchResponse;
@@ -35,7 +37,18 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberFindOneResponse findMemberInfo() {
         final Member currentMember = memberUtil.getCurrentMember();
-        return MemberFindOneResponse.from(currentMember);
+
+        // TODO: 이미지 확장자 정보 같이 넘겨주는 작업 추가 (24.01.26)
+        // 이미지 업로드와 닉네임 변경 분리 후 제거 예정
+        ImageFileExtension imageFileExtension = null;
+        Profile profile = currentMember.getProfile();
+        if (profile.getProfileImageUrl() != null) {
+            String profileImageUrl = profile.getProfileImageUrl();
+            String extension = profileImageUrl.substring(profileImageUrl.lastIndexOf(".") + 1);
+            System.out.println("extension = " + extension);
+            imageFileExtension = ImageFileExtension.of(extension);
+        }
+        return MemberFindOneResponse.of(currentMember, imageFileExtension);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/depromeet/domain/member/dto/response/MemberFindOneResponse.java
+++ b/src/main/java/com/depromeet/domain/member/dto/response/MemberFindOneResponse.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.member.dto.response;
 
+import com.depromeet.domain.image.domain.ImageFileExtension;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.MemberRole;
 import com.depromeet.domain.member.domain.MemberStatus;
@@ -10,17 +11,19 @@ public record MemberFindOneResponse(
         Long memberId,
         String nickname,
         String profileImageUrl,
+        ImageFileExtension imageFileExtension,
         MemberStatus memberStatus,
         MemberRole memberRole,
         MemberVisibility memberVisibility,
         String username,
         LocalDateTime createdAt,
         LocalDateTime updatedAt) {
-    public static MemberFindOneResponse from(Member member) {
+    public static MemberFindOneResponse of(Member member, ImageFileExtension imageFileExtension) {
         return new MemberFindOneResponse(
                 member.getId(),
                 member.getProfile().getNickname(),
                 member.getProfile().getProfileImageUrl(),
+                imageFileExtension,
                 member.getStatus(),
                 member.getRole(),
                 member.getVisibility(),

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
 
     // Image
     IMAGE_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지 키를 찾을 수 없습니다."),
+    IMAGE_FILE_EXTENSION_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지 파일 형식을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #228 

## 📌 작업 내용 및 특이사항
- 프론트 요청으로 인해 `ImageFileExtension`을 응답하도록 추가합니다.
- `ImageFileExtension`을 응답하는 이유는 현재 이미지 변경과 닉네임 변경이 통합되어있어, 추 후 이를 분리하고 제거 할 예정

