### PR TITLE
feat: 랜덤 닉네임 기능 도입에 따른 `GUEST` 상태 제거

### DIFF
--- a/src/main/java/com/depromeet/domain/auth/api/AuthController.java
+++ b/src/main/java/com/depromeet/domain/auth/api/AuthController.java
@@ -26,10 +26,11 @@ public class AuthController {
     private final AuthService authService;
     private final CookieUtil cookieUtil;
 
-    @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
+    @Deprecated
+    @Operation(summary = "회원가입", description = "회원가입을 진행합니다. (현재 사용하지 않습니다.)")
     @PostMapping("/register")
     public ResponseEntity<Void> memberRegister(@Valid @RequestBody MemberRegisterRequest request) {
-        authService.registerMember(request);
+        // do nothing
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/depromeet/domain/auth/api/AuthController.java
+++ b/src/main/java/com/depromeet/domain/auth/api/AuthController.java
@@ -34,6 +34,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
+    @Deprecated
     @Operation(summary = "아이디/비밀번호 임시 회원가입", description = "아이디/비밀번호 임시 회원가입을 진행합니다.")
     @PostMapping("/temp-register")
     public ResponseEntity<TokenPairResponse> memberTempRegister(
@@ -47,6 +48,7 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).headers(tokenHeaders).body(response);
     }
 
+    @Deprecated
     @Operation(summary = "로그인", description = "토큰 발급을 위해 로그인을 진행합니다.")
     @PostMapping("/login")
     public ResponseEntity<TokenPairResponse> memberLogin(

--- a/src/main/java/com/depromeet/domain/auth/application/AuthService.java
+++ b/src/main/java/com/depromeet/domain/auth/application/AuthService.java
@@ -13,16 +13,13 @@ import com.depromeet.domain.member.domain.OauthInfo;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
-
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Slf4j
 @Service

--- a/src/main/java/com/depromeet/domain/auth/application/AuthService.java
+++ b/src/main/java/com/depromeet/domain/auth/application/AuthService.java
@@ -3,7 +3,6 @@ package com.depromeet.domain.auth.application;
 import com.depromeet.domain.auth.application.nickname.NicknameGenerationStrategy;
 import com.depromeet.domain.auth.domain.OauthProvider;
 import com.depromeet.domain.auth.dto.request.IdTokenRequest;
-import com.depromeet.domain.auth.dto.request.MemberRegisterRequest;
 import com.depromeet.domain.auth.dto.request.UsernamePasswordRequest;
 import com.depromeet.domain.auth.dto.response.SocialLoginResponse;
 import com.depromeet.domain.auth.dto.response.TokenPairResponse;
@@ -35,11 +34,6 @@ public class AuthService {
     private final JwtTokenService jwtTokenService;
     private final IdTokenVerifier idTokenVerifier;
     private final NicknameGenerationStrategy nicknameGenerationStrategy;
-
-    public void registerMember(MemberRegisterRequest request) {
-        final Member member = memberUtil.getCurrentMember();
-        member.register(request.nickname());
-    }
 
     public TokenPairResponse registerWithUsernameAndPassword(UsernamePasswordRequest request) {
         Optional<Member> member = memberRepository.findByUsername(request.username());

--- a/src/main/java/com/depromeet/domain/auth/application/AuthService.java
+++ b/src/main/java/com/depromeet/domain/auth/application/AuthService.java
@@ -104,15 +104,15 @@ public class AuthService {
     private Member fetchOrCreate(OidcUser oidcUser) {
         return memberRepository
                 .findByOauthInfo(extractOauthInfo(oidcUser))
-                .orElseGet(() -> saveAsGuest(oidcUser));
+                .orElseGet(() -> saveMember(oidcUser));
     }
 
-    private Member saveAsGuest(OidcUser oidcUser) {
+    private Member saveMember(OidcUser oidcUser) {
 
         OauthInfo oauthInfo = extractOauthInfo(oidcUser);
         String nickname = generateRandomNickname();
-        Member guest = Member.createNormalMember(oauthInfo, nickname);
-        return memberRepository.save(guest);
+        Member member = Member.createNormalMember(oauthInfo, nickname);
+        return memberRepository.save(member);
     }
 
     private String generateRandomNickname() {

--- a/src/main/java/com/depromeet/domain/auth/application/AuthService.java
+++ b/src/main/java/com/depromeet/domain/auth/application/AuthService.java
@@ -13,13 +13,16 @@ import com.depromeet.domain.member.domain.OauthInfo;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -34,14 +37,14 @@ public class AuthService {
     private final IdTokenVerifier idTokenVerifier;
     private final NicknameGenerationStrategy nicknameGenerationStrategy;
 
+    @Deprecated
     public TokenPairResponse registerWithUsernameAndPassword(UsernamePasswordRequest request) {
         Optional<Member> member = memberRepository.findByUsername(request.username());
 
         // 첫 회원가입
         if (member.isEmpty()) {
             String encodedPassword = passwordEncoder.encode(request.password());
-            final Member savedMember =
-                    Member.createNormalMember(request.username(), encodedPassword);
+            final Member savedMember = Member.createNormalMember(null, null); // do nothing
             memberRepository.save(savedMember);
             return getLoginResponse(savedMember);
         }

--- a/src/main/java/com/depromeet/domain/auth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/depromeet/domain/auth/dto/response/SocialLoginResponse.java
@@ -4,10 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SocialLoginResponse(
         @Schema(description = "엑세스 토큰", defaultValue = "accessToken") String accessToken,
-        @Schema(description = "리프레시 토큰", defaultValue = "refreshToken") String refreshToken) {
+        @Schema(description = "리프레시 토큰", defaultValue = "refreshToken") String refreshToken,
+        @Schema(description = "게스트 여부", defaultValue = "false") boolean isGuest) {
 
     public static SocialLoginResponse from(TokenPairResponse tokenPairResponse) {
         return new SocialLoginResponse(
-                tokenPairResponse.accessToken(), tokenPairResponse.refreshToken());
+                tokenPairResponse.accessToken(), tokenPairResponse.refreshToken(), false);
     }
 }

--- a/src/main/java/com/depromeet/domain/auth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/depromeet/domain/auth/dto/response/SocialLoginResponse.java
@@ -4,11 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SocialLoginResponse(
         @Schema(description = "엑세스 토큰", defaultValue = "accessToken") String accessToken,
-        @Schema(description = "리프레시 토큰", defaultValue = "refreshToken") String refreshToken,
-        @Schema(description = "게스트 여부", defaultValue = "true") boolean isGuest) {
+        @Schema(description = "리프레시 토큰", defaultValue = "refreshToken") String refreshToken) {
 
-    public static SocialLoginResponse from(TokenPairResponse tokenPairResponse, boolean isGuest) {
+    public static SocialLoginResponse from(TokenPairResponse tokenPairResponse) {
         return new SocialLoginResponse(
-                tokenPairResponse.accessToken(), tokenPairResponse.refreshToken(), isGuest);
+                tokenPairResponse.accessToken(), tokenPairResponse.refreshToken());
     }
 }

--- a/src/main/java/com/depromeet/domain/member/domain/Member.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Member.java
@@ -108,15 +108,6 @@ public class Member extends BaseTimeEntity {
         this.lastLoginAt = LocalDateTime.now();
     }
 
-    public void register(String nickname) {
-        validateRegisterAvailable();
-        // TODO: Profile 클래스를 제거하고 Member 클래스 필드로 변경
-        // TODO: profileImageUrl이 항상 null이 되는 문제 해결
-        // TODO: Profile.createProfile에서 url에 null이 아닌 this.profile.getProfileImageUrl()을 넣어야 함
-        this.profile = Profile.createProfile(nickname, null);
-        this.role = MemberRole.USER;
-    }
-
     public void updateProfile(Profile profile) {
         this.profile = profile;
     }

--- a/src/main/java/com/depromeet/domain/member/domain/Member.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Member.java
@@ -74,22 +74,22 @@ public class Member extends BaseTimeEntity {
         this.password = password;
     }
 
-    public static Member createGuestMember(OauthInfo oauthInfo, String nickname) {
+    public static Member createNormalMember(OauthInfo oauthInfo, String nickname) {
         return Member.builder()
                 .profile(Profile.createProfile(nickname, null))
                 .oauthInfo(oauthInfo)
                 .status(MemberStatus.NORMAL)
-                .role(MemberRole.GUEST)
+                .role(MemberRole.USER)
                 .visibility(MemberVisibility.PUBLIC)
                 .build();
     }
 
-    public static Member createGuestMember(String username, String password) {
+    public static Member createNormalMember(String username, String password) {
         return Member.builder()
                 .username(username)
                 .password(password)
                 .status(MemberStatus.NORMAL)
-                .role(MemberRole.GUEST)
+                .role(MemberRole.USER)
                 .visibility(MemberVisibility.PUBLIC)
                 .build();
     }
@@ -117,11 +117,5 @@ public class Member extends BaseTimeEntity {
             throw new CustomException(ErrorCode.MEMBER_ALREADY_DELETED);
         }
         this.status = MemberStatus.DELETED;
-    }
-
-    private void validateRegisterAvailable() {
-        if (role != MemberRole.GUEST) {
-            throw new CustomException(ErrorCode.MEMBER_ALREADY_REGISTERED);
-        }
     }
 }

--- a/src/main/java/com/depromeet/domain/member/domain/Member.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Member.java
@@ -84,16 +84,6 @@ public class Member extends BaseTimeEntity {
                 .build();
     }
 
-    public static Member createNormalMember(String username, String password) {
-        return Member.builder()
-                .username(username)
-                .password(password)
-                .status(MemberStatus.NORMAL)
-                .role(MemberRole.USER)
-                .visibility(MemberVisibility.PUBLIC)
-                .build();
-    }
-
     @Deprecated
     public static Member createNormalMember(Profile profile) {
         return Member.builder()

--- a/src/main/java/com/depromeet/domain/member/domain/Member.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Member.java
@@ -94,6 +94,7 @@ public class Member extends BaseTimeEntity {
                 .build();
     }
 
+    @Deprecated
     public static Member createNormalMember(Profile profile) {
         return Member.builder()
                 .profile(profile)

--- a/src/main/java/com/depromeet/domain/member/domain/MemberRole.java
+++ b/src/main/java/com/depromeet/domain/member/domain/MemberRole.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum MemberRole {
-    GUEST("ROLE_GUEST"),
     USER("ROLE_USER"),
     ADMIN("ROLE_ADMIN");
 

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -30,7 +30,6 @@ public enum ErrorCode {
     MEMBER_ALREADY_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     MEMBER_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 탈퇴한 회원입니다."),
     PASSWORD_NOT_MATCHES(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    GUEST_MEMBER_REQUIRES_REGISTRATION(HttpStatus.UNAUTHORIZED, "게스트 회원은 회원가입을 먼저 진행해야 합니다."),
     ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
 
     // Mission

--- a/src/main/java/com/depromeet/global/security/CustomOidcUser.java
+++ b/src/main/java/com/depromeet/global/security/CustomOidcUser.java
@@ -16,8 +16,4 @@ public class CustomOidcUser extends DefaultOidcUser {
         this.memberId = memberId;
         this.memberRole = memberRole;
     }
-
-    public boolean isGuest() {
-        return MemberRole.GUEST.equals(memberRole);
-    }
 }

--- a/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
@@ -49,9 +49,8 @@ class MemberServiceTest {
     }
 
     private void saveAndRegisterMember(OauthInfo oauthInfo) {
-        Member member = Member.createGuestMember(oauthInfo, "testNickname");
+        Member member = Member.createNormalMember(oauthInfo, "testNickname");
         memberRepository.save(member);
-        member.register("testNickname");
         PrincipalDetails principalDetails = new PrincipalDetails(1L, "USER");
         Authentication authentication =
                 new UsernamePasswordAuthenticationToken(

--- a/src/test/java/com/depromeet/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/depromeet/domain/member/domain/MemberTest.java
@@ -1,28 +1,16 @@
 package com.depromeet.domain.member.domain;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.depromeet.global.error.exception.CustomException;
-import com.depromeet.global.error.exception.ErrorCode;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class MemberTest {
 
-    // Fixture
-    Profile profile;
-
-    @BeforeEach
-    void setUp() {
-        profile = Profile.createProfile("testNickname", "testProfileImageUrl");
-    }
-
     @Test
-    void 회원가입시_초기_상태는_NORMAL이다() {
+    void 소셜_로그인시_초기_상태는_NORMAL이다() {
         // given
         Member member =
-                Member.createGuestMember(
+                Member.createNormalMember(
                         OauthInfo.createOauthInfo("testProvider", "testProviderId", "testEmail"),
                         "testNickname");
 
@@ -34,10 +22,10 @@ class MemberTest {
     }
 
     @Test
-    void 회원가입시_초기_역할은_GUEST이다() {
+    void 소셜_로그인시_초기_역할은_USER이다() {
         // given
         Member member =
-                Member.createGuestMember(
+                Member.createNormalMember(
                         OauthInfo.createOauthInfo("testProvider", "testProviderId", "testEmail"),
                         "testNickname");
 
@@ -45,14 +33,14 @@ class MemberTest {
         MemberRole role = member.getRole();
 
         // then
-        assertEquals(MemberRole.GUEST, role);
+        assertEquals(MemberRole.USER, role);
     }
 
     @Test
-    void 회원가입시_초기_공개여부는_PUBLIC이다() {
+    void 소셜_로그인시시_초기_계정공개여부는_PUBLIC이다() {
         // given
         Member member =
-                Member.createGuestMember(
+                Member.createNormalMember(
                         OauthInfo.createOauthInfo("testProvider", "testProviderId", "testEmail"),
                         "testNickname");
 
@@ -61,47 +49,6 @@ class MemberTest {
 
         // then
         assertEquals(MemberVisibility.PUBLIC, visibility);
-    }
-
-    @Test
-    void 회원가입시_게스트멤버의_닉네임이_설정된다() {
-        // given
-        Member member =
-                Member.createGuestMember(
-                        OauthInfo.createOauthInfo("testProvider", "testProviderId", "testEmail"),
-                        "testNickname");
-
-        // when
-        member.register("testNickname");
-
-        // then
-        assertEquals("testNickname", member.getProfile().getNickname());
-    }
-
-    @Test
-    void 회원가입시_게스트멤버는_일반멤버로_변경된다() {
-        // given
-        Member member =
-                Member.createGuestMember(
-                        OauthInfo.createOauthInfo("testProvider", "testProviderId", "testEmail"),
-                        "testNickname");
-
-        // when
-        member.register("testNickname");
-
-        // then
-        assertEquals(MemberRole.USER, member.getRole());
-    }
-
-    @Test
-    void 회원가입시_일반멤버이면_예외가_발생한다() {
-        // given
-        Member member = Member.createNormalMember(profile);
-
-        // when & then
-        assertThatThrownBy(() -> member.register("testNickname"))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(ErrorCode.MEMBER_ALREADY_REGISTERED.getMessage());
     }
 
     @Test

--- a/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
@@ -54,9 +54,9 @@ class MissionServiceTest {
                 new UsernamePasswordAuthenticationToken(
                         principal, null, principal.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        Member guestMember =
+        Member member =
                 Member.createNormalMember(OauthInfo.createOauthInfo(null, null, null), "nickname");
-        memberRepository.save(guestMember);
+        memberRepository.save(member);
     }
 
     @Test

--- a/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.depromeet.DatabaseCleaner;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.member.domain.OauthInfo;
 import com.depromeet.domain.mission.application.MissionService;
 import com.depromeet.domain.mission.dao.MissionRepository;
 import com.depromeet.domain.mission.domain.Mission;
@@ -51,9 +52,10 @@ class MissionServiceTest {
         PrincipalDetails principal = new PrincipalDetails(1L, "USER");
         Authentication authentication =
                 new UsernamePasswordAuthenticationToken(
-                        principal, "password", principal.getAuthorities());
+                        principal, null, principal.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        Member guestMember = Member.createGuestMember("username", "password");
+        Member guestMember =
+                Member.createNormalMember(OauthInfo.createOauthInfo(null, null, null), "nickname");
         memberRepository.save(guestMember);
     }
 

--- a/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
@@ -44,7 +44,8 @@ class MissionRecordServiceTest {
         when(securityUtil.getCurrentMemberId()).thenReturn(1L);
 
         member =
-                Member.createGuestMember(OauthInfo.createOauthInfo("test", "test", "test"), "test");
+                Member.createNormalMember(
+                        OauthInfo.createOauthInfo("test", "test", "test"), "test");
         memberRepository.save(member);
 
         mission =

--- a/src/test/java/com/depromeet/global/util/MemberUtilTest.java
+++ b/src/test/java/com/depromeet/global/util/MemberUtilTest.java
@@ -37,10 +37,10 @@ class MemberUtilTest {
                 new UsernamePasswordAuthenticationToken(
                         principal, "password", principal.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        Member guestMember =
+        Member member =
                 Member.createNormalMember(
                         OauthInfo.createOauthInfo("test", "test", "test"), "test");
-        Member savedMember = memberRepository.save(guestMember);
+        Member savedMember = memberRepository.save(member);
         // when
         Member currentMember = memberUtil.getCurrentMember();
         // then

--- a/src/test/java/com/depromeet/global/util/MemberUtilTest.java
+++ b/src/test/java/com/depromeet/global/util/MemberUtilTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.depromeet.DatabaseCleaner;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.member.domain.OauthInfo;
 import com.depromeet.global.security.PrincipalDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,9 @@ class MemberUtilTest {
                 new UsernamePasswordAuthenticationToken(
                         principal, "password", principal.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        Member guestMember = Member.createGuestMember("username", "password");
+        Member guestMember =
+                Member.createNormalMember(
+                        OauthInfo.createOauthInfo("test", "test", "test"), "test");
         Member savedMember = memberRepository.save(guestMember);
         // when
         Member currentMember = memberUtil.getCurrentMember();


### PR DESCRIPTION
## 🌱 관련 이슈
- close #230

## 📌 작업 내용 및 특이사항
- `MemberRole` 에서 `GUEST` 상태를 제거했습니다.
- 닉네임 변경 및 GUEST -> USER 상태로 업데이트하는 `register()` 관련 메서드를 제거했습니다.
- ID/PW 관련 메서드를 삭제했습니다. (`createGuestMember(String username, String password)`)
- ID/PW 관련 컨트롤러 / 서비스 메서드를 deprecated 처리했습니다.
    - 게스트 관련 로직의 경우 아무런 동작을 하지 않도록 수정했습니다 (`// do nothing` 주석 참고)
- 소셜 로그인 response의 `isGuest` 필드는 항상 false를 리턴합니다.

## 📝 참고사항
- 현재 테스트 시 `createNormalMember(Profile profile)` 을 사용하고 있는데, 테스트 전용 생성자를 사용하는 것은 지양해야 하므로 `createNormalMember(OauthInfo info, String nickname)` 으로 대체해야 합니다.
- 이에 따라 `createNormalMember(Profile profile)` 을 deprecated 처리했습니다.

## 📚 기타
- 
