### PR TITLE
fix: 닉네임 조회 시 팔로우 상태 버그 수정

### DIFF
--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -85,22 +85,25 @@ public class MemberService {
                 }
             }
 
-            if (existRelation) {
-                Optional<MemberRelation> optionalMemberRelation =
-                        memberRelationByTargetId.stream()
-                                .filter(
-                                        memberRelation ->
-                                                member.getId()
-                                                        .equals(memberRelation.getSource().getId()))
-                                .findFirst();
-                if (optionalMemberRelation.isPresent()) {
-                    response.add(MemberSearchResponse.toFollowedByMeResponse(member));
-                    continue;
-                }
-
+            if (existRelation) { // 닉네임 검색한 애들 중 내가 팔로우한 애라면
                 response.add(MemberSearchResponse.toFollowingResponse(member));
                 continue;
             }
+
+            // 내가 팔로우를 하지 않았을 때
+            Optional<MemberRelation> optionalMemberRelation =
+                    memberRelationByTargetId.stream()
+                            .filter(
+                                    memberRelation ->
+                                            member.getId()
+                                                    .equals(memberRelation.getSource().getId()))
+                            .findFirst();
+            if (optionalMemberRelation.isPresent()) { // 상대방만 나를 팔로우 하고 있을  때
+                response.add(MemberSearchResponse.toFollowedByMeResponse(member));
+                continue;
+            }
+
+            // 아니라면 서로 팔로우가 아닌 상태
             response.add(MemberSearchResponse.toNotFollowingResponse(member));
         }
         response =

--- a/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
@@ -234,9 +234,7 @@ class MemberServiceTest {
             memberRelationRepository.save(
                     MemberRelation.createMemberRelation(currentMember, searchMember1));
 
-            // 도모와 재현이는 맞팔로우
-            memberRelationRepository.save(
-                    MemberRelation.createMemberRelation(currentMember, searchMember2));
+            // 재현이가 도모만 팔로우
             memberRelationRepository.save(
                     MemberRelation.createMemberRelation(searchMember2, currentMember));
 
@@ -253,7 +251,7 @@ class MemberServiceTest {
             // 도모만 윤범이를 팔로우하고있다.
             assertEquals(FollowStatus.FOLLOWING, responses.get(1).followStatus());
 
-            // 도모는 재현이와 맞팔로우 관계이다.
+            // 재현이만 도모를 팔로우하고있다.
             assertEquals(FollowStatus.FOLLOWED_BY_ME, responses.get(2).followStatus());
         }
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #253 

## 📌 작업 내용 및 특이사항
<img src="https://github.com/depromeet/10mm-server/assets/64088250/fb2f17b3-772e-4dc6-a353-52de576b2440" width="300"/>

- 당근조이와 도모는 현재 맞팔로우 상태인데, 당근조이만 도모를 팔로우한 경우처럼 `맞팔로우`버튼이 보이는 문제 발생
- 로직 상 잘못 코드 짜놨더라구용 급하게 수정했슴니돠😥
