### PR TITLE
feat: 피드 탭 구현

### DIFF
--- a/src/main/java/com/depromeet/domain/feed/api/FeedController.java
+++ b/src/main/java/com/depromeet/domain/feed/api/FeedController.java
@@ -1,0 +1,26 @@
+package com.depromeet.domain.feed.api;
+
+import com.depromeet.domain.feed.application.FeedService;
+import com.depromeet.domain.feed.dto.response.FeedOneResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "6. [피드]", description = "피드 관련 API입니다.")
+@RequestMapping("/feed")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final FeedService feedService;
+
+    @Operation(summary = "피드 탭", description = "피드 탭을 조회합니다.")
+    @GetMapping
+    public List<FeedOneResponse> feedFindAll() {
+        return feedService.findAllFeed();
+    }
+}

--- a/src/main/java/com/depromeet/domain/feed/api/FeedController.java
+++ b/src/main/java/com/depromeet/domain/feed/api/FeedController.java
@@ -1,12 +1,14 @@
 package com.depromeet.domain.feed.api;
 
 import com.depromeet.domain.feed.application.FeedService;
+import com.depromeet.domain.feed.dto.response.FeedOneByProfileResponse;
 import com.depromeet.domain.feed.dto.response.FeedOneResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,8 +21,14 @@ public class FeedController {
     private final FeedService feedService;
 
     @Operation(summary = "피드 탭", description = "피드 탭을 조회합니다.")
-    @GetMapping
+    @GetMapping("/me")
     public List<FeedOneResponse> feedFindAll() {
         return feedService.findAllFeed();
+    }
+
+    @Operation(summary = "프로필 피드", description = "피드 탭을 조회합니다.")
+    @GetMapping("/{targetId}")
+    public List<FeedOneByProfileResponse> feedFindAllByTargetId(@PathVariable Long targetId) {
+        return feedService.findAllFeedByTargetId(targetId);
     }
 }

--- a/src/main/java/com/depromeet/domain/feed/api/FeedController.java
+++ b/src/main/java/com/depromeet/domain/feed/api/FeedController.java
@@ -27,8 +27,8 @@ public class FeedController {
     }
 
     @Operation(summary = "프로필 피드", description = "피드 탭을 조회합니다.")
