### PR TITLE
feat: 캘린더 뷰 조회 응답에 미션 시작 시간, 끝 시간을 추가

### DIFF
--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -3,15 +3,11 @@ package com.depromeet.domain.missionRecord.api;
 import com.depromeet.domain.missionRecord.application.MissionRecordService;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordUpdateRequest;
-import com.depromeet.domain.missionRecord.dto.response.MissionRecordCreateResponse;
-import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindOneResponse;
-import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindResponse;
-import com.depromeet.domain.missionRecord.dto.response.MissionRecordUpdateResponse;
+import com.depromeet.domain.missionRecord.dto.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.YearMonth;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -40,7 +36,7 @@ public class MissionRecordController {
 
     @Operation(summary = "미션 기록 조회 (캘린더 뷰)", description = "미션 기록을 조회합니다.")
     @GetMapping
-    public List<MissionRecordFindResponse> missionRecordFind(
+    public MissionRecordCalendarResponse missionRecordFind(
             @RequestParam("missionId") Long missionId,
             @RequestParam("yearMonth") YearMonth yearMonth) {
         return missionRecordService.findAllMissionRecord(missionId, yearMonth);

--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -10,10 +10,7 @@ import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.domain.missionRecord.domain.MissionRecordTtl;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordUpdateRequest;
-import com.depromeet.domain.missionRecord.dto.response.MissionRecordCreateResponse;
-import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindOneResponse;
-import com.depromeet.domain.missionRecord.dto.response.MissionRecordFindResponse;
-import com.depromeet.domain.missionRecord.dto.response.MissionRecordUpdateResponse;
+import com.depromeet.domain.missionRecord.dto.response.*;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
@@ -93,11 +90,14 @@ public class MissionRecordService {
     }
 
     @Transactional(readOnly = true)
-    public List<MissionRecordFindResponse> findAllMissionRecord(
-            Long missionId, YearMonth yearMonth) {
+    public MissionRecordCalendarResponse findAllMissionRecord(Long missionId, YearMonth yearMonth) {
         List<MissionRecord> missionRecords =
                 missionRecordRepository.findAllByMissionIdAndYearMonth(missionId, yearMonth);
-        return missionRecords.stream().map(MissionRecordFindResponse::from).toList();
+        List<MissionRecordFindResponse> missionRecordFindResponses =
+                missionRecords.stream().map(MissionRecordFindResponse::from).toList();
+        Mission mission = findMissionById(missionId);
+        return MissionRecordCalendarResponse.of(
+                mission.getStartedAt(), mission.getFinishedAt(), missionRecordFindResponses);
     }
 
     public MissionRecordUpdateResponse updateMissionRecord(

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordCalendarResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordCalendarResponse.java
@@ -1,0 +1,35 @@
+package com.depromeet.domain.missionRecord.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MissionRecordCalendarResponse(
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 시작 시간",
+                        defaultValue = "2024-01-01 00:34:00",
+                        type = "string")
+                LocalDateTime missionStartedAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 종료 시간",
+                        defaultValue = "2024-01-15 00:34:00",
+                        type = "string")
+                LocalDateTime missionFinishedAt,
+        @Schema(description = "미션 기록들") List<MissionRecordFindResponse> missionRecords) {
+    public static MissionRecordCalendarResponse of(
+            LocalDateTime missionStartedAt,
+            LocalDateTime missionFinishedAt,
+            List<MissionRecordFindResponse> missionRecords) {
+        return new MissionRecordCalendarResponse(
+                missionStartedAt, missionFinishedAt, missionRecords);
+    }
+}

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindOneResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindOneResponse.java
@@ -11,7 +11,7 @@ public record MissionRecordFindOneResponse(
                 String remark,
         @Schema(
                         description = "미션 기록 인증 사진 Url",
-                        defaultValue = "https://ik.imagekit.io/demo/medium_cafe_B1iTdD0C.jpg")
+                        defaultValue = "https://image.10mm.today/default.png")
                 String imageUrl,
         @Schema(description = "미션 수행한 시간", defaultValue = "21") long duration,
         @Schema(description = "미션 시작한 지 N일차", defaultValue = "3") long sinceDay,

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindResponse.java
@@ -11,7 +11,7 @@ public record MissionRecordFindResponse(
                 String remark,
         @Schema(
                         description = "미션 기록 인증 사진 Url",
-                        defaultValue = "https://ik.imagekit.io/demo/medium_cafe_B1iTdD0C.jpg")
+                        defaultValue = "https://image.10mm.today/default.png")
                 String imageUrl,
         @Schema(description = "미션 시작 일자", defaultValue = "3") int missionDay,
         @JsonFormat(


### PR DESCRIPTION
## 🌱 관련 이슈
- close #250 

## 📌 작업 내용 및 특이사항
![image](https://github.com/depromeet/10mm-server/assets/64088250/e8508198-09ac-446a-a79b-48b72c744015)

- 기존 미션기록 조회 시 n일차에 해당하는 값을 계산해서 보내주고 있었는데, 기획 상 미션 기록을 완료하지 않은 날(empty case)일 때도 n일차에 해당하는 값을 보어주여야 합니다. (이미지 맨 우측 화면 참고)
- 따라서 `GET /records - 미션 기록 조회(캘린더뷰) API`에서 미션의 시작 시간과 끝 시간을 추가
(프론트와 협의 완료 @wade3420)
