### PR TITLE
refactor: JWT 토큰 필터 로직 개선

### DIFF
--- a/src/main/java/com/depromeet/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/depromeet/domain/auth/application/JwtTokenService.java
@@ -122,12 +122,12 @@ public class JwtTokenService {
     }
 
     private Member getMemberFrom(String refreshToken) throws NoSuchElementException {
-        Long memberId = jwtTokenProvider.parseRefreshToken(refreshToken);
-        return memberRepository.findById(memberId).orElseThrow();
+        RefreshTokenDto refreshTokenDto = jwtTokenProvider.parseRefreshToken(refreshToken);
+        return memberRepository.findById(refreshTokenDto.memberId()).orElseThrow();
     }
 
     public Authentication getAuthentication(String accessToken) {
-        AccessToken parsedAccessToken = jwtTokenProvider.parseAccessToken(accessToken);
+        AccessTokenDto parsedAccessToken = jwtTokenProvider.parseAccessToken(accessToken);
 
         UserDetails userDetails =
                 new PrincipalDetails(

--- a/src/main/java/com/depromeet/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/depromeet/domain/auth/application/JwtTokenService.java
@@ -63,6 +63,46 @@ public class JwtTokenService {
         refreshTokenRepository.save(refreshToken);
     }
 
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
+        try {
+            return jwtTokenProvider.parseAccessToken(accessTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RefreshTokenDto retrieveRefreshToken(String refreshTokenValue) {
+        RefreshTokenDto refreshTokenDto = parseRefreshToken(refreshTokenValue);
+
+        if (refreshTokenDto == null) {
+            return null;
+        }
+
+        // 파싱된 DTO와 일치하는 토큰이 Redis에 저장되어 있는지 확인
+        Optional<RefreshToken> refreshToken = getRefreshTokenFromRedis(refreshTokenDto.memberId());
+
+        // Redis에 토큰이 존재하고, 쿠키의 토큰과 값이 일치하면 DTO 반환
+        if (refreshToken.isPresent()
+                && refreshTokenDto.tokenValue().equals(refreshToken.get().getToken())) {
+            return refreshTokenDto;
+        }
+
+        // Redis에 토큰이 존재하지 않거나, 쿠키의 토큰과 값이 일치하지 않으면 null 반환
+        return null;
+    }
+
+    private Optional<RefreshToken> getRefreshTokenFromRedis(Long memberId) {
+        return refreshTokenRepository.findById(memberId);
+    }
+
+    private RefreshTokenDto parseRefreshToken(String refreshTokenValue) {
+        try {
+            return jwtTokenProvider.parseRefreshToken(refreshTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     public String reissueAccessToken(String refreshToken) {
         Member member = getMemberFrom(refreshToken);
         return createAccessToken(member.getId(), member.getRole());

--- a/src/main/java/com/depromeet/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/depromeet/domain/auth/application/JwtTokenService.java
@@ -97,5 +97,16 @@ public class JwtTokenService {
         }
     }
 
+    public AccessTokenDto reissueAccessTokenIfExpired(String accessTokenValue) {
+        // AT가 만료된 경우 AT 재발급, 만료되지 않은 경우 null 반환
+        try {
+            jwtTokenProvider.parseAccessToken(accessTokenValue);
+            return null;
+        } catch (ExpiredJwtException e) {
+            Long memberId = Long.parseLong(e.getClaims().getSubject());
+            MemberRole memberRole =
+                    MemberRole.valueOf(e.getClaims().get(TOKEN_ROLE_NAME, String.class));
+            return createAccessTokenDto(memberId, memberRole);
+        }
     }
 }

--- a/src/main/java/com/depromeet/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/depromeet/domain/auth/application/JwtTokenService.java
@@ -2,6 +2,8 @@ package com.depromeet.domain.auth.application;
 
 import com.depromeet.domain.auth.dao.RefreshTokenRepository;
 import com.depromeet.domain.auth.domain.RefreshToken;
+import com.depromeet.domain.auth.dto.AccessTokenDto;
+import com.depromeet.domain.auth.dto.RefreshTokenDto;
 import com.depromeet.domain.auth.dto.response.AccessToken;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
@@ -9,6 +11,7 @@ import com.depromeet.domain.member.domain.MemberRole;
 import com.depromeet.global.security.JwtTokenProvider;
 import com.depromeet.global.security.PrincipalDetails;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -27,6 +30,10 @@ public class JwtTokenService {
         return jwtTokenProvider.generateAccessToken(memberId, memberRole);
     }
 
+    public AccessTokenDto createAccessTokenDto(Long memberId, MemberRole memberRole) {
+        return jwtTokenProvider.generateAccessTokenDto(memberId, memberRole);
+    }
+
     public String createRefreshToken(Long memberId) {
         String token = jwtTokenProvider.generateRefreshToken(memberId);
         RefreshToken refreshToken =
@@ -37,6 +44,23 @@ public class JwtTokenService {
                         .build();
         refreshTokenRepository.save(refreshToken);
         return token;
+    }
+
+    public RefreshTokenDto createRefreshTokenDto(Long memberId) {
+        RefreshTokenDto refreshTokenDto = jwtTokenProvider.generateRefreshTokenDto(memberId);
+        saveRefreshTokenToRedis(memberId, refreshTokenDto.tokenValue(), refreshTokenDto.ttl());
+        return refreshTokenDto;
+    }
+
+    private void saveRefreshTokenToRedis(
+            Long memberId, String refreshTokenDto, Long refreshTokenDto1) {
+        RefreshToken refreshToken =
+                RefreshToken.builder()
+                        .memberId(memberId)
+                        .token(refreshTokenDto)
+                        .ttl(refreshTokenDto1)
+                        .build();
+        refreshTokenRepository.save(refreshToken);
     }
 
     public String reissueAccessToken(String refreshToken) {

--- a/src/main/java/com/depromeet/domain/auth/dto/AccessTokenDto.java
+++ b/src/main/java/com/depromeet/domain/auth/dto/AccessTokenDto.java
@@ -1,0 +1,5 @@
+package com.depromeet.domain.auth.dto;
+
+import com.depromeet.domain.member.domain.MemberRole;
+
+public record AccessTokenDto(Long memberId, MemberRole memberRole, String tokenValue) {}

--- a/src/main/java/com/depromeet/domain/auth/dto/RefreshTokenDto.java
+++ b/src/main/java/com/depromeet/domain/auth/dto/RefreshTokenDto.java
@@ -1,0 +1,3 @@
+package com.depromeet.domain.auth.dto;
+
+public record RefreshTokenDto(Long memberId, String tokenValue, Long ttl) {}

--- a/src/main/java/com/depromeet/global/common/constants/SecurityConstants.java
+++ b/src/main/java/com/depromeet/global/common/constants/SecurityConstants.java
@@ -11,6 +11,8 @@ public final class SecurityConstants {
     public static final String APPLE_JWK_SET_URL = "https://appleid.apple.com/auth/keys";
     public static final String KAKAO_ISSUER = "https://kauth.kakao.com";
     public static final String APPLE_ISSUER = "https://appleid.apple.com";
+    public static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
     private SecurityConstants() {}
 }

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -23,9 +23,6 @@ public enum ErrorCode {
     // Security
     AUTH_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보를 찾을 수 없습니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
-    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     MEMBER_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 가입된 회원입니다."),
     MEMBER_ALREADY_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     MEMBER_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 탈퇴한 회원입니다."),

--- a/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
@@ -57,7 +57,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // AT가 만료된 경우 AT 재발급, 만료되지 않은 경우 null 반환
         Optional<AccessTokenDto> reissuedAccessToken =
-                Optional.ofNullable(jwtTokenService.reissueAccessTokenIfExpired(refreshTokenValue));
+                Optional.ofNullable(jwtTokenService.reissueAccessTokenIfExpired(accessTokenValue));
         // RT 유효하면 파싱, 유효하지 않으면 null 반환
         RefreshTokenDto refreshTokenDto = jwtTokenService.retrieveRefreshToken(refreshTokenValue);
 
@@ -65,7 +65,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (reissuedAccessToken.isPresent() && refreshTokenDto != null) {
             AccessTokenDto accessToken = reissuedAccessToken.get(); // 재발급된 AT
             RefreshTokenDto refreshToken =
-                    jwtTokenService.createRefreshToken(refreshTokenDto.memberId());
+                    jwtTokenService.createRefreshTokenDto(refreshTokenDto.memberId());
             cookieUtil.addTokenCookies(
                     response, accessToken.tokenValue(), refreshToken.tokenValue());
             setAuthenticationToContext(accessToken.memberId(), accessToken.memberRole());

--- a/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -76,8 +77,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             AccessTokenDto accessToken = reissuedAccessToken.get(); // 재발급된 AT
             RefreshTokenDto refreshToken =
                     jwtTokenService.createRefreshTokenDto(refreshTokenDto.memberId());
-            cookieUtil.addTokenCookies(
-                    response, accessToken.tokenValue(), refreshToken.tokenValue());
+
+            // 쿠키에 재발급된 AT, RT 저장
+            HttpHeaders httpHeaders =
+                    cookieUtil.generateTokenCookies(
+                            accessToken.tokenValue(), refreshToken.tokenValue());
+            response.addHeader(
+                    HttpHeaders.SET_COOKIE, httpHeaders.getFirst(ACCESS_TOKEN_COOKIE_NAME));
+            response.addHeader(
+                    HttpHeaders.SET_COOKIE, httpHeaders.getFirst(REFRESH_TOKEN_COOKIE_NAME));
+
             setAuthenticationToContext(accessToken.memberId(), accessToken.memberRole());
         }
 

--- a/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import com.depromeet.domain.auth.dto.response.AccessToken;
 import com.depromeet.global.util.CookieUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -17,6 +18,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
 
 @Slf4j
 @Component
@@ -32,8 +34,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         // TODO: 쿠키 방식으로 변경 시 아래 로직 수정 필요
-        String accessToken = extractAccessToken(request);
-        String refreshToken = extractRefreshToken(request);
+        String accessToken = extractAccessTokenFromCookie(request);
+        String refreshToken = extractRefreshTokenFromCookie(request);
 
         // TODO: 엑세스 토큰 없더라도 쿠키의 리프레시 토큰으로 재발급하도록 수정 필요
         // ATK, RTK 둘 중 하나라도 빈 상태로 오면 통과
@@ -88,6 +90,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return Optional.ofNullable(request.getHeader(ACCESS_TOKEN_HEADER))
                 .filter(token -> token.startsWith(TOKEN_PREFIX))
                 .map(token -> token.replace(TOKEN_PREFIX, ""))
+                .orElse(null);
+    }
+
+    private String extractAccessTokenFromCookie(HttpServletRequest request) {
+        return Optional.ofNullable(WebUtils.getCookie(request, ACCESS_TOKEN_COOKIE_NAME))
+                .map(Cookie::getValue)
+                .orElse(null);
+    }
+
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        return Optional.ofNullable(WebUtils.getCookie(request, REFRESH_TOKEN_COOKIE_NAME))
+                .map(Cookie::getValue)
                 .orElse(null);
     }
 }

--- a/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
@@ -3,6 +3,9 @@ package com.depromeet.global.security;
 import static com.depromeet.global.common.constants.SecurityConstants.*;
 
 import com.depromeet.domain.auth.application.JwtTokenService;
+import com.depromeet.domain.auth.dto.AccessTokenDto;
+import com.depromeet.domain.auth.dto.RefreshTokenDto;
+import com.depromeet.domain.member.domain.MemberRole;
 import com.depromeet.global.util.CookieUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -13,6 +16,10 @@ import java.io.IOException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.WebUtils;
@@ -30,8 +37,50 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String accessToken = extractAccessTokenFromCookie(request);
-        String refreshToken = extractRefreshTokenFromCookie(request);
+        String accessTokenValue = extractAccessTokenFromCookie(request);
+        String refreshTokenValue = extractRefreshTokenFromCookie(request);
+
+        // 쿠키에서 가져올 때 AT와 RT 중 하나라도 없으면 실패
+        if (accessTokenValue == null || refreshTokenValue == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        AccessTokenDto accessTokenDto = jwtTokenService.retrieveAccessToken(accessTokenValue);
+
+        // AT가 유효하면 통과
+        if (accessTokenDto != null) {
+            setAuthenticationToContext(accessTokenDto.memberId(), accessTokenDto.memberRole());
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // AT가 만료된 경우 AT 재발급, 만료되지 않은 경우 null 반환
+        Optional<AccessTokenDto> reissuedAccessToken =
+                Optional.ofNullable(jwtTokenService.reissueAccessTokenIfExpired(refreshTokenValue));
+        // RT 유효하면 파싱, 유효하지 않으면 null 반환
+        RefreshTokenDto refreshTokenDto = jwtTokenService.retrieveRefreshToken(refreshTokenValue);
+
+        // AT가 만료되었고, RT가 유효하면 AT, RT 재발급
+        if (reissuedAccessToken.isPresent() && refreshTokenDto != null) {
+            AccessTokenDto accessToken = reissuedAccessToken.get(); // 재발급된 AT
+            RefreshTokenDto refreshToken =
+                    jwtTokenService.createRefreshToken(refreshTokenDto.memberId());
+            cookieUtil.addTokenCookies(
+                    response, accessToken.tokenValue(), refreshToken.tokenValue());
+            setAuthenticationToContext(accessToken.memberId(), accessToken.memberRole());
+        }
+
+        // AT, RT가 모두 만료된 경우 실패
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthenticationToContext(Long memberId, MemberRole memberRole) {
+        UserDetails userDetails = new PrincipalDetails(memberId, memberRole.toString());
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     private String extractRefreshToken(HttpServletRequest request) {

--- a/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
@@ -83,20 +83,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
-    private String extractRefreshToken(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader(REFRESH_TOKEN_HEADER))
-                .filter(token -> token.startsWith(TOKEN_PREFIX))
-                .map(token -> token.replace(TOKEN_PREFIX, ""))
-                .orElse(null);
-    }
-
-    private String extractAccessToken(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader(ACCESS_TOKEN_HEADER))
-                .filter(token -> token.startsWith(TOKEN_PREFIX))
-                .map(token -> token.replace(TOKEN_PREFIX, ""))
-                .orElse(null);
-    }
-
     private String extractAccessTokenFromCookie(HttpServletRequest request) {
         return Optional.ofNullable(WebUtils.getCookie(request, ACCESS_TOKEN_COOKIE_NAME))
                 .map(Cookie::getValue)

--- a/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
@@ -3,7 +3,6 @@ package com.depromeet.global.security;
 import static com.depromeet.global.common.constants.SecurityConstants.*;
 
 import com.depromeet.domain.auth.application.JwtTokenService;
-import com.depromeet.domain.auth.dto.response.AccessToken;
 import com.depromeet.global.util.CookieUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -14,8 +13,6 @@ import java.io.IOException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.WebUtils;
@@ -33,50 +30,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        // TODO: 쿠키 방식으로 변경 시 아래 로직 수정 필요
         String accessToken = extractAccessTokenFromCookie(request);
         String refreshToken = extractRefreshTokenFromCookie(request);
-
-        // TODO: 엑세스 토큰 없더라도 쿠키의 리프레시 토큰으로 재발급하도록 수정 필요
-        // ATK, RTK 둘 중 하나라도 빈 상태로 오면 통과
-        if (accessToken == null || refreshToken == null) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        boolean isAccessTokenExpired = jwtTokenService.isAccessTokenExpired(accessToken);
-        boolean isRefreshTokenExpired = jwtTokenService.isRefreshTokenExpired(refreshToken);
-
-        // ATK, RTK 둘 다 만료되었으면 통과
-        if (isAccessTokenExpired && isRefreshTokenExpired) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        // ATK 만료되었고 RTK 만료되지 않았으면 RTK로 ATK, RTK 재발급
-        if (isAccessTokenExpired && !isRefreshTokenExpired) {
-            accessToken = jwtTokenService.reissueAccessToken(refreshToken);
-            refreshToken = jwtTokenService.reissueRefreshToken(refreshToken);
-        }
-
-        // ATK 만료되지 않았고 RTK 만료되었으면 ATK로 ATK, RTK 재발급
-        if (!isAccessTokenExpired && isRefreshTokenExpired) {
-            AccessToken accessTokenDto = jwtTokenService.parseAccessToken(accessToken);
-            accessToken = jwtTokenService.reissueAccessToken(accessTokenDto);
-            refreshToken = jwtTokenService.reissueRefreshToken(accessTokenDto);
-        }
-
-        // ATK, RTK 둘 다 만료되지 않았으면 RTK 재발급
-        if (!isAccessTokenExpired && !isRefreshTokenExpired) {
-            AccessToken accessTokenDto = jwtTokenService.parseAccessToken(accessToken);
-            refreshToken = jwtTokenService.reissueRefreshToken(accessTokenDto);
-        }
-
-        cookieUtil.addTokenCookies(response, accessToken, refreshToken);
-        Authentication authentication = jwtTokenService.getAuthentication(accessToken);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        filterChain.doFilter(request, response);
     }
 
     private String extractRefreshToken(HttpServletRequest request) {

--- a/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
@@ -20,12 +20,10 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.WebUtils;
 
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/depromeet/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/depromeet/global/security/JwtTokenProvider.java
@@ -2,7 +2,8 @@ package com.depromeet.global.security;
 
 import static com.depromeet.global.common.constants.SecurityConstants.TOKEN_ROLE_NAME;
 
-import com.depromeet.domain.auth.dto.response.AccessToken;
+import com.depromeet.domain.auth.dto.AccessTokenDto;
+import com.depromeet.domain.auth.dto.RefreshTokenDto;
 import com.depromeet.domain.member.domain.MemberRole;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
@@ -29,6 +30,14 @@ public class JwtTokenProvider {
         return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
     }
 
+    public AccessTokenDto generateAccessTokenDto(Long memberId, MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        String tokenValue = buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+        return new AccessTokenDto(memberId, memberRole, tokenValue);
+    }
+
     public String generateRefreshToken(Long memberId) {
         Date issuedAt = new Date();
         Date expiredAt =
@@ -36,8 +45,14 @@ public class JwtTokenProvider {
         return buildRefreshToken(memberId, issuedAt, expiredAt);
     }
 
-    public AccessToken parseAccessToken(String token) {
-        Jws<Claims> claims = getClaims(token, getAccessTokenKey());
+    public RefreshTokenDto generateRefreshTokenDto(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        String tokenValue = buildRefreshToken(memberId, issuedAt, expiredAt);
+        return new RefreshTokenDto(
+                memberId, tokenValue, jwtProperties.refreshTokenExpirationTime());
+    }
 
         try {
             validateDefaultClaims(claims);

--- a/src/main/java/com/depromeet/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/depromeet/global/security/JwtTokenProvider.java
@@ -114,13 +114,11 @@ public class JwtTokenProvider {
     }
 
     private Jws<Claims> getClaims(String token, Key key) {
-        try {
-            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-        } catch (ExpiredJwtException e) {
-            throw new CustomException(ErrorCode.EXPIRED_JWT_TOKEN);
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.INVALID_JWT_TOKEN);
-        }
+        return Jwts.parserBuilder()
+                .requireIssuer(jwtProperties.issuer())
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
     }
 
     private String buildAccessToken(

--- a/src/main/java/com/depromeet/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/depromeet/global/security/JwtTokenProvider.java
@@ -124,21 +124,6 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
     }
 
-    private void validateDefaultClaims(Jws<Claims> claims) {
-        // issuer가 일치하는지 검증
-        if (jwtProperties.issuer().equals(claims.getBody().getIssuer())) {
-            return;
-        }
-
-        // subject 문자열 리터럴이 양수 memberId인지 검증
-        if (claims.getBody().getSubject().matches("^[1-9][0-9]*$")) {
-            return;
-        }
-
-        // INVALID_JWT_TOKEN 예외는 각 parse 메서드에서 INVALID_ACCESS_TOKEN, INVALID_REFRESH_TOKEN 예외로 변환됨
-        throw new CustomException(ErrorCode.INVALID_JWT_TOKEN);
-    }
-
     private Jws<Claims> getClaims(String token, Key key) {
         return Jwts.parserBuilder()
                 .requireIssuer(jwtProperties.issuer())

--- a/src/main/java/com/depromeet/global/security/PrincipalDetails.java
+++ b/src/main/java/com/depromeet/global/security/PrincipalDetails.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 public class PrincipalDetails implements UserDetails {
 
     private final Long memberId;
+    // TODO: MemberRole을 사용하도록 수정
     private final String role;
 
     @Override

--- a/src/main/java/com/depromeet/global/util/CookieUtil.java
+++ b/src/main/java/com/depromeet/global/util/CookieUtil.java
@@ -3,7 +3,6 @@ package com.depromeet.global.util;
 import static com.depromeet.global.common.constants.SecurityConstants.ACCESS_TOKEN_COOKIE_NAME;
 import static com.depromeet.global.common.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
 
-import com.depromeet.infra.config.jwt.JwtProperties;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -15,7 +14,6 @@ import org.springframework.stereotype.Component;
 public class CookieUtil {
 
     private final SpringEnvironmentUtil springEnvironmentUtil;
-    private final JwtProperties jwtProperties;
 
     public void addTokenCookies(
             HttpServletResponse response, String accessToken, String refreshToken) {
@@ -30,7 +28,6 @@ public class CookieUtil {
         ResponseCookie accessTokenCookie =
                 ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
                         .path("/")
-                        .maxAge(jwtProperties.accessTokenExpirationTime())
                         .secure(true)
                         .sameSite(sameSite)
                         .httpOnly(false)
@@ -39,7 +36,6 @@ public class CookieUtil {
         ResponseCookie refreshTokenCookie =
                 ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
                         .path("/")
-                        .maxAge(jwtProperties.refreshTokenExpirationTime())
                         .secure(true)
                         .sameSite(sameSite)
                         .httpOnly(false)

--- a/src/main/java/com/depromeet/global/util/CookieUtil.java
+++ b/src/main/java/com/depromeet/global/util/CookieUtil.java
@@ -3,7 +3,6 @@ package com.depromeet.global.util;
 import static com.depromeet.global.common.constants.SecurityConstants.ACCESS_TOKEN_COOKIE_NAME;
 import static com.depromeet.global.common.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
 
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -14,12 +13,6 @@ import org.springframework.stereotype.Component;
 public class CookieUtil {
 
     private final SpringEnvironmentUtil springEnvironmentUtil;
-
-    public void addTokenCookies(
-            HttpServletResponse response, String accessToken, String refreshToken) {
-        HttpHeaders headers = generateTokenCookies(accessToken, refreshToken);
-        headers.forEach((key, value) -> response.addHeader(key, value.get(0)));
-    }
 
     public HttpHeaders generateTokenCookies(String accessToken, String refreshToken) {
 

--- a/src/main/java/com/depromeet/global/util/CookieUtil.java
+++ b/src/main/java/com/depromeet/global/util/CookieUtil.java
@@ -1,5 +1,8 @@
 package com.depromeet.global.util;
 
+import static com.depromeet.global.common.constants.SecurityConstants.ACCESS_TOKEN_COOKIE_NAME;
+import static com.depromeet.global.common.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+
 import com.depromeet.infra.config.jwt.JwtProperties;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +28,7 @@ public class CookieUtil {
         String sameSite = determineSameSitePolicy();
 
         ResponseCookie accessTokenCookie =
-                ResponseCookie.from("accessToken", accessToken)
+                ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
                         .path("/")
                         .maxAge(jwtProperties.accessTokenExpirationTime())
                         .secure(true)
@@ -34,7 +37,7 @@ public class CookieUtil {
                         .build();
 
         ResponseCookie refreshTokenCookie =
-                ResponseCookie.from("refreshToken", refreshToken)
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
                         .path("/")
                         .maxAge(jwtProperties.refreshTokenExpirationTime())
                         .secure(true)

--- a/src/test/java/com/depromeet/domain/follow/api/FollowControllerTest.java
+++ b/src/test/java/com/depromeet/domain/follow/api/FollowControllerTest.java
@@ -11,7 +11,6 @@ import com.depromeet.domain.follow.application.FollowService;
 import com.depromeet.domain.follow.dto.request.FollowCreateRequest;
 import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
 import com.depromeet.global.error.exception.ErrorCode;
-import com.depromeet.global.security.JwtAuthenticationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,7 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(FollowController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@MockBean({JpaMetamodelMappingContext.class, JwtAuthenticationFilter.class})
+@MockBean({JpaMetamodelMappingContext.class})
 class FollowControllerTest {
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;

--- a/src/test/java/com/depromeet/domain/image/api/ImageControllerTest.java
+++ b/src/test/java/com/depromeet/domain/image/api/ImageControllerTest.java
@@ -12,7 +12,6 @@ import com.depromeet.domain.image.domain.ImageFileExtension;
 import com.depromeet.domain.image.dto.request.MissionRecordImageCreateRequest;
 import com.depromeet.domain.image.dto.request.MissionRecordImageUploadCompleteRequest;
 import com.depromeet.domain.image.dto.response.PresignedUrlResponse;
-import com.depromeet.global.security.JwtAuthenticationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.awt.*;
 import org.junit.jupiter.api.Nested;
@@ -27,7 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ImageController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@MockBean({JpaMetamodelMappingContext.class, JwtAuthenticationFilter.class})
+@MockBean({JpaMetamodelMappingContext.class})
 class ImageControllerTest {
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -26,7 +26,6 @@ import com.depromeet.domain.mission.dto.response.MissionFindResponse;
 import com.depromeet.domain.mission.dto.response.MissionUpdateResponse;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
-import com.depromeet.global.security.JwtAuthenticationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -43,7 +42,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(MissionController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@MockBean({JpaMetamodelMappingContext.class, JwtAuthenticationFilter.class})
+@MockBean({JpaMetamodelMappingContext.class})
 class MissionControllerTest {
 
     @Autowired private MockMvc mockMvc;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #218

## 📌 작업 내용 및 특이사항
- 파싱된 토큰을 토큰 DTO로 매핑하도록 수정하여, 불필요한 추가 파싱이 발생하는 부분을 제거했습니다. (`AccessTokenDto`, `RefreshTokenDto`)
- 토큰 검증 로직을 변경했습니다.
    - issuer 검증의 경우 `.requireIssuer()` 로 이전했습니다.
    - 그 외 예외의 경우 parser가 그대로 던지게 합니다.
    - 이때 예외를 잡지 않으므로, 파싱 메서드의 try 블럭 안에 `getClaims`를 넣습니다.
- 토큰 파싱 로직을 변경했습니다.
    - 토큰 파싱에 성공하면 -> DTO로 변환합니다.
    - 만료된 토큰인 경우 -> `ExpiredJwtException` 을 던집니다.
    - 그 외 유효하지 않은 토큰으로 예외가 발생하는 경우 -> null 을 반환합니다. 
- 토큰 재발급 로직을 변경했습니다.
    -  토큰이 만료된 경우에만 (그 외 유효하지 않은 케이스 제외) 재발급이 필요합니다.
    - 위에서 던지는 `ExpiredJwtException` 을 잡아서, 해당 예외 클래스가 가지는 클레임 정보를 바탕으로 토큰을 재발급합니다.
- 스웨거 테스트를 위해 헤더에 엑세스 토큰이 있으면 우선적으로 검증합니다.
    - id 토큰 발급받은 후 `/social-login` 에서 발급받은 AT를 스웨거 헤더에 설정하면 됩니다.
- 쿠키 관련 변경사항
    - 쿠키의 maxAge를 삭제했습니다.
    - 쿠키는 maxAge가 지나면 자동적으로 제거되는데, 이때 서버에서는 해당 쿠키가 애초부터 없었는지, 만료되어 없어진 것인지 판단할 수 없습니다.
    - 어차피 쿠키에 들어있는 토큰의 경우 expiration을 관리하고 있으므로, 쿠키의 유효기간까지 관리할 필요는 없습니다. 

## 📝 참고사항
- 

## 📚 기타
- 
