### PR TITLE
feat: 유저 팔로잉/팔로워 목록 조회 API

### DIFF
--- a/src/main/java/com/depromeet/domain/follow/api/FollowController.java
+++ b/src/main/java/com/depromeet/domain/follow/api/FollowController.java
@@ -5,10 +5,12 @@ import com.depromeet.domain.follow.dto.request.FollowCreateRequest;
 import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
 import com.depromeet.domain.follow.dto.response.FollowFindMeInfoResponse;
 import com.depromeet.domain.follow.dto.response.FollowFindTargetInfoResponse;
+import com.depromeet.domain.follow.dto.response.FollowListResponse;
 import com.depromeet.domain.follow.dto.response.MemberFollowedResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -56,4 +58,12 @@ public class FollowController {
     public List<MemberFollowedResponse> followedUserFindAll() {
         return followService.findAllFollowedMember();
     }
+
+    // 팔로잉, 팔로워 리스트 응답
+    @GetMapping("/{targetId}/list")
+    @Operation(summary = "팔로잉, 팔로워 유저 리스트를 반환합니다", description = "팔로잉, 팔로워 유저들을 반환합니다.")
+    public FollowListResponse followList(@PathVariable Long targetId) {
+        return followService.findFollowList(targetId);
+    }
+
 }

--- a/src/main/java/com/depromeet/domain/follow/api/FollowController.java
+++ b/src/main/java/com/depromeet/domain/follow/api/FollowController.java
@@ -10,7 +10,6 @@ import com.depromeet.domain.follow.dto.response.MemberFollowedResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -65,5 +64,4 @@ public class FollowController {
     public FollowListResponse followList(@PathVariable Long targetId) {
         return followService.findFollowList(targetId);
     }
-
 }

--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -4,12 +4,10 @@ import com.depromeet.domain.follow.dao.MemberRelationRepository;
 import com.depromeet.domain.follow.domain.MemberRelation;
 import com.depromeet.domain.follow.dto.request.FollowCreateRequest;
 import com.depromeet.domain.follow.dto.request.FollowDeleteRequest;
-import com.depromeet.domain.follow.dto.response.FollowFindMeInfoResponse;
-import com.depromeet.domain.follow.dto.response.FollowFindTargetInfoResponse;
-import com.depromeet.domain.follow.dto.response.FollowStatus;
-import com.depromeet.domain.follow.dto.response.MemberFollowedResponse;
+import com.depromeet.domain.follow.dto.response.*;
 import com.depromeet.domain.member.dao.MemberRepository;
 import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.member.dto.response.MemberSearchResponse;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.missionRecord.domain.ImageUploadStatus;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
@@ -187,5 +185,100 @@ public class FollowService {
                                         new CustomException(
                                                 ErrorCode.FOLLOW_TARGET_MEMBER_NOT_FOUND));
         return targetMember;
