### PR TITLE
fix: fcm 토큰이 빈 값이라면 푸시 알림을 보내지 않도록 설정

### DIFF
--- a/src/main/java/com/depromeet/domain/follow/api/FollowController.java
+++ b/src/main/java/com/depromeet/domain/follow/api/FollowController.java
@@ -58,7 +58,6 @@ public class FollowController {
         return followService.findAllFollowedMember();
     }
 
-    // 팔로잉, 팔로워 리스트 응답
     @GetMapping("/{targetId}/list")
     @Operation(summary = "팔로잉, 팔로워 유저 리스트를 반환합니다", description = "팔로잉, 팔로워 유저들을 반환합니다.")
     public FollowListResponse followList(@PathVariable Long targetId) {

--- a/src/main/java/com/depromeet/domain/member/domain/FcmInfo.java
+++ b/src/main/java/com/depromeet/domain/member/domain/FcmInfo.java
@@ -21,7 +21,7 @@ public class FcmInfo {
     }
 
     public static FcmInfo createFcmInfo() {
-        return FcmInfo.builder().fcmToken("").appAlarm(true).build();
+        return FcmInfo.builder().appAlarm(true).build();
     }
 
     public static FcmInfo toggleAlarm(FcmInfo fcmState) {

--- a/src/main/java/com/depromeet/domain/member/domain/Member.java
+++ b/src/main/java/com/depromeet/domain/member/domain/Member.java
@@ -36,7 +36,7 @@ public class Member extends BaseTimeEntity {
 
     @Embedded private OauthInfo oauthInfo;
 
-    @Embedded private FcmInfo fcmInfo = FcmInfo.createFcmInfo();
+    @Embedded private FcmInfo fcmInfo;
 
     @Enumerated(EnumType.STRING)
     private MemberStatus status;

--- a/src/main/java/com/depromeet/global/config/fcm/FcmService.java
+++ b/src/main/java/com/depromeet/global/config/fcm/FcmService.java
@@ -29,6 +29,9 @@ public class FcmService {
     }
 
     public ApiFuture<String> sendMessageSync(String token, String title, String content) {
+        if (token == null || token.isEmpty()) {
+            return null;
+        }
         Message message =
                 Message.builder()
                         .setToken(token)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #278

## 📌 작업 내용 및 특이사항
- 현재 fcm 토큰 값이 null이거나, 다른 공백 값으로 채웠을 때 푸시알림을 보낸다면 아래와 같은 에러 발생
`Exactly one of token, topic or condition must be specified`
<img width="1380" alt="image" src="https://github.com/depromeet/10mm-server/assets/64088250/5bae3391-5a83-4770-b14b-b9b875a01b56">
- 토큰이 빈값일 때 보내지 않도록 설정