### PR TITLE
fix: nickname 검색 예외 처리 (escape)

### DIFF
--- a/src/main/java/com/depromeet/domain/member/api/MemberController.java
+++ b/src/main/java/com/depromeet/domain/member/api/MemberController.java
@@ -54,7 +54,8 @@ public class MemberController {
 
     @Operation(summary = "닉네임으로 회원 검색", description = "닉네임으로 회원을 검색합니다.")
     @GetMapping("/search")
-    public List<MemberSearchResponse> memberNicknameSearch(@RequestParam(required = false) String nickname) {
+    public List<MemberSearchResponse> memberNicknameSearch(
+            @RequestParam(required = false) String nickname) {
         return memberService.searchMemberNickname(nickname);
     }
 

--- a/src/main/java/com/depromeet/domain/member/api/MemberController.java
+++ b/src/main/java/com/depromeet/domain/member/api/MemberController.java
@@ -44,7 +44,7 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "닉네임 중복 체크", description = "닉네임 중복 체크를 진행합니다.")
+    @Operation(summary = "닉네임 유효성 체크", description = "닉네임 유효성 체크를 진행합니다.")
     @PostMapping("/check-nickname")
     public ResponseEntity<Void> memberNicknameCheck(
             @Valid @RequestBody NicknameCheckRequest request) {
@@ -77,8 +77,8 @@ public class MemberController {
     @Operation(summary = "회원 닉네임 변경", description = "회원 닉네임을 변경합니다.")
     @PutMapping("/me/nickname")
     public ResponseEntity<Void> memberNicknameUpdate(
-            @Valid @RequestBody NicknameUpdateRequest reqest) {
-        memberService.updateMemberNickname(reqest);
+            @Valid @RequestBody NicknameUpdateRequest request) {
+        memberService.updateMemberNickname(request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/depromeet/domain/member/api/MemberController.java
+++ b/src/main/java/com/depromeet/domain/member/api/MemberController.java
@@ -54,7 +54,7 @@ public class MemberController {
 
     @Operation(summary = "닉네임으로 회원 검색", description = "닉네임으로 회원을 검색합니다.")
     @GetMapping("/search")
-    public List<MemberSearchResponse> memberNicknameSearch(@RequestParam String nickname) {
+    public List<MemberSearchResponse> memberNicknameSearch(@RequestParam(required = false) String nickname) {
         return memberService.searchMemberNickname(nickname);
     }
 

--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -73,8 +73,11 @@ public class MemberService {
     @Transactional(readOnly = true)
     public List<MemberSearchResponse> searchMemberNickname(String nickname) {
         final Member currentMember = memberUtil.getCurrentMember();
+        final String escapingNickname = escapeSpecialCharacters(nickname);
+
         List<Member> members =
-                memberRepository.nicknameSearch(nickname, currentMember.getProfile().getNickname());
+                memberRepository.nicknameSearch(
+                        escapingNickname, currentMember.getProfile().getNickname());
         List<MemberRelation> memberRelationBySourceId =
                 memberRelationRepository.findAllBySourceIdAndTargetIn(
                         currentMember.getId(), members);
@@ -173,5 +176,10 @@ public class MemberService {
     public void updateFcmToken(UpdateFcmTokenRequest updateFcmTokenRequest) {
         final Member currentMember = memberUtil.getCurrentMember();
         currentMember.updateFcmToken(currentMember.getFcmInfo(), updateFcmTokenRequest.fcmToken());
+    }
+
+    private String escapeSpecialCharacters(String nickname) {
+        // 여기서 특수문자를 '_'로 대체할 수 있도록 정규표현식을 활용하여 구현
+        return nickname.replaceAll("[^0-9a-zA-Z가-힣 ]", "_");
     }
 }

--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -62,16 +62,16 @@ public class MemberService {
     @Transactional(readOnly = true)
     public void checkNickname(NicknameCheckRequest request) {
         validateNicknameNotDuplicate(request.nickname());
-		if (validateNicknameText(request.nickname())) {
-			throw new CustomException(ErrorCode.MEMBER_INVALID_NICKNAME);
-		}
+        if (validateNicknameText(request.nickname())) {
+            throw new CustomException(ErrorCode.MEMBER_INVALID_NICKNAME);
+        }
     }
 
-	private boolean validateNicknameText(String nickname) {
-		return nickname == null || nickname.trim().isEmpty();
-	}
+    private boolean validateNicknameText(String nickname) {
+        return nickname == null || nickname.trim().isEmpty();
+    }
 
-	private void validateNicknameNotDuplicate(String nickname) {
+    private void validateNicknameNotDuplicate(String nickname) {
         if (memberRepository.existsByProfileNickname(nickname)) {
             throw new CustomException(ErrorCode.MEMBER_ALREADY_NICKNAME);
         }

--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -180,6 +180,6 @@ public class MemberService {
 
     private String escapeSpecialCharacters(String nickname) {
         // 여기서 특수문자를 '_'로 대체할 수 있도록 정규표현식을 활용하여 구현
-        return nickname != null ? nickname.replaceAll("[^0-9a-zA-Z가-힣 ]", "_") : "";
+        return nickname == null ? "" : nickname.replaceAll("[^0-9a-zA-Z가-힣 ]", "_");
     }
 }

--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -62,9 +62,16 @@ public class MemberService {
     @Transactional(readOnly = true)
     public void checkNickname(NicknameCheckRequest request) {
         validateNicknameNotDuplicate(request.nickname());
+		if (validateNicknameText(request.nickname())) {
+			throw new CustomException(ErrorCode.MEMBER_INVALID_NICKNAME);
+		}
     }
 
-    private void validateNicknameNotDuplicate(String nickname) {
+	private boolean validateNicknameText(String nickname) {
+		return nickname == null || nickname.trim().isEmpty();
+	}
+
+	private void validateNicknameNotDuplicate(String nickname) {
         if (memberRepository.existsByProfileNickname(nickname)) {
             throw new CustomException(ErrorCode.MEMBER_ALREADY_NICKNAME);
         }
@@ -150,10 +157,10 @@ public class MemberService {
         }
     }
 
-    public void updateMemberNickname(NicknameUpdateRequest reqest) {
+    public void updateMemberNickname(NicknameUpdateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
-        validateNicknameNotDuplicate(reqest.nickname());
-        currentMember.updateNickname(reqest.nickname());
+        validateNicknameNotDuplicate(request.nickname());
+        currentMember.updateNickname(escapeSpecialCharacters(request.nickname()));
     }
 
     private ImageFileExtension getImageFileExtension(Profile profile) {

--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -180,6 +180,6 @@ public class MemberService {
 
     private String escapeSpecialCharacters(String nickname) {
         // 여기서 특수문자를 '_'로 대체할 수 있도록 정규표현식을 활용하여 구현
-        return nickname.replaceAll("[^0-9a-zA-Z가-힣 ]", "_");
+        return nickname != null ? nickname.replaceAll("[^0-9a-zA-Z가-힣 ]", "_") : "";
     }
 }

--- a/src/main/java/com/depromeet/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/depromeet/domain/member/dao/MemberRepository.java
@@ -20,8 +20,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByProfileNickname(String nickname);
 
-    @Query(
-            "SELECT m FROM Member m WHERE m.profile.nickname LIKE CONCAT('%', :searchNickname, '%') escape '_' AND m.profile.nickname != :myNickname")
+	@Query(
+		"SELECT m FROM Member m WHERE m.profile.nickname LIKE CONCAT('%', :searchNickname, '%') escape '_' AND m.profile.nickname != :myNickname")
     List<Member> nicknameSearch(
             @Param("searchNickname") String searchNickname, @Param("myNickname") String myNickname);
 }

--- a/src/main/java/com/depromeet/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/depromeet/domain/member/dao/MemberRepository.java
@@ -2,6 +2,7 @@ package com.depromeet.domain.member.dao;
 
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.OauthInfo;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,6 +21,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProfileNickname(String nickname);
 
     @Query(
-            "SELECT m FROM Member m WHERE m.profile.nickname like %:searchNickname% AND m.profile.nickname != :myNickname")
-    List<Member> nicknameSearch(String searchNickname, String myNickname);
+            "SELECT m FROM Member m WHERE m.profile.nickname LIKE CONCAT('%', :searchNickname, '%') escape '_' AND m.profile.nickname != :myNickname")
+    List<Member> nicknameSearch(
+            @Param("searchNickname") String searchNickname, @Param("myNickname") String myNickname);
 }

--- a/src/main/java/com/depromeet/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/depromeet/domain/member/dao/MemberRepository.java
@@ -20,8 +20,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByProfileNickname(String nickname);
 
-	@Query(
-		"SELECT m FROM Member m WHERE m.profile.nickname LIKE CONCAT('%', :searchNickname, '%') escape '_' AND m.profile.nickname != :myNickname")
+    @Query(
+            "SELECT m FROM Member m WHERE m.profile.nickname LIKE CONCAT('%', :searchNickname, '%') escape '_' AND m.profile.nickname != :myNickname")
     List<Member> nicknameSearch(
             @Param("searchNickname") String searchNickname, @Param("myNickname") String myNickname);
 }

--- a/src/main/java/com/depromeet/domain/member/domain/Profile.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Profile.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
 
-    @Pattern(regexp = "[^0-9a-zA-Z가-힣 ]", message = "올바르지 않는 닉네임 표현입니다.")
+    @Pattern(regexp = "[^0-9a-zA-Z가-힣 ]", message = "올바르지 않은 닉네임 표현입니다.")
     private String nickname;
 
     @Getter private String profileImageUrl;

--- a/src/main/java/com/depromeet/domain/member/domain/Profile.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Profile.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
 
-    @Pattern(regexp = "[^0-9a-zA-Z가-힣]")
+    @Pattern(regexp = "[^0-9a-zA-Z가-힣 ]")
     private String nickname;
 
     @Getter private String profileImageUrl;

--- a/src/main/java/com/depromeet/domain/member/domain/Profile.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Profile.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
 
-    @Pattern(regexp = "[^0-9a-zA-Z가-힣 ]")
+    @Pattern(regexp = "[^0-9a-zA-Z가-힣 ]", message = "올바르지 않는 닉네임 표현입니다.")
     private String nickname;
 
     @Getter private String profileImageUrl;

--- a/src/main/java/com/depromeet/domain/member/domain/Profile.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Profile.java
@@ -1,13 +1,17 @@
 package com.depromeet.domain.member.domain;
 
 import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
+
+    @Pattern(regexp = "[^0-9a-zA-Z가-힣]")
     private String nickname;
+
     @Getter private String profileImageUrl;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
     MEMBER_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 가입된 회원입니다."),
     MEMBER_ALREADY_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+    MEMBER_INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "올바르지 않는 닉네임입니다."),
     MEMBER_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 탈퇴한 회원입니다."),
     PASSWORD_NOT_MATCHES(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),

--- a/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/depromeet/domain/member/application/MemberServiceTest.java
@@ -182,6 +182,64 @@ class MemberServiceTest {
         }
 
         @Test
+        void 검색_키워드에_퍼센트_키워드가_들어왔을_때_NPE_무시_처리한다() {
+            // given
+            memberRepository.save(
+                    Member.createNormalMember(Profile.createProfile("도모", "도모 이미지 URL")));
+            memberRepository.save(
+                    Member.createNormalMember(Profile.createProfile("도모 바보", "testImageUrl")));
+
+            String searchNickname = "%";
+
+            // when
+            List<MemberSearchResponse> responses =
+                    memberService.searchMemberNickname(searchNickname);
+
+            // then
+            assertEquals(0, responses.size());
+        }
+
+        @Test
+        void 검색_키워드에_공백에_따른_처리만_허용한다() {
+            // given
+            memberRepository.save(Member.createNormalMember(Profile.createProfile("바보", "도모 얼굴")));
+            memberRepository.save(
+                    Member.createNormalMember(Profile.createProfile("도 모", "도모 이미지 URL")));
+            memberRepository.save(
+                    Member.createNormalMember(Profile.createProfile("도모 바보", "testImageUrl")));
+            memberRepository.save(
+                    Member.createNormalMember(Profile.createProfile(" 도모", "도모 잘생김")));
+            String searchNickname = " ";
+
+            // when
+            List<MemberSearchResponse> responses =
+                    memberService.searchMemberNickname(searchNickname);
+
+            // then
+            assertEquals(3, responses.size());
+        }
+
+        @Test
+        void 검색_키워드에_특수문자_입력_시_정규식_예외처리를_한다() {
+            // given
+            memberRepository.save(
+                    Member.createNormalMember(Profile.createProfile("#도모", "도모 이미지 URL")));
+            memberRepository.save(
+                    Member.createNormalMember(Profile.createProfile("도모 바보#", "testImageUrl")));
+
+            memberRepository.save(
+                    Member.createNormalMember(Profile.createProfile("#도모 바보#", "testImageUrl")));
+            String searchNickname = "#";
+
+            // when
+            List<MemberSearchResponse> responses =
+                    memberService.searchMemberNickname(searchNickname);
+
+            // then
+            assertEquals(0, responses.size());
+        }
+
+        @Test
         void 정렬조건은_일치하는경우_먼저보여주고_나머지는_사전순에_따른다() {
             // given
             String searchNickname = "도모";


### PR DESCRIPTION
## 🌱 관련 이슈
- close #266 

## 📌 작업 내용 및 특이사항
**nickname 검색 시 특수문자, 공백에 대한 예외처리**
- 정규식으로 한글, 숫자, 영문 대소문자는 `_`로 replaceAll 처리 후 nativeQuery에서 _로 escaping
- controller에서는 `%` 키워드가 직접 들어올 시 null로 처리하게 되어 NullPointException이 터지는 이슈 해결

## 📝 참고사항
- 디쟌팀과 추가 기획사항이 발생 시 추가 수정 예정

## 📚 기타
- 이렇게 하는 게 맞는 지 본인도 헷갈리니 꼼꼼한 리뷰 바람