-    @GetMapping("/{targetId}")
-    public List<FeedOneByProfileResponse> feedFindAllByTargetId(@PathVariable Long targetId) {
-        return feedService.findAllFeedByTargetId(targetId);
+    @GetMapping("/{memberId}")
+    public List<FeedOneByProfileResponse> feedFindAllByTargetId(@PathVariable Long memberId) {
+        return feedService.findAllFeedByTargetId(memberId);
     }
 }

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -76,10 +76,7 @@ public class FeedService {
     }
 
     private List<FeedOneByProfileResponse> extractFeedResponses(List<MissionRecord> records) {
-        return records.stream()
-                // .map(record -> FeedOneByProfileResponse.of(record.getMission(), record))
-                .map(FeedOneByProfileResponse::of)
-                .toList();
+        return records.stream().map(FeedOneByProfileResponse::of).toList();
     }
 
     private List<MissionVisibility> determineVisibilityConditionsByRelationsWithMe(

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -1,20 +1,18 @@
 package com.depromeet.domain.feed.application;
 
+import com.depromeet.domain.feed.dto.response.FeedOneByProfileResponse;
 import com.depromeet.domain.feed.dto.response.FeedOneResponse;
 import com.depromeet.domain.follow.dao.MemberRelationRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.dao.MissionRepository;
 import com.depromeet.domain.mission.domain.Mission;
-import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
+import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.global.util.MemberUtil;
-
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.IntStream;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,26 +22,86 @@ public class FeedService {
     private final MemberUtil memberUtil;
     private final MissionRepository missionRepository;
     private final MemberRelationRepository memberRelationRepository;
-	private final MissionRecordRepository missionRecordRepository;
 
-	public List<FeedOneResponse> findAllFeed() {
+    public List<FeedOneResponse> findAllFeed() {
         final Member currentMember = memberUtil.getCurrentMember();
         List<Long> sourceIds =
-                memberRelationRepository.findAllBySourceId(currentMember.getId()).stream()
-                        .map(memberRelation -> memberRelation.getTarget().getId())
-                        .toList();
+                new ArrayList<>(
+                        memberRelationRepository.findAllBySourceId(currentMember.getId()).stream()
+                                .map(memberRelation -> memberRelation.getTarget().getId())
+                                .toList());
+        sourceIds.add(currentMember.getId());
 
         List<Mission> feedAll = missionRepository.findFeedAll(sourceIds);
 
-		List<FeedOneResponse> returnList = feedAll.stream()
-			.flatMap(mission -> {
-				List<MissionRecord> missionRecords = mission.getMissionRecords();
-				return missionRecords.stream()
-					.filter(Objects::nonNull)
-					.map(record -> FeedOneResponse.of(mission, record));
-			})
-			.toList();
+        return feedAll.stream()
+                .flatMap(
+                        mission -> {
+                            List<MissionRecord> missionRecords = mission.getMissionRecords();
+                            return missionRecords.stream()
+                                    .filter(Objects::nonNull)
+                                    .map(record -> FeedOneResponse.of(mission, record));
+                        })
+                .toList();
+    }
 
-		return returnList;
+    public List<FeedOneByProfileResponse> findAllFeedByTargetId(Long targetId) {
+        Member sourceMember = memberUtil.getCurrentMember();
+
+        /*
+         본인 프로필
+         targetId가 본인이다.
+         그렇다면 공개 여부 상관없이 full-scan
+
+         타인 프로필
+         만약 sourceId와 targetId가 다르다.
+         그렇다면 공개 여부에서 비공개는 exclude 한다.
+         추가로 내가 타인 프로필에서 팔로잉 관계가 이뤄졌는지 여부 확인하여 팔로우 관계 여부 체크
+        */
+        if (targetId != null) {
+            return findFeedByTargetMember(sourceMember, targetId);
+        } else {
+            return findFeedBySourceMember(sourceMember);
+        }
+    }
+
+    private List<FeedOneByProfileResponse> findFeedByTargetMember(
+            Member sourceMember, Long targetId) {
+        final Member targetMember = memberUtil.getMemberByMemberId(targetId);
+        List<MissionVisibility> visibilities =
+                new ArrayList<>(Arrays.asList(MissionVisibility.ALL));
+
+        // 팔로우 관계 true: visibility.FOLLOW and ALL, false: visibility.ALL only
+        boolean existMemberRelation =
+                memberRelationRepository.existsBySourceIdAndTargetId(
+                        sourceMember.getId(), targetMember.getId());
+        if (existMemberRelation) {
+            visibilities.add(MissionVisibility.FOLLOWER);
+        }
+        if (sourceMember.getId().equals(targetId)) {
+            visibilities.add(MissionVisibility.FOLLOWER);
+            visibilities.add(MissionVisibility.NONE);
+        }
+        List<Mission> feedAllByMemberId =
+                missionRepository.findFeedAllByMemberId(targetId, visibilities);
+        return extractFeedResponses(feedAllByMemberId);
+    }
+
+    private List<FeedOneByProfileResponse> findFeedBySourceMember(Member sourceMember) {
+        List<Mission> feedAllByMemberId =
+                missionRepository.findFeedAllByMemberId(sourceMember.getId(), null);
+        return extractFeedResponses(feedAllByMemberId);
+    }
+
+    private List<FeedOneByProfileResponse> extractFeedResponses(List<Mission> missions) {
+        return missions.stream()
+                .flatMap(
+                        mission -> {
+                            List<MissionRecord> missionRecords = mission.getMissionRecords();
+                            return missionRecords.stream()
+                                    .filter(Objects::nonNull)
+                                    .map(record -> FeedOneByProfileResponse.of(mission, record));
+                        })
+                .toList();
     }
 }

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -11,7 +11,6 @@ import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.global.util.MemberUtil;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -44,16 +43,16 @@ public class FeedService {
         Member sourceMember = memberUtil.getCurrentMember();
 
         /*
-         본인 프로필
+         본인 프로필 findFeedBySourceMember
          targetId가 본인이다.
          그렇다면 공개 여부 상관없이 full-scan
 
-         타인 프로필
+         타인 프로필 findFeedByTargetMember
          만약 sourceId와 targetId가 다르다.
          그렇다면 공개 여부에서 비공개는 exclude 한다.
          추가로 내가 타인 프로필에서 팔로잉 관계가 이뤄졌는지 여부 확인하여 팔로우 관계 여부 체크
         */
-        if (targetId != null) {
+        if (!targetId.equals(sourceMember.getId())) {
             return findFeedByTargetMember(sourceMember, targetId);
         } else {
             return findFeedBySourceMember(sourceMember);
@@ -63,8 +62,7 @@ public class FeedService {
     private List<FeedOneByProfileResponse> findFeedByTargetMember(
             Member sourceMember, Long targetId) {
         final Member targetMember = memberUtil.getMemberByMemberId(targetId);
-        List<MissionVisibility> visibilities =
-                new ArrayList<>(Arrays.asList(MissionVisibility.ALL));
+        List<MissionVisibility> visibilities = new ArrayList<>(List.of(MissionVisibility.ALL));
 
         // 팔로우 관계 true: visibility.FOLLOW and ALL, false: visibility.ALL only
         boolean existMemberRelation =

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -43,14 +43,14 @@ public class FeedService {
     public List<FeedOneByProfileResponse> findAllFeedByTargetId(Long targetId) {
         final Long sourceId = securityUtil.getCurrentMemberId();
 
-        if (!isMyFeedRequired(targetId, sourceId)) {
+        if (isMyFeedRequired(targetId, sourceId)) {
             return findFeedByOtherMember(sourceId, targetId);
         }
         return findFeedByCurrentMember(sourceId);
     }
 
     private boolean isMyFeedRequired(Long targetId, Long sourceId) {
-        return targetId.equals(sourceId);
+        return !targetId.equals(sourceId);
     }
 
     private List<FeedOneByProfileResponse> findFeedByOtherMember(Long sourceId, Long targetId) {
@@ -60,12 +60,10 @@ public class FeedService {
         boolean isMemberRelationExistsWithMe =
                 memberRelationRepository.existsBySourceIdAndTargetId(
                         sourceId, targetMember.getId());
-
+        List<MissionVisibility> visibilities =
+                determineVisibilityConditionsByRelationsWithMe(isMemberRelationExistsWithMe);
         List<MissionRecord> feedAllByMemberId =
-                missionRecordRepository.findFeedAllByMemberId(
-                        targetId,
-                        determineVisibilityConditionsByRelationsWithMe(
-                                isMemberRelationExistsWithMe));
+                missionRecordRepository.findFeedAllByMemberId(targetId, visibilities);
         return extractFeedResponses(feedAllByMemberId);
     }
 
@@ -79,7 +77,8 @@ public class FeedService {
 
     private List<FeedOneByProfileResponse> extractFeedResponses(List<MissionRecord> records) {
         return records.stream()
-                .map(record -> FeedOneByProfileResponse.of(record.getMission(), record))
+                // .map(record -> FeedOneByProfileResponse.of(record.getMission(), record))
+                .map(FeedOneByProfileResponse::of)
                 .toList();
     }
 

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -3,6 +3,7 @@ package com.depromeet.domain.feed.application;
 import com.depromeet.domain.feed.dto.response.FeedOneByProfileResponse;
 import com.depromeet.domain.feed.dto.response.FeedOneResponse;
 import com.depromeet.domain.follow.dao.MemberRelationRepository;
+import com.depromeet.domain.follow.domain.MemberRelation;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
@@ -29,13 +30,13 @@ public class FeedService {
     @Transactional(readOnly = true)
     public List<FeedOneResponse> findAllFeed() {
         final Member currentMember = memberUtil.getCurrentMember();
-        List<Long> sourceIds =
+        List<Member> members =
                 memberRelationRepository.findAllBySourceId(currentMember.getId()).stream()
-                        .map(memberRelation -> memberRelation.getTarget().getId())
+                        .map(MemberRelation::getTarget)
                         .collect(Collectors.toList());
-        sourceIds.add(currentMember.getId());
+        members.add(currentMember);
 
-        return missionRecordRepository.findFeedAll(sourceIds);
+        return missionRecordRepository.findFeedAll(members);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -4,15 +4,14 @@ import com.depromeet.domain.feed.dto.response.FeedOneByProfileResponse;
 import com.depromeet.domain.feed.dto.response.FeedOneResponse;
 import com.depromeet.domain.follow.dao.MemberRelationRepository;
 import com.depromeet.domain.member.domain.Member;
-import com.depromeet.domain.mission.dao.MissionRepository;
-import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.global.util.MemberUtil;
+import com.depromeet.global.util.SecurityUtil;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,79 +21,73 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FeedService {
     private final MemberUtil memberUtil;
-    private final MissionRepository missionRepository;
     private final MissionRecordRepository missionRecordRepository;
     private final MemberRelationRepository memberRelationRepository;
+    private final SecurityUtil securityUtil;
 
     @Transactional(readOnly = true)
     public List<FeedOneResponse> findAllFeed() {
         final Member currentMember = memberUtil.getCurrentMember();
         List<Long> sourceIds =
-                new ArrayList<>(
-                        memberRelationRepository.findAllBySourceId(currentMember.getId()).stream()
-                                .map(memberRelation -> memberRelation.getTarget().getId())
-                                .toList());
+                memberRelationRepository.findAllBySourceId(currentMember.getId()).stream()
+                        .map(memberRelation -> memberRelation.getTarget().getId())
+                        .collect(Collectors.toList());
         sourceIds.add(currentMember.getId());
 
         return missionRecordRepository.findFeedAll(sourceIds);
     }
 
     public List<FeedOneByProfileResponse> findAllFeedByTargetId(Long targetId) {
-        Member sourceMember = memberUtil.getCurrentMember();
+        final Long sourceId = securityUtil.getCurrentMemberId();
 
-        /*
-         본인 프로필 findFeedBySourceMember
-         targetId가 본인이다.
-         그렇다면 공개 여부 상관없이 full-scan
-
-         타인 프로필 findFeedByTargetMember
-         만약 sourceId와 targetId가 다르다.
-         그렇다면 공개 여부에서 비공개는 exclude 한다.
-         추가로 내가 타인 프로필에서 팔로잉 관계가 이뤄졌는지 여부 확인하여 팔로우 관계 여부 체크
-        */
-        if (!targetId.equals(sourceMember.getId())) {
-            return findFeedByTargetMember(sourceMember, targetId);
-        } else {
-            return findFeedBySourceMember(sourceMember);
+        if (!isMyFeedRequired(targetId, sourceId)) {
+            return findFeedByOtherMember(sourceId, targetId);
         }
+        return findFeedByCurrentMember(sourceId);
     }
 
-    private List<FeedOneByProfileResponse> findFeedByTargetMember(
-            Member sourceMember, Long targetId) {
+    private boolean isMyFeedRequired(Long targetId, Long sourceId) {
+        return targetId.equals(sourceId);
+    }
+
+    private List<FeedOneByProfileResponse> findFeedByOtherMember(Long sourceId, Long targetId) {
         final Member targetMember = memberUtil.getMemberByMemberId(targetId);
-        List<MissionVisibility> visibilities = new ArrayList<>(List.of(MissionVisibility.ALL));
 
         // 팔로우 관계 true: visibility.FOLLOW and ALL, false: visibility.ALL only
-        boolean existMemberRelation =
+        boolean isMemberRelationExistsWithMe =
                 memberRelationRepository.existsBySourceIdAndTargetId(
-                        sourceMember.getId(), targetMember.getId());
-        if (existMemberRelation) {
-            visibilities.add(MissionVisibility.FOLLOWER);
-        }
-        if (sourceMember.getId().equals(targetId)) {
-            visibilities.add(MissionVisibility.FOLLOWER);
-            visibilities.add(MissionVisibility.NONE);
-        }
-        List<Mission> feedAllByMemberId =
-                missionRepository.findFeedAllByMemberId(targetId, visibilities);
+                        sourceId, targetMember.getId());
+
+        List<MissionRecord> feedAllByMemberId =
+                missionRecordRepository.findFeedAllByMemberId(
+                        targetId,
+                        determineVisibilityConditionsByRelationsWithMe(
+                                isMemberRelationExistsWithMe));
         return extractFeedResponses(feedAllByMemberId);
     }
 
-    private List<FeedOneByProfileResponse> findFeedBySourceMember(Member sourceMember) {
-        List<Mission> feedAllByMemberId =
-                missionRepository.findFeedAllByMemberId(sourceMember.getId(), null);
+    private List<FeedOneByProfileResponse> findFeedByCurrentMember(Long sourceId) {
+        List<MissionVisibility> visibilities =
+                List.of(MissionVisibility.NONE, MissionVisibility.FOLLOWER, MissionVisibility.ALL);
+        List<MissionRecord> feedAllByMemberId =
+                missionRecordRepository.findFeedAllByMemberId(sourceId, visibilities);
         return extractFeedResponses(feedAllByMemberId);
     }
 
-    private List<FeedOneByProfileResponse> extractFeedResponses(List<Mission> missions) {
-        return missions.stream()
-                .flatMap(
-                        mission -> {
-                            List<MissionRecord> missionRecords = mission.getMissionRecords();
-                            return missionRecords.stream()
-                                    .filter(Objects::nonNull)
-                                    .map(record -> FeedOneByProfileResponse.of(mission, record));
-                        })
+    private List<FeedOneByProfileResponse> extractFeedResponses(List<MissionRecord> records) {
+        return records.stream()
+                .map(record -> FeedOneByProfileResponse.of(record.getMission(), record))
                 .toList();
+    }
+
+    private List<MissionVisibility> determineVisibilityConditionsByRelationsWithMe(
+            boolean isMemberRelationExistsWithMe) {
+        List<MissionVisibility> visibilities = new ArrayList<>();
+        visibilities.add(MissionVisibility.ALL);
+
+        if (isMemberRelationExistsWithMe) {
+            visibilities.add(MissionVisibility.FOLLOWER);
+        }
+        return visibilities;
     }
 }

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -1,0 +1,49 @@
+package com.depromeet.domain.feed.application;
+
+import com.depromeet.domain.feed.dto.response.FeedOneResponse;
+import com.depromeet.domain.follow.dao.MemberRelationRepository;
+import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.mission.dao.MissionRepository;
+import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.global.util.MemberUtil;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeedService {
+    private final MemberUtil memberUtil;
+    private final MissionRepository missionRepository;
+    private final MemberRelationRepository memberRelationRepository;
+	private final MissionRecordRepository missionRecordRepository;
+
+	public List<FeedOneResponse> findAllFeed() {
+        final Member currentMember = memberUtil.getCurrentMember();
+        List<Long> sourceIds =
+                memberRelationRepository.findAllBySourceId(currentMember.getId()).stream()
+                        .map(memberRelation -> memberRelation.getTarget().getId())
+                        .toList();
+
+        List<Mission> feedAll = missionRepository.findFeedAll(sourceIds);
+
+		List<FeedOneResponse> returnList = feedAll.stream()
+			.flatMap(mission -> {
+				List<MissionRecord> missionRecords = mission.getMissionRecords();
+				return missionRecords.stream()
+					.filter(Objects::nonNull)
+					.map(record -> FeedOneResponse.of(mission, record));
+			})
+			.toList();
+
+		return returnList;
+    }
+}

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -40,7 +40,10 @@ public class FeedService {
                             List<MissionRecord> missionRecords = mission.getMissionRecords();
                             return missionRecords.stream()
                                     .filter(Objects::nonNull)
-                                    .map(record -> FeedOneResponse.of(mission, record));
+                                    .map(
+                                            record ->
+                                                    FeedOneResponse.of(
+                                                            mission, record, mission.getMember()));
                         })
                 .toList();
     }

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 // TODO: Redis 사용해서 캐싱 작업 필요
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class FeedService {
     private final MemberUtil memberUtil;
     private final MissionRecordRepository missionRecordRepository;
@@ -37,6 +38,7 @@ public class FeedService {
         return missionRecordRepository.findFeedAll(sourceIds);
     }
 
+    @Transactional(readOnly = true)
     public List<FeedOneByProfileResponse> findAllFeedByTargetId(Long targetId) {
         final Long sourceId = securityUtil.getCurrentMemberId();
 

--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneByProfileResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneByProfileResponse.java
@@ -35,6 +35,7 @@ public record FeedOneByProfileResponse(
                         defaultValue = "2024-01-20 00:34:00",
                         type = "string")
                 LocalDateTime finishedAt) {
+
     public static FeedOneByProfileResponse of(Mission mission, MissionRecord missionRecord) {
         return new FeedOneByProfileResponse(
                 mission.getId(),

--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneByProfileResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneByProfileResponse.java
@@ -1,6 +1,5 @@
 package com.depromeet.domain.feed.dto.response;
 
-import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -36,15 +35,15 @@ public record FeedOneByProfileResponse(
                         type = "string")
                 LocalDateTime finishedAt) {
 
-    public static FeedOneByProfileResponse of(Mission mission, MissionRecord missionRecord) {
+    public static FeedOneByProfileResponse of(MissionRecord record) {
         return new FeedOneByProfileResponse(
-                mission.getId(),
-                missionRecord.getId(),
-                mission.getName(),
-                missionRecord.getImageUrl(),
-                missionRecord.getDuration().toMinutes(),
-                Duration.between(missionRecord.getStartedAt(), LocalDateTime.now()).toDays() + 1,
-                missionRecord.getStartedAt(),
-                missionRecord.getFinishedAt());
+                record.getMission().getId(),
+                record.getId(),
+                record.getMission().getName(),
+                record.getImageUrl(),
+                record.getDuration().toMinutes(),
+                Duration.between(record.getStartedAt(), LocalDateTime.now()).toDays() + 1,
+                record.getStartedAt(),
+                record.getFinishedAt());
     }
 }

--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneByProfileResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneByProfileResponse.java
@@ -7,12 +7,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
-public record FeedOneResponse(
-        @Schema(description = "작성자 ID", defaultValue = "1") Long targetId,
+public record FeedOneByProfileResponse(
         @Schema(description = "미션 ID", defaultValue = "1") Long missionId,
         @Schema(description = "미션 기록 ID", defaultValue = "1") Long recordId,
         @Schema(description = "미션 이름", defaultValue = "default name") String name,
-        @Schema(description = "미션 일지 내용", defaultValue = "default remark") String remark,
         @Schema(
                         description = "미션 기록 인증 사진 Url",
                         defaultValue = "https://image.10mm.today/default.png")
@@ -25,7 +23,7 @@ public record FeedOneResponse(
                         timezone = "Asia/Seoul")
                 @Schema(
                         description = "미션 기록 시작 시간",
-                        defaultValue = "2024-01-06 00:00:00",
+                        defaultValue = "2023-01-06 00:00:00",
                         type = "string")
                 LocalDateTime startedAt,
         @JsonFormat(
@@ -37,13 +35,11 @@ public record FeedOneResponse(
                         defaultValue = "2024-01-20 00:34:00",
                         type = "string")
                 LocalDateTime finishedAt) {
-    public static FeedOneResponse of(Mission mission, MissionRecord missionRecord) {
-        return new FeedOneResponse(
-                mission.getMember().getId(),
+    public static FeedOneByProfileResponse of(Mission mission, MissionRecord missionRecord) {
+        return new FeedOneByProfileResponse(
                 mission.getId(),
                 missionRecord.getId(),
                 mission.getName(),
-                missionRecord.getRemark(),
                 missionRecord.getImageUrl(),
                 missionRecord.getDuration().toMinutes(),
                 Duration.between(missionRecord.getStartedAt(), LocalDateTime.now()).toDays() + 1,

--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
@@ -7,7 +7,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 
 public record FeedOneResponse(
-        @Schema(description = "작성자 ID", defaultValue = "1") Long targetId,
+        @Schema(description = "작성자 ID", defaultValue = "1") Long memberId,
         @Schema(description = "작성자 닉네임", defaultValue = "default name") String nickname,
         @Schema(description = "작성자 프로필 이미지", defaultValue = "https://image.10mm.today/default.png")
                 String profileImage,
@@ -41,7 +41,7 @@ public record FeedOneResponse(
                 LocalDateTime finishedAt) {
     @QueryProjection
     public FeedOneResponse(
-            Long targetId,
+            Long memberId,
             String nickname,
             String profileImage,
             Long missionId,
@@ -53,7 +53,7 @@ public record FeedOneResponse(
             LocalDateTime startedAt,
             LocalDateTime finishedAt) {
         this(
-                targetId,
+                memberId,
                 nickname,
                 profileImage,
                 missionId,
@@ -68,7 +68,7 @@ public record FeedOneResponse(
     }
 
     public static FeedOneResponse of(
-            Long targetId,
+            Long memberId,
             String nickname,
             String profileImage,
             Long missionId,
@@ -80,7 +80,7 @@ public record FeedOneResponse(
             LocalDateTime startedAt,
             LocalDateTime finishedAt) {
         return new FeedOneResponse(
-                targetId,
+                memberId,
                 nickname,
                 profileImage,
                 missionId,

--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.feed.dto.response;
 
+import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 
 public record FeedOneResponse(
         @Schema(description = "작성자 ID", defaultValue = "1") Long targetId,
+        @Schema(description = "작성자 닉네임", defaultValue = "default nickname") String nickname,
         @Schema(description = "미션 ID", defaultValue = "1") Long missionId,
         @Schema(description = "미션 기록 ID", defaultValue = "1") Long recordId,
         @Schema(description = "미션 이름", defaultValue = "default name") String name,
@@ -37,9 +39,10 @@ public record FeedOneResponse(
                         defaultValue = "2024-01-20 00:34:00",
                         type = "string")
                 LocalDateTime finishedAt) {
-    public static FeedOneResponse of(Mission mission, MissionRecord missionRecord) {
+    public static FeedOneResponse of(Mission mission, MissionRecord missionRecord, Member member) {
         return new FeedOneResponse(
                 mission.getMember().getId(),
+                member.getProfile().getNickname(),
                 mission.getId(),
                 missionRecord.getId(),
                 mission.getName(),

--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
@@ -1,0 +1,53 @@
+package com.depromeet.domain.feed.dto.response;
+
+import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public record FeedOneResponse(
+        @Schema(description = "작성자 ID", defaultValue = "1") Long targetId,
+        @Schema(description = "미션 ID", defaultValue = "1") Long missionId,
+		@Schema(description = "미션 기록 ID", defaultValue = "1") Long recordId,
+        @Schema(description = "미션 이름", defaultValue = "default name") String name,
+        @Schema(description = "미션 일지 내용", defaultValue = "default remark") String remark,
+        @Schema(
+                        description = "미션 기록 인증 사진 Url",
+                        defaultValue = "https://image.10mm.today/default.png")
+                String recordImageUrl,
+        @Schema(description = "미션 수행한 시간", defaultValue = "21") long duration,
+        @Schema(description = "미션 시작한 지 N일차", defaultValue = "3") long sinceDay,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 기록 시작 시간",
+                        defaultValue = "2023-01-03 00:00:00",
+                        type = "string")
+                LocalDateTime startedAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 기록 종료 시간",
+                        defaultValue = "2024-01-03 00:34:00",
+                        type = "string")
+                LocalDateTime finishedAt) {
+    public static FeedOneResponse of(Mission mission, MissionRecord missionRecord) {
+        return new FeedOneResponse(
+                mission.getMember().getId(),
+                mission.getId(),
+                missionRecord.getId(),
+                mission.getName(),
+                missionRecord.getRemark(),
+                missionRecord.getImageUrl(),
+                missionRecord.getDuration().toMinutes(),
+                Duration.between(missionRecord.getStartedAt(), LocalDateTime.now()).toDays() + 1,
+                missionRecord.getStartedAt(),
+                missionRecord.getFinishedAt());
+    }
+}

--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
@@ -5,54 +5,40 @@ import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import lombok.Data;
 
-@Data
-public class FeedOneResponse {
-    @Schema(description = "작성자 ID", defaultValue = "1")
-    Long targetId;
-
-    @Schema(description = "작성자 닉네임", defaultValue = "default name")
-    String nickname;
-
-    @Schema(description = "작성자 프로필 이미지", defaultValue = "https://image.10mm.today/default.png")
-    String profileImage;
-
-    @Schema(description = "미션 ID", defaultValue = "1")
-    Long missionId;
-
-    @Schema(description = "미션 이름", defaultValue = "default name")
-    String name;
-
-    @Schema(description = "미션 기록 ID", defaultValue = "1")
-    Long recordId;
-
-    @Schema(description = "미션 일지 내용", defaultValue = "default remark")
-    String remark;
-
-    @Schema(description = "미션 기록 인증 사진 Url", defaultValue = "https://image.10mm.today/default.png")
-    String recordImageUrl;
-
-    @Schema(description = "미션 수행한 시간", defaultValue = "21")
-    long duration;
-
-    @Schema(description = "미션 시작한 지 N일차", defaultValue = "3")
-    long sinceDay;
-
-    @JsonFormat(
-            shape = JsonFormat.Shape.STRING,
-            pattern = "yyyy-MM-dd HH:mm:ss",
-            timezone = "Asia/Seoul")
-    @Schema(description = "미션 기록 시작 시간", defaultValue = "2024-01-06 00:00:00", type = "string")
-    LocalDateTime startedAt;
-
-    @JsonFormat(
-            shape = JsonFormat.Shape.STRING,
-            pattern = "yyyy-MM-dd HH:mm:ss",
-            timezone = "Asia/Seoul")
-    @Schema(description = "미션 기록 종료 시간", defaultValue = "2024-01-20 00:34:00", type = "string")
-    LocalDateTime finishedAt;
-
+public record FeedOneResponse(
+        @Schema(description = "작성자 ID", defaultValue = "1") Long targetId,
+        @Schema(description = "작성자 닉네임", defaultValue = "default name") String nickname,
+        @Schema(description = "작성자 프로필 이미지", defaultValue = "https://image.10mm.today/default.png")
+                String profileImage,
+        @Schema(description = "미션 ID", defaultValue = "1") Long missionId,
+        @Schema(description = "미션 이름", defaultValue = "default name") String name,
+        @Schema(description = "미션 기록 ID", defaultValue = "1") Long recordId,
+        @Schema(description = "미션 일지 내용", defaultValue = "default remark") String remark,
+        @Schema(
+                        description = "미션 기록 인증 사진 Url",
+                        defaultValue = "https://image.10mm.today/default.png")
+                String recordImageUrl,
+        @Schema(description = "미션 수행한 시간", defaultValue = "21") long duration,
+        @Schema(description = "미션 시작한 지 N일차", defaultValue = "3") long sinceDay,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 기록 시작 시간",
+                        defaultValue = "2024-01-06 00:00:00",
+                        type = "string")
+                LocalDateTime startedAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 기록 종료 시간",
+                        defaultValue = "2024-01-20 00:34:00",
+                        type = "string")
+                LocalDateTime finishedAt) {
     @QueryProjection
     public FeedOneResponse(
             Long targetId,
@@ -66,17 +52,45 @@ public class FeedOneResponse {
             Duration duration,
             LocalDateTime startedAt,
             LocalDateTime finishedAt) {
-        this.targetId = targetId;
-        this.nickname = nickname;
-        this.profileImage = profileImage;
-        this.missionId = missionId;
-        this.name = name;
-        this.recordId = recordId;
-        this.remark = remark;
-        this.recordImageUrl = recordImageUrl;
-        this.duration = duration.toMinutes();
-        this.sinceDay = Duration.between(startedAt, LocalDateTime.now()).toDays() + 1;
-        this.startedAt = startedAt;
-        this.finishedAt = finishedAt;
+        this(
+                targetId,
+                nickname,
+                profileImage,
+                missionId,
+                name,
+                recordId,
+                remark,
+                recordImageUrl,
+                duration.toMinutes(),
+                Duration.between(startedAt, LocalDateTime.now()).toDays() + 1,
+                startedAt,
+                finishedAt);
+    }
+
+    public static FeedOneResponse of(
+            Long targetId,
+            String nickname,
+            String profileImage,
+            Long missionId,
+            String name,
+            Long recordId,
+            String remark,
+            String recordImageUrl,
+            Duration duration,
+            LocalDateTime startedAt,
+            LocalDateTime finishedAt) {
+        return new FeedOneResponse(
+                targetId,
+                nickname,
+                profileImage,
+                missionId,
+                name,
+                recordId,
+                remark,
+                recordImageUrl,
+                duration.toMinutes(),
+                Duration.between(startedAt, LocalDateTime.now()).toDays() + 1,
+                startedAt,
+                finishedAt);
     }
 }

--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
@@ -1,56 +1,82 @@
 package com.depromeet.domain.feed.dto.response;
 
-import com.depromeet.domain.member.domain.Member;
-import com.depromeet.domain.mission.domain.Mission;
-import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import lombok.Data;
 
-public record FeedOneResponse(
-        @Schema(description = "작성자 ID", defaultValue = "1") Long targetId,
-        @Schema(description = "작성자 닉네임", defaultValue = "default nickname") String nickname,
-        @Schema(description = "미션 ID", defaultValue = "1") Long missionId,
-        @Schema(description = "미션 기록 ID", defaultValue = "1") Long recordId,
-        @Schema(description = "미션 이름", defaultValue = "default name") String name,
-        @Schema(description = "미션 일지 내용", defaultValue = "default remark") String remark,
-        @Schema(
-                        description = "미션 기록 인증 사진 Url",
-                        defaultValue = "https://image.10mm.today/default.png")
-                String recordImageUrl,
-        @Schema(description = "미션 수행한 시간", defaultValue = "21") long duration,
-        @Schema(description = "미션 시작한 지 N일차", defaultValue = "3") long sinceDay,
-        @JsonFormat(
-                        shape = JsonFormat.Shape.STRING,
-                        pattern = "yyyy-MM-dd HH:mm:ss",
-                        timezone = "Asia/Seoul")
-                @Schema(
-                        description = "미션 기록 시작 시간",
-                        defaultValue = "2024-01-06 00:00:00",
-                        type = "string")
-                LocalDateTime startedAt,
-        @JsonFormat(
-                        shape = JsonFormat.Shape.STRING,
-                        pattern = "yyyy-MM-dd HH:mm:ss",
-                        timezone = "Asia/Seoul")
-                @Schema(
-                        description = "미션 기록 종료 시간",
-                        defaultValue = "2024-01-20 00:34:00",
-                        type = "string")
-                LocalDateTime finishedAt) {
-    public static FeedOneResponse of(Mission mission, MissionRecord missionRecord, Member member) {
-        return new FeedOneResponse(
-                mission.getMember().getId(),
-                member.getProfile().getNickname(),
-                mission.getId(),
-                missionRecord.getId(),
-                mission.getName(),
-                missionRecord.getRemark(),
-                missionRecord.getImageUrl(),
-                missionRecord.getDuration().toMinutes(),
-                Duration.between(missionRecord.getStartedAt(), LocalDateTime.now()).toDays() + 1,
-                missionRecord.getStartedAt(),
-                missionRecord.getFinishedAt());
+@Data
+public class FeedOneResponse {
+    @Schema(description = "작성자 ID", defaultValue = "1")
+    Long targetId;
+
+    @Schema(description = "작성자 닉네임", defaultValue = "default name")
+    String nickname;
+
+    @Schema(description = "작성자 프로필 이미지", defaultValue = "https://image.10mm.today/default.png")
+    String profileImage;
+
+    @Schema(description = "미션 ID", defaultValue = "1")
+    Long missionId;
+
+    @Schema(description = "미션 이름", defaultValue = "default name")
+    String name;
+
+    @Schema(description = "미션 기록 ID", defaultValue = "1")
+    Long recordId;
+
+    @Schema(description = "미션 일지 내용", defaultValue = "default remark")
+    String remark;
+
+    @Schema(description = "미션 기록 인증 사진 Url", defaultValue = "https://image.10mm.today/default.png")
+    String recordImageUrl;
+
+    @Schema(description = "미션 수행한 시간", defaultValue = "21")
+    long duration;
+
+    @Schema(description = "미션 시작한 지 N일차", defaultValue = "3")
+    long sinceDay;
+
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd HH:mm:ss",
+            timezone = "Asia/Seoul")
+    @Schema(description = "미션 기록 시작 시간", defaultValue = "2024-01-06 00:00:00", type = "string")
+    LocalDateTime startedAt;
+
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd HH:mm:ss",
+            timezone = "Asia/Seoul")
+    @Schema(description = "미션 기록 종료 시간", defaultValue = "2024-01-20 00:34:00", type = "string")
+    LocalDateTime finishedAt;
+
+    @QueryProjection
+    public FeedOneResponse(
+            Long targetId,
+            String nickname,
+            String profileImage,
+            Long missionId,
+            String name,
+            Long recordId,
+            String remark,
+            String recordImageUrl,
+            Duration duration,
+            LocalDateTime startedAt,
+            LocalDateTime finishedAt) {
+        this.targetId = targetId;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.missionId = missionId;
+        this.name = name;
+        this.recordId = recordId;
+        this.remark = remark;
+        this.recordImageUrl = recordImageUrl;
+        this.duration = duration.toMinutes();
+        this.sinceDay = Duration.between(startedAt, LocalDateTime.now()).toDays() + 1;
+        this.startedAt = startedAt;
+        this.finishedAt = finishedAt;
     }
 }

--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -187,6 +187,7 @@ public class FollowService {
         return targetMember;
     }
 
+    @Transactional(readOnly = true)
     public FollowListResponse findFollowList(Long targetId) {
         final Member currentMember = memberUtil.getCurrentMember();
         Member targetMember = getTargetMember(targetId);

--- a/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/follow/dao/MemberRelationRepositoryImpl.java
@@ -22,6 +22,7 @@ public class MemberRelationRepositoryImpl implements MemberRelationRepositoryCus
         return jpaQueryFactory
                 .selectFrom(memberRelation)
                 .leftJoin(memberRelation.target, member)
+                .fetchJoin()
                 .leftJoin(memberRelation.target.missions, mission)
                 .leftJoin(mission.missionRecords, missionRecord)
                 .where(sourceIdEq(memberId))

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
@@ -12,5 +12,7 @@ public interface MissionRepositoryCustom {
 
     List<Mission> findMissionsWithRecordsByRelations(Long memberId, boolean existsMemberRelations);
 
+    List<Mission> findFeedAll(List<Long> sourceIds);
+
     void updateFinishedDurationStatus(LocalDateTime today);
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
@@ -1,7 +1,6 @@
 package com.depromeet.domain.mission.dao;
 
 import com.depromeet.domain.mission.domain.Mission;
-import com.depromeet.domain.mission.domain.MissionVisibility;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -12,8 +11,6 @@ public interface MissionRepositoryCustom {
     List<Mission> findInProgressMissionsWithRecords(Long memberId);
 
     List<Mission> findMissionsWithRecordsByRelations(Long memberId, boolean existsMemberRelations);
-
-    List<Mission> findFeedAllByMemberId(Long memberId, List<MissionVisibility> visibilities);
 
     void updateFinishedDurationStatus(LocalDateTime today);
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.mission.dao;
 
 import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.domain.mission.domain.MissionVisibility;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -13,6 +14,8 @@ public interface MissionRepositoryCustom {
     List<Mission> findMissionsWithRecordsByRelations(Long memberId, boolean existsMemberRelations);
 
     List<Mission> findFeedAll(List<Long> sourceIds);
+
+    List<Mission> findFeedAllByMemberId(Long memberId, List<MissionVisibility> visibilities);
 
     void updateFinishedDurationStatus(LocalDateTime today);
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
@@ -13,8 +13,6 @@ public interface MissionRepositoryCustom {
 
     List<Mission> findMissionsWithRecordsByRelations(Long memberId, boolean existsMemberRelations);
 
-    List<Mission> findFeedAll(List<Long> sourceIds);
-
     List<Mission> findFeedAllByMemberId(Long memberId, List<MissionVisibility> visibilities);
 
     void updateFinishedDurationStatus(LocalDateTime today);

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.mission.dao;
 
+import static com.depromeet.domain.member.domain.QMember.*;
 import static com.depromeet.domain.mission.domain.QMission.*;
 import static com.depromeet.domain.missionRecord.domain.QMissionRecord.*;
 
@@ -67,6 +68,19 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
                         mission.finishedAt.loe(today),
                         mission.durationStatus.ne(DurationStatus.FINISHED))
                 .execute();
+    }
+
+    @Override
+    public List<Mission> findFeedAll(List<Long> sourceIds) {
+        return jpaQueryFactory
+                .selectFrom(mission)
+                .leftJoin(mission.missionRecords, missionRecord)
+                .fetchJoin()
+                .where(
+                        mission.member.id.in(sourceIds),
+                        mission.visibility.in(MissionVisibility.FOLLOWER, MissionVisibility.ALL))
+                .orderBy(missionRecord.startedAt.desc())
+                .fetch();
     }
 
     private BooleanExpression memberIdEq(Long memberId) {

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -7,7 +7,6 @@ import static com.depromeet.domain.missionRecord.domain.QMissionRecord.*;
 import com.depromeet.domain.mission.domain.DurationStatus;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.domain.MissionVisibility;
-import com.depromeet.domain.missionRecord.domain.ImageUploadStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -69,33 +68,6 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
                         mission.finishedAt.loe(today),
                         mission.durationStatus.ne(DurationStatus.FINISHED))
                 .execute();
-    }
-
-    /*
-    1. 미션 레코드를 기준으로 한다. 그런데 여기에 미션 정보도 필요하고, 멤버 정보도 필요한 거임.
-    2. 그래서 미션 레코드를 기준으로 쿼리하되 미션을 조인하고, 멤버도 조인한다.
-    3. where 조건 필터링할 때 멤버 조인했으니까, 이 멤버가 sourceID 기반으로 한 멤버 리스트 안에 있는지 필터링만 하면 끝
-    4. 정렬은 레코드 생성순서로
-    */
-
-    @Override
-    public List<Mission> findFeedAllByMemberId(
-            Long memberId, List<MissionVisibility> visibilities) {
-        JPAQuery<Mission> query =
-                jpaQueryFactory
-                        .selectFrom(mission)
-                        .leftJoin(mission.missionRecords, missionRecord)
-                        .fetchJoin()
-                        .where(
-                                mission.member.id.eq(memberId),
-                                missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
-                        .orderBy(missionRecord.startedAt.desc());
-
-        if (visibilities != null) {
-            query = query.where(mission.visibility.in(visibilities));
-        }
-
-        return query.fetch();
     }
 
     private BooleanExpression memberIdEq(Long memberId) {

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -71,19 +71,12 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
                 .execute();
     }
 
-    @Override
-    public List<Mission> findFeedAll(List<Long> sourceIds) {
-        return jpaQueryFactory
-                .selectFrom(mission)
-                .leftJoin(mission.missionRecords, missionRecord)
-                .fetchJoin()
-                .where(
-                        mission.member.id.in(sourceIds),
-                        mission.visibility.in(MissionVisibility.FOLLOWER, MissionVisibility.ALL),
-                        missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
-                .orderBy(missionRecord.startedAt.desc())
-                .fetch();
-    }
+    /*
+    1. 미션 레코드를 기준으로 한다. 그런데 여기에 미션 정보도 필요하고, 멤버 정보도 필요한 거임.
+    2. 그래서 미션 레코드를 기준으로 쿼리하되 미션을 조인하고, 멤버도 조인한다.
+    3. where 조건 필터링할 때 멤버 조인했으니까, 이 멤버가 sourceID 기반으로 한 멤버 리스트 안에 있는지 필터링만 하면 끝
+    4. 정렬은 레코드 생성순서로
+    */
 
     @Override
     public List<Mission> findFeedAllByMemberId(

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -81,16 +81,21 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
     @Override
     public List<Mission> findFeedAllByMemberId(
             Long memberId, List<MissionVisibility> visibilities) {
-        return jpaQueryFactory
-                .selectFrom(mission)
-                .leftJoin(mission.missionRecords, missionRecord)
-                .fetchJoin()
-                .where(
-                        mission.member.id.eq(memberId),
-                        mission.visibility.in(visibilities),
-                        missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
-                .orderBy(missionRecord.startedAt.desc())
-                .fetch();
+        JPAQuery<Mission> query =
+                jpaQueryFactory
+                        .selectFrom(mission)
+                        .leftJoin(mission.missionRecords, missionRecord)
+                        .fetchJoin()
+                        .where(
+                                mission.member.id.eq(memberId),
+                                missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
+                        .orderBy(missionRecord.startedAt.desc());
+
+        if (visibilities != null) {
+            query = query.where(mission.visibility.in(visibilities));
+        }
+
+        return query.fetch();
     }
 
     private BooleanExpression memberIdEq(Long memberId) {

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -7,6 +7,7 @@ import static com.depromeet.domain.missionRecord.domain.QMissionRecord.*;
 import com.depromeet.domain.mission.domain.DurationStatus;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.domain.MissionVisibility;
+import com.depromeet.domain.missionRecord.domain.ImageUploadStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -78,7 +79,23 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
                 .fetchJoin()
                 .where(
                         mission.member.id.in(sourceIds),
-                        mission.visibility.in(MissionVisibility.FOLLOWER, MissionVisibility.ALL))
+                        mission.visibility.in(MissionVisibility.FOLLOWER, MissionVisibility.ALL),
+                        missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
+                .orderBy(missionRecord.startedAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<Mission> findFeedAllByMemberId(
+            Long memberId, List<MissionVisibility> visibilities) {
+        return jpaQueryFactory
+                .selectFrom(mission)
+                .leftJoin(mission.missionRecords, missionRecord)
+                .fetchJoin()
+                .where(
+                        mission.member.id.eq(memberId),
+                        mission.visibility.in(visibilities),
+                        missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
                 .orderBy(missionRecord.startedAt.desc())
                 .fetch();
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.missionRecord.dao;
 
 import com.depromeet.domain.feed.dto.response.FeedOneResponse;
+import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import java.time.YearMonth;
 import java.util.List;
@@ -10,6 +11,8 @@ public interface MissionRecordRepositoryCustom {
     List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth);
 
     List<FeedOneResponse> findFeedAll(List<Long> sourceIds);
+
+    List<MissionRecord> findFeedAllByMemberId(Long memberId, List<MissionVisibility> visibilities);
 
     boolean isCompletedMissionExistsToday(Long missionId);
 

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.missionRecord.dao;
 
+import com.depromeet.domain.feed.dto.response.FeedOneResponse;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import java.time.YearMonth;
 import java.util.List;
@@ -7,6 +8,8 @@ import java.util.List;
 public interface MissionRecordRepositoryCustom {
 
     List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth);
+
+    List<FeedOneResponse> findFeedAll(List<Long> sourceIds);
 
     boolean isCompletedMissionExistsToday(Long missionId);
 

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.missionRecord.dao;
 
 import com.depromeet.domain.feed.dto.response.FeedOneResponse;
+import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import java.time.YearMonth;
@@ -10,7 +11,7 @@ public interface MissionRecordRepositoryCustom {
 
     List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth);
 
-    List<FeedOneResponse> findFeedAll(List<Long> sourceIds);
+    List<FeedOneResponse> findFeedAll(List<Member> members);
 
     List<MissionRecord> findFeedAllByMemberId(Long memberId, List<MissionVisibility> visibilities);
 

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -91,6 +91,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
                 .leftJoin(missionRecord.mission, mission)
                 .fetchJoin()
                 .where(
+                        mission.visibility.in(visibilities),
                         mission.member.id.eq(memberId),
                         missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
                 .orderBy(missionRecord.startedAt.desc())

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -5,6 +5,7 @@ import static com.depromeet.domain.mission.domain.QMission.*;
 import static com.depromeet.domain.missionRecord.domain.QMissionRecord.*;
 
 import com.depromeet.domain.feed.dto.response.FeedOneResponse;
+import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.missionRecord.domain.ImageUploadStatus;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
@@ -52,7 +53,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     }
 
     @Override
-    public List<FeedOneResponse> findFeedAll(List<Long> sourceIds) {
+    public List<FeedOneResponse> findFeedAll(List<Member> members) {
         return jpaQueryFactory
                 .select(
                         Projections.constructor(
@@ -74,7 +75,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
                 .leftJoin(mission.member, member)
                 .on(mission.member.id.eq(missionRecord.mission.member.id))
                 .where(
-                        missionRecord.mission.member.id.in(sourceIds),
+                        missionRecord.mission.member.in(members),
                         missionRecord.mission.visibility.in(
                                 MissionVisibility.FOLLOWER, MissionVisibility.ALL),
                         missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Repository;
 public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCustom {
 
     private final JPAQueryFactory jpaQueryFactory;
+    private static final long FEED_TAB_LIMIT = 100;
 
     @Override
     public List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth) {
@@ -78,6 +79,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
                                 MissionVisibility.FOLLOWER, MissionVisibility.ALL),
                         missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
                 .orderBy(missionRecord.startedAt.desc())
+                .limit(FEED_TAB_LIMIT)
                 .fetch();
     }
 

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -84,6 +84,20 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     }
 
     @Override
+    public List<MissionRecord> findFeedAllByMemberId(
+            Long memberId, List<MissionVisibility> visibilities) {
+        return jpaQueryFactory
+                .selectFrom(missionRecord)
+                .leftJoin(missionRecord.mission, mission)
+                .fetchJoin()
+                .where(
+                        mission.member.id.eq(memberId),
+                        missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
+                .orderBy(missionRecord.startedAt.desc())
+                .fetch();
+    }
+
+    @Override
     public void deleteByMissionRecordId(Long missionRecordId) {
         jpaQueryFactory.delete(missionRecord).where(missionRecord.id.eq(missionRecordId)).execute();
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,3 +15,6 @@ logging:
   level:
     org.springframework.orm.jpa: DEBUG
     org.springframework.transaction: DEBUG
+
+server:
+  port: 8889

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,6 +15,3 @@ logging:
   level:
     org.springframework.orm.jpa: DEBUG
     org.springframework.transaction: DEBUG
-
-server:
-  port: 8889

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,3 +15,4 @@ logging:
   level:
     org.springframework.orm.jpa: DEBUG
     org.springframework.transaction: DEBUG
+


### PR DESCRIPTION
## 🌱 관련 이슈
- close #270 

## 📌 작업 내용 및 특이사항
- 피드 탭 구현 사항으로 엔드포인트는 `/feed/me`, `/feed/{targerId}`로 구현
- `/feed/me`는 탭에 있는 feed 버튼을 클릭 시 동작되는 API
  - member, mission, missionRecord를 join해서 필요한 필드에 대해서만 select하는 방식이기에 Projections 생성자 방식을 사용
  - 피드같은 경우 미션 내역이 빠르게 증가되어 Latency를 고려하여 100개까지 LIMIT 제한
  - Projections를 사용을 위한 데이터 모델은 FeedOneResponse로 DTO record 구현
  - Projections를 사용하기에 fetchJoin이 아닌 on절을 사용한 매핑
- `/feed/{targerId}`는 마이프로필과 타인 프로필에 보여지는 피드 API
  - targerId가 본인인 경우 공개 여부 상관없이 전부 조회하고, 아닌 경우 팔로잉 관계에 따라 공개 여부를 결정하여 조회해 response

## 📝 참고사항
![image](https://github.com/depromeet/10mm-server/assets/68099546/2324d1ba-6ecc-49f1-bc77-d89227105c38)
- `/feed/me` API 호출 시 위와 같은 쿼리가 한번 더 발생되는 현상이 있어 같이 고민하면 좋을 듯합니다.


## 📚 기타
- 
