### PR TITLE
fix: 쿠키 적용 후 개발서버에서 에러 발생하는 문제 해결

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,8 +3,6 @@ name: develop Build And Deploy
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,6 +3,8 @@ name: develop Build And Deploy
 on:
   push:
     branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/src/main/java/com/depromeet/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/global/config/swagger/SwaggerConfig.java
@@ -66,15 +66,7 @@ public class SwaggerConfig {
                                 .scheme("bearer")
                                 .bearerFormat("JWT")
                                 .in(In.HEADER)
-                                .name("Authorization"))
-                .addSecuritySchemes(
-                        "refreshToken",
-                        new SecurityScheme()
-                                .type(Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")
-                                .in(In.HEADER)
-                                .name("Refresh-Token"));
+                                .name("Authorization"));
     }
 
     private Info swaggerInfo() {

--- a/src/main/java/com/depromeet/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/global/config/swagger/SwaggerConfig.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.In;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
@@ -37,6 +38,7 @@ public class SwaggerConfig {
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .servers(swaggerServers())
+                .addSecurityItem(securityRequirement())
                 .components(authSetting())
                 .info(swaggerInfo());
     }
@@ -79,6 +81,12 @@ public class SwaggerConfig {
                 .title(API_TITLE)
                 .description(API_DESCRIPTION)
                 .license(license);
+    }
+
+    private SecurityRequirement securityRequirement() {
+        SecurityRequirement securityRequirement = new SecurityRequirement();
+        securityRequirement.addList("accessToken");
+        return securityRequirement;
     }
 
     @Bean

--- a/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
@@ -32,7 +32,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final CookieUtil cookieUtil;
 
     private static String extractAccessTokenFromHeader(HttpServletRequest request) {
-        return request.getHeader(ACCESS_TOKEN_HEADER).replace(TOKEN_PREFIX, "");
+        return Optional.ofNullable(request.getHeader(ACCESS_TOKEN_HEADER))
+                .map(header -> header.replace(TOKEN_PREFIX, ""))
+                .orElse(null);
     }
 
     @Override

--- a/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
@@ -32,7 +32,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final CookieUtil cookieUtil;
 
     private static String extractAccessTokenFromHeader(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader(ACCESS_TOKEN_HEADER))
+        return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
+                .filter(header -> header.startsWith(TOKEN_PREFIX))
                 .map(header -> header.replace(TOKEN_PREFIX, ""))
                 .orElse(null);
     }

--- a/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depromeet/global/security/JwtAuthenticationFilter.java
@@ -31,12 +31,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenService jwtTokenService;
     private final CookieUtil cookieUtil;
 
+    private static String extractAccessTokenFromHeader(HttpServletRequest request) {
+        return request.getHeader(ACCESS_TOKEN_HEADER).replace(TOKEN_PREFIX, "");
+    }
+
     @Override
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String accessTokenHeaderValue = request.getHeader(ACCESS_TOKEN_HEADER);
+        String accessTokenHeaderValue = extractAccessTokenFromHeader(request);
         String accessTokenValue = extractAccessTokenFromCookie(request);
         String refreshTokenValue = extractRefreshTokenFromCookie(request);
 

--- a/src/main/java/com/depromeet/global/util/SecurityUtil.java
+++ b/src/main/java/com/depromeet/global/util/SecurityUtil.java
@@ -1,5 +1,7 @@
 package com.depromeet.global.util;
 
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -9,6 +11,10 @@ public class SecurityUtil {
 
     public Long getCurrentMemberId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return Long.parseLong(authentication.getName());
+        try {
+            return Long.parseLong(authentication.getName());
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.AUTH_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/depromeet/global/util/SecurityUtil.java
+++ b/src/main/java/com/depromeet/global/util/SecurityUtil.java
@@ -1,6 +1,6 @@
 package com.depromeet.global.util;
 
-import com.depromeet.global.security.PrincipalDetails;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
@@ -8,9 +8,7 @@ import org.springframework.stereotype.Component;
 public class SecurityUtil {
 
     public Long getCurrentMemberId() {
-        PrincipalDetails principal =
-                (PrincipalDetails)
-                        SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return Long.parseLong(principal.getUsername());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return Long.parseLong(authentication.getName());
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #258
- close #240 

## 📌 작업 내용 및 특이사항
- 스웨거 시큐리티 스키마 활성화 처리해서 API 요청 날릴 떄 헤더 포함되도록 세팅했습니다.
- 헤더 가져와서 Bearer prefix 떼주는 부분에서 NPE 발생하는 이슈 있어서, Optional로 감싸줬습니다.
    - p.s. 오늘 서버에서 503 터지는 이슈 있어서 서버 로그 확인해보니 누군가 NPE를 마구마구 터트리고 있어서... 서버가 공격당하는 줄 알고 식겁했지만... 알고보니 헬스체크를 정기적으로 날리는 LB였고... 헬스체크 API에서 NPE가 터지고 있어서 해당 이슈가 발생하는 거였습니다...
- 시큐리티 유틸리티에서 익명 유저로 로그인하는 경우 `getName()` 호출할 때 memberId가 아니라 문자열이 들어오기 때문에, try-catch로 감싸줬습니다.
- 또한 시큐리티 유틸에서 `PrincipalDetails` 로 캐스팅하는 방법 대신 `Authentication` 인터페이스가 제공하는 `getName()` 사용해서 좀 더 우아하게 처리해줬습니다.

## 📝 참고사항
- 

## 📚 기타
- 