+    }
+
+    public FollowListResponse findFollowList(Long targetId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        Member targetMember = getTargetMember(targetId);
+
+        List<MemberSearchResponse> followingList = new ArrayList<>();
+        List<MemberSearchResponse> followerList = new ArrayList<>();
+
+        List<MemberRelation> targetMemberSources = memberRelationRepository.findAllBySourceId(targetMember.getId());
+        List<MemberRelation> targetMemberTargets = memberRelationRepository.findAllByTargetId(targetMember.getId());
+
+        List<MemberRelation> currentMemberSources = memberRelationRepository.findAllBySourceId(currentMember.getId());
+        List<MemberRelation> currentMemberTargets = memberRelationRepository.findAllByTargetId(currentMember.getId());
+
+        // target 유저의 팔로잉
+        List<Member> followingMembers = targetMemberSources.stream().map(MemberRelation::getTarget).toList();
+
+        // target 유저의 팔로워
+        List<Member> followerMembers = targetMemberTargets.stream().map(MemberRelation::getSource).toList();
+
+//        // current 유저의 팔로잉
+//        List<Member> currentFollowingMembers = currentMemberSources.stream().map(MemberRelation::getTarget).toList();
+//
+//        // current 유저의 팔로워
+//        List<Member> currentFollowerMembers = currentMemberTargets.stream()
+//            .map(MemberRelation::getSource)
+//            .toList();
+
+        // 팔로잉 리스트 구하기
+        for (Member member : followingMembers) {
+            boolean existRelation = false;
+            for (MemberRelation memberRelation : currentMemberSources) {
+                if (member.getId().equals(memberRelation.getTarget().getId())) {
+                    existRelation = true;
+                    break;
+                }
+            }
+
+            if (existRelation) { // 조회 된 애들 중 내가 팔로우한 애라면
+                followingList.add(MemberSearchResponse.toFollowingResponse(member));
+                continue;
+            }
+
+            // 내가 팔로우를 하지 않았을 때
+            Optional<MemberRelation> optionalMemberRelation =
+                    currentMemberTargets.stream()
+                            .filter(
+                                    memberRelation ->
+                                            member.getId()
+                                                    .equals(memberRelation.getSource().getId()))
+                            .findFirst();
+            if (optionalMemberRelation.isPresent()) { // 상대방만 나를 팔로우 하고 있을  때
+                followingList.add(MemberSearchResponse.toFollowedByMeResponse(member));
+                continue;
+            }
+
+            // 아니라면 서로 팔로우가 아닌 상태
+            followingList.add(MemberSearchResponse.toNotFollowingResponse(member));
+        }
+
+        // 팔로워 리스트 구하기
+        for (Member member : followerMembers) {
+            boolean existRelation = false;
+            for (MemberRelation memberRelation : currentMemberSources) {
+                if (member.getId().equals(memberRelation.getTarget().getId())) {
+                    existRelation = true;
+                    break;
+                }
+            }
+
+            if (existRelation) { // 조회 된 애들 중 내가 팔로우한 애라면
+                followerList.add(MemberSearchResponse.toFollowingResponse(member));
+                continue;
+            }
+
+            // 내가 팔로우를 하지 않았을 때
+            Optional<MemberRelation> optionalMemberRelation =
+                    currentMemberTargets.stream()
+                            .filter(
+                                    memberRelation ->
+                                            member.getId()
+                                                    .equals(memberRelation.getSource().getId()))
+                            .findFirst();
+            if (optionalMemberRelation.isPresent()) { // 상대방만 나를 팔로우 하고 있을  때
+                followerList.add(MemberSearchResponse.toFollowedByMeResponse(member));
+                continue;
+            }
+
+            // 아니라면 서로 팔로우가 아닌 상태
+            followerList.add(MemberSearchResponse.toNotFollowingResponse(member));
+        }
+
+        return FollowListResponse.of(targetMember.getProfile().getNickname(), followingList, followerList);
+
     }
 }

--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -213,16 +213,22 @@ public class FollowService {
                 targetMemberTargets.stream().map(MemberRelation::getSource).toList();
 
         // 팔로잉 리스트 구하기
-        getFollowStatusIncludeList(followingMembers, currentMemberSources, followingList, currentMemberTargets);
+        getFollowStatusIncludeList(
+                followingMembers, currentMemberSources, followingList, currentMemberTargets);
 
         // 팔로워 리스트 구하기
-        getFollowStatusIncludeList(followerMembers, currentMemberSources, followerList, currentMemberTargets);
+        getFollowStatusIncludeList(
+                followerMembers, currentMemberSources, followerList, currentMemberTargets);
 
         return FollowListResponse.of(
                 targetMember.getProfile().getNickname(), followingList, followerList);
     }
 
