### PR TITLE
hotfix: 회원 프로필 이미지 변경 PresignedUrl 발급 시 이미지 키 생성

### DIFF
--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -118,6 +118,12 @@ public class ImageService {
                         request.imageFileExtension().getUploadExtension());
 
         String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+        imageRepository.save(
+                Image.createImage(
+                        ImageType.MEMBER_PROFILE,
+                        currentMember.getId(),
+                        imageKey,
+                        request.imageFileExtension()));
         return PresignedUrlResponse.from(presignedUrl);
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #232

## 📌 작업 내용 및 특이사항
- 회원 PresignedUrl 발급 시 이미지 키를 저장하지 않아서 회원 프로필 이미지 수정되지 않는 문제를 해결