### PR TITLE
refactor: 닉네임 및 프로필 이미지 API를 각각의 V2 API로 분리

### DIFF
--- a/src/main/java/com/depromeet/domain/image/api/ImageController.java
+++ b/src/main/java/com/depromeet/domain/image/api/ImageController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,5 +51,15 @@ public class ImageController {
     public void memberProfileUploaded(
             @Valid @RequestBody MemberProfileImageUploadCompleteRequest request) {
         imageService.uploadCompleteMemberProfile(request);
+    }
+
+    @Operation(
+            summary = "회원 프로필 이미지 업로드 완료처리 V2",
+            description = "V1과 동일합니다. 단, 요청 바디에 닉네임을 넣더라도 무시됩니다.")
+    @PostMapping("/members/me/upload-complete/v2")
+    public ResponseEntity<Void> memberProfileUploadedV2(
+            @Valid @RequestBody MemberProfileImageUploadCompleteRequest request) {
+        imageService.uploadCompleteMemberProfileV2(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/depromeet/domain/image/api/ImageController.java
+++ b/src/main/java/com/depromeet/domain/image/api/ImageController.java
@@ -46,7 +46,8 @@ public class ImageController {
         return imageService.createMemberProfilePresignedUrl(request);
     }
 
-    @Operation(summary = "회원 프로필 이미지 업로드 완료처리", description = "회원 프로필 이미지 업로드 완료 시 호출하시면 됩니다.")
+    @Deprecated
+    @Operation(summary = "회원 프로필 이미지 업로드 완료처리 V1", description = "회원 프로필 이미지 업로드 완료 시 호출하시면 됩니다.")
     @PostMapping("/members/me/upload-complete")
     public void memberProfileUploaded(
             @Valid @RequestBody MemberProfileImageUploadCompleteRequest request) {

--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -146,6 +146,27 @@ public class ImageService {
         currentMember.updateProfile(Profile.createProfile(request.nickname(), imageUrl));
     }
 
+    public void uploadCompleteMemberProfileV2(MemberProfileImageUploadCompleteRequest request) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        String imageUrl = null;
+        if (request.imageFileExtension() != null) {
+            Image image =
+                    findImage(
+                            ImageType.MEMBER_PROFILE,
+                            currentMember.getId(),
+                            request.imageFileExtension());
+            imageUrl =
+                    createReadImageUrl(
+                            ImageType.MEMBER_PROFILE,
+                            currentMember.getId(),
+                            image.getImageKey(),
+                            request.imageFileExtension());
+        }
+        // 닉네임 변경은 무시됩니다 (현재 닉네임을 그대로 사용)
+        String currentNickname = currentMember.getProfile().getNickname();
+        currentMember.updateProfile(Profile.createProfile(currentNickname, imageUrl));
+    }
+
     private Image findImage(
             ImageType imageType, Long targetId, ImageFileExtension imageFileExtension) {
         return imageRepository

--- a/src/main/java/com/depromeet/domain/image/dto/request/MemberProfileImageUploadCompleteRequest.java
+++ b/src/main/java/com/depromeet/domain/image/dto/request/MemberProfileImageUploadCompleteRequest.java
@@ -2,10 +2,8 @@ package com.depromeet.domain.image.dto.request;
 
 import com.depromeet.domain.image.domain.ImageFileExtension;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record MemberProfileImageUploadCompleteRequest(
         @Schema(description = "이미지 파일의 확장자", defaultValue = "JPEG")
                 ImageFileExtension imageFileExtension,
-        @NotNull(message = "닉네임은 비워둘 수 없습니다.") @Schema(description = "닉네임", defaultValue = "당근조이")
-                String nickname) {}
+        @Schema(description = "닉네임", defaultValue = "당근조이") String nickname) {}

--- a/src/main/java/com/depromeet/domain/member/api/MemberController.java
+++ b/src/main/java/com/depromeet/domain/member/api/MemberController.java
@@ -3,6 +3,7 @@ package com.depromeet.domain.member.api;
 import com.depromeet.domain.auth.dto.request.UsernameCheckRequest;
 import com.depromeet.domain.member.application.MemberService;
 import com.depromeet.domain.member.dto.request.NicknameCheckRequest;
+import com.depromeet.domain.member.dto.request.NicknameUpdateRequest;
 import com.depromeet.domain.member.dto.response.MemberFindOneResponse;
 import com.depromeet.domain.member.dto.response.MemberSearchResponse;
 import com.depromeet.domain.member.dto.response.MemberSocialInfoResponse;
@@ -69,5 +70,13 @@ public class MemberController {
     public ResponseEntity<MemberSocialInfoResponse> memberSocialInfoFind() {
         MemberSocialInfoResponse response = memberService.findMemberSocialInfo();
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "회원 닉네임 변경", description = "회원 닉네임을 변경합니다.")
+    @PutMapping("/me/nickname")
+    public ResponseEntity<Void> memberNicknameUpdate(
+            @Valid @RequestBody NicknameUpdateRequest reqest) {
+        memberService.updateMemberNickname(reqest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -9,6 +9,7 @@ import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.Profile;
 import com.depromeet.domain.member.dto.request.NicknameCheckRequest;
+import com.depromeet.domain.member.dto.request.NicknameUpdateRequest;
 import com.depromeet.domain.member.dto.response.MemberFindOneResponse;
 import com.depromeet.domain.member.dto.response.MemberSearchResponse;
 import com.depromeet.domain.member.dto.response.MemberSocialInfoResponse;
@@ -59,7 +60,11 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public void checkNickname(NicknameCheckRequest request) {
-        if (memberRepository.existsByProfileNickname(request.nickname())) {
+        validateNicknameNotDuplicate(request.nickname());
+    }
+
+    private void validateNicknameNotDuplicate(String nickname) {
+        if (memberRepository.existsByProfileNickname(nickname)) {
             throw new CustomException(ErrorCode.MEMBER_ALREADY_NICKNAME);
         }
     }

--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -146,6 +146,12 @@ public class MemberService {
         }
     }
 
+    public void updateMemberNickname(NicknameUpdateRequest reqest) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        validateNicknameNotDuplicate(reqest.nickname());
+        currentMember.updateNickname(reqest.nickname());
+    }
+
     private ImageFileExtension getImageFileExtension(Profile profile) {
         // TODO: 이미지 확장자 정보 같이 넘겨주는 작업 추가 (24.01.26)
         // 이미지 업로드와 닉네임 변경 분리 후 제거 예정

--- a/src/main/java/com/depromeet/domain/member/domain/Member.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Member.java
@@ -109,4 +109,8 @@ public class Member extends BaseTimeEntity {
         }
         this.status = MemberStatus.DELETED;
     }
+
+    public void updateNickname(String nickname) {
+        this.profile = Profile.createProfile(nickname, this.profile.getProfileImageUrl());
+    }
 }

--- a/src/main/java/com/depromeet/domain/member/dto/request/NicknameUpdateRequest.java
+++ b/src/main/java/com/depromeet/domain/member/dto/request/NicknameUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.depromeet.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record NicknameUpdateRequest(
+        @NotNull(message = "닉네임은 비워둘 수 없습니다.")
+                @Schema(description = "회원 닉네임", defaultValue = "nickname")
+                String nickname) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #255

## 📌 작업 내용 및 특이사항
- `upload-complete/v2` 를 구현했습니다.
    - 기존과 동일하게 동작하되, nickname 필드를 전달하지 않아야 합니다.
    - 만약 전달하더라도, 내부적으로는 아무런 동작을 하지 않습니다 (기존 닉네임 유지)
    - 닉네임을 전달할 수 있는 이유는 v1과 동일한 DTO를 사용하기 때문입니다. -> 해당 DTO에서 nickname not null 검증 조건을 제거했습니다.
- 닉네임 중복검증 메서드를 재사용을 위해 분리했습니다.
- 닉네임 변경 API를 구현했습니다. (`PUT members/me/nickname`)
- 닉네임 변경 테스트를 작성했습니다.

## 📝 참고사항
- 

## 📚 기타
- 