-    private static void getFollowStatusIncludeList(List<Member> targetMembers, List<MemberRelation> currentMemberSources, List<MemberSearchResponse> resultList, List<MemberRelation> currentMemberTargets) {
+    private static void getFollowStatusIncludeList(
+            List<Member> targetMembers,
+            List<MemberRelation> currentMemberSources,
+            List<MemberSearchResponse> resultList,
+            List<MemberRelation> currentMemberTargets) {
         for (Member member : targetMembers) {
             boolean existRelation = false;
             for (MemberRelation memberRelation : currentMemberSources) {

--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -194,25 +194,32 @@ public class FollowService {
         List<MemberSearchResponse> followingList = new ArrayList<>();
         List<MemberSearchResponse> followerList = new ArrayList<>();
 
-        List<MemberRelation> targetMemberSources = memberRelationRepository.findAllBySourceId(targetMember.getId());
-        List<MemberRelation> targetMemberTargets = memberRelationRepository.findAllByTargetId(targetMember.getId());
+        List<MemberRelation> targetMemberSources =
+                memberRelationRepository.findAllBySourceId(targetMember.getId());
+        List<MemberRelation> targetMemberTargets =
+                memberRelationRepository.findAllByTargetId(targetMember.getId());
 
-        List<MemberRelation> currentMemberSources = memberRelationRepository.findAllBySourceId(currentMember.getId());
-        List<MemberRelation> currentMemberTargets = memberRelationRepository.findAllByTargetId(currentMember.getId());
+        List<MemberRelation> currentMemberSources =
+                memberRelationRepository.findAllBySourceId(currentMember.getId());
+        List<MemberRelation> currentMemberTargets =
+                memberRelationRepository.findAllByTargetId(currentMember.getId());
 
         // target 유저의 팔로잉
-        List<Member> followingMembers = targetMemberSources.stream().map(MemberRelation::getTarget).toList();
+        List<Member> followingMembers =
+                targetMemberSources.stream().map(MemberRelation::getTarget).toList();
 
         // target 유저의 팔로워
-        List<Member> followerMembers = targetMemberTargets.stream().map(MemberRelation::getSource).toList();
+        List<Member> followerMembers =
+                targetMemberTargets.stream().map(MemberRelation::getSource).toList();
 
-//        // current 유저의 팔로잉
-//        List<Member> currentFollowingMembers = currentMemberSources.stream().map(MemberRelation::getTarget).toList();
-//
-//        // current 유저의 팔로워
-//        List<Member> currentFollowerMembers = currentMemberTargets.stream()
-//            .map(MemberRelation::getSource)
-//            .toList();
+        //        // current 유저의 팔로잉
+        //        List<Member> currentFollowingMembers =
+        // currentMemberSources.stream().map(MemberRelation::getTarget).toList();
+        //
+        //        // current 유저의 팔로워
+        //        List<Member> currentFollowerMembers = currentMemberTargets.stream()
+        //            .map(MemberRelation::getSource)
+        //            .toList();
 
         // 팔로잉 리스트 구하기
         for (Member member : followingMembers) {
@@ -278,7 +285,7 @@ public class FollowService {
             followerList.add(MemberSearchResponse.toNotFollowingResponse(member));
         }
 
-        return FollowListResponse.of(targetMember.getProfile().getNickname(), followingList, followerList);
-
+        return FollowListResponse.of(
+                targetMember.getProfile().getNickname(), followingList, followerList);
     }
 }

--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -212,80 +212,46 @@ public class FollowService {
         List<Member> followerMembers =
                 targetMemberTargets.stream().map(MemberRelation::getSource).toList();
 
-        //        // current 유저의 팔로잉
-        //        List<Member> currentFollowingMembers =
-        // currentMemberSources.stream().map(MemberRelation::getTarget).toList();
-        //
-        //        // current 유저의 팔로워
-        //        List<Member> currentFollowerMembers = currentMemberTargets.stream()
-        //            .map(MemberRelation::getSource)
-        //            .toList();
-
         // 팔로잉 리스트 구하기
-        for (Member member : followingMembers) {
-            boolean existRelation = false;
-            for (MemberRelation memberRelation : currentMemberSources) {
-                if (member.getId().equals(memberRelation.getTarget().getId())) {
-                    existRelation = true;
-                    break;
-                }
-            }
-
-            if (existRelation) { // 조회 된 애들 중 내가 팔로우한 애라면
-                followingList.add(MemberSearchResponse.toFollowingResponse(member));
-                continue;
-            }
-
-            // 내가 팔로우를 하지 않았을 때
-            Optional<MemberRelation> optionalMemberRelation =
-                    currentMemberTargets.stream()
-                            .filter(
-                                    memberRelation ->
-                                            member.getId()
-                                                    .equals(memberRelation.getSource().getId()))
-                            .findFirst();
-            if (optionalMemberRelation.isPresent()) { // 상대방만 나를 팔로우 하고 있을  때
-                followingList.add(MemberSearchResponse.toFollowedByMeResponse(member));
-                continue;
-            }
-
-            // 아니라면 서로 팔로우가 아닌 상태
-            followingList.add(MemberSearchResponse.toNotFollowingResponse(member));
-        }
+        getFollowStatusIncludeList(followingMembers, currentMemberSources, followingList, currentMemberTargets);
 
         // 팔로워 리스트 구하기
-        for (Member member : followerMembers) {
-            boolean existRelation = false;
-            for (MemberRelation memberRelation : currentMemberSources) {
-                if (member.getId().equals(memberRelation.getTarget().getId())) {
-                    existRelation = true;
-                    break;
-                }
-            }
-
-            if (existRelation) { // 조회 된 애들 중 내가 팔로우한 애라면
-                followerList.add(MemberSearchResponse.toFollowingResponse(member));
-                continue;
-            }
-
-            // 내가 팔로우를 하지 않았을 때
-            Optional<MemberRelation> optionalMemberRelation =
-                    currentMemberTargets.stream()
-                            .filter(
-                                    memberRelation ->
-                                            member.getId()
-                                                    .equals(memberRelation.getSource().getId()))
-                            .findFirst();
-            if (optionalMemberRelation.isPresent()) { // 상대방만 나를 팔로우 하고 있을  때
-                followerList.add(MemberSearchResponse.toFollowedByMeResponse(member));
-                continue;
-            }
-
-            // 아니라면 서로 팔로우가 아닌 상태
-            followerList.add(MemberSearchResponse.toNotFollowingResponse(member));
-        }
+        getFollowStatusIncludeList(followerMembers, currentMemberSources, followerList, currentMemberTargets);
 
         return FollowListResponse.of(
                 targetMember.getProfile().getNickname(), followingList, followerList);
+    }
+
+    private static void getFollowStatusIncludeList(List<Member> targetMembers, List<MemberRelation> currentMemberSources, List<MemberSearchResponse> resultList, List<MemberRelation> currentMemberTargets) {
+        for (Member member : targetMembers) {
+            boolean existRelation = false;
+            for (MemberRelation memberRelation : currentMemberSources) {
+                if (member.getId().equals(memberRelation.getTarget().getId())) {
+                    existRelation = true;
+                    break;
+                }
+            }
+
+            if (existRelation) { // 조회 된 애들 중 내가 팔로우한 애라면
+                resultList.add(MemberSearchResponse.toFollowingResponse(member));
+                continue;
+            }
+
+            // 내가 팔로우를 하지 않았을 때
+            Optional<MemberRelation> optionalMemberRelation =
+                    currentMemberTargets.stream()
+                            .filter(
+                                    memberRelation ->
+                                            member.getId()
+                                                    .equals(memberRelation.getSource().getId()))
+                            .findFirst();
+            if (optionalMemberRelation.isPresent()) { // 상대방만 나를 팔로우 하고 있을  때
+                resultList.add(MemberSearchResponse.toFollowedByMeResponse(member));
+                continue;
+            }
+
+            // 아니라면 서로 팔로우가 아닌 상태
+            resultList.add(MemberSearchResponse.toNotFollowingResponse(member));
+        }
     }
 }

--- a/src/main/java/com/depromeet/domain/follow/dto/response/FollowListResponse.java
+++ b/src/main/java/com/depromeet/domain/follow/dto/response/FollowListResponse.java
@@ -1,0 +1,19 @@
+package com.depromeet.domain.follow.dto.response;
+
+import com.depromeet.domain.member.dto.response.MemberSearchResponse;
+
+import java.util.List;
+
+public record FollowListResponse(
+        String targetNickname,
+        List<MemberSearchResponse> followingList,
+        List<MemberSearchResponse> followerList
+) {
+    public static FollowListResponse of(
+            String targetNickname,
+            List<MemberSearchResponse> followingList,
+            List<MemberSearchResponse> followerList
+    ) {
+        return new FollowListResponse(targetNickname, followingList, followerList);
+    }
+}

--- a/src/main/java/com/depromeet/domain/follow/dto/response/FollowListResponse.java
+++ b/src/main/java/com/depromeet/domain/follow/dto/response/FollowListResponse.java
@@ -1,19 +1,16 @@
 package com.depromeet.domain.follow.dto.response;
 
 import com.depromeet.domain.member.dto.response.MemberSearchResponse;
-
 import java.util.List;
 
 public record FollowListResponse(
         String targetNickname,
         List<MemberSearchResponse> followingList,
-        List<MemberSearchResponse> followerList
-) {
+        List<MemberSearchResponse> followerList) {
     public static FollowListResponse of(
             String targetNickname,
             List<MemberSearchResponse> followingList,
-            List<MemberSearchResponse> followerList
-    ) {
+            List<MemberSearchResponse> followerList) {
         return new FollowListResponse(targetNickname, followingList, followerList);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #273 

## 📌 작업 내용 및 특이사항

<img src="https://github.com/depromeet/10mm-server/assets/64088250/74a7cd10-358e-4c6c-b85e-324220bb4a0c" width="600"/>

- 회원 프로필 페이지에서 팔로잉/팔로워 카운트는 현재 보여주고 있으나, 클릭 시(위 이미지 우측) 리스트를 조회할 수 있어야 합니다.


아래와 같이 API 응답 예정입니다
```java
{
  "success": true,
  "status": 200,
  "data": {
    "targetNickname": "",
    "followingList": [
      {
        "memberId": 2,
        "nickname": "ㅅㄷㄴㅅ",
        "profileImageUrl": "https://kr.object.ncloudstorage.com/10mm-images/local/member_profile/1/image.jpeg",
        "followStatus": "FOLLOWING"
      },
      {
        "memberId": 4,
        "nickname": "4번",
        "profileImageUrl": "https://kr.object.ncloudstorage.com/10mm-images/local/member_profile/1/image.jpeg",
        "followStatus": "FOLLOWING"
      }
    ],
    "followerList": [
      {
        "memberId": 5,
        "nickname": "5",
        "profileImageUrl": "https://kr.object.ncloudstorage.com/10mm-images/local/member_profile/1/image.jpeg",
        "followStatus": "FOLLOWED_BY_ME"
      }
    ]
  },
  "timestamp": "2024-02-05T12:51:27.056682"
}
```
