### PR TITLE
feat: 소셜 로그인 회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/depromeet/domain/auth/application/AuthService.java
+++ b/src/main/java/com/depromeet/domain/auth/application/AuthService.java
@@ -103,7 +103,7 @@ public class AuthService {
 
     private Member fetchOrCreate(OidcUser oidcUser) {
         return memberRepository
-                .findByOauthInfo(extractOauthInfo(oidcUser))
+                .findByOauthInfoAndStatus(extractOauthInfo(oidcUser), MemberStatus.NORMAL)
                 .orElseGet(() -> saveMember(oidcUser));
     }
 

--- a/src/main/java/com/depromeet/domain/member/api/MemberController.java
+++ b/src/main/java/com/depromeet/domain/member/api/MemberController.java
@@ -8,6 +8,7 @@ import com.depromeet.domain.member.dto.request.UpdateFcmTokenRequest;
 import com.depromeet.domain.member.dto.response.MemberFindOneResponse;
 import com.depromeet.domain.member.dto.response.MemberSearchResponse;
 import com.depromeet.domain.member.dto.response.MemberSocialInfoResponse;
+import com.depromeet.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final CookieUtil cookieUtil;
 
     @Operation(summary = "회원 정보 확인", description = "로그인 된 회원의 정보를 확인합니다.")
     @GetMapping("/me")
@@ -64,7 +66,7 @@ public class MemberController {
     @DeleteMapping("/withdrawal")
     public ResponseEntity<Void> memberWithdrawal() {
         memberService.withdrawal();
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().headers(cookieUtil.deleteTokenCookies()).build();
     }
 
     @Operation(summary = "소셜 로그인 정보 조회하기", description = "소셜 로그인 정보를 조회합니다.")

--- a/src/main/java/com/depromeet/domain/member/api/MemberController.java
+++ b/src/main/java/com/depromeet/domain/member/api/MemberController.java
@@ -62,8 +62,8 @@ public class MemberController {
     // TODO: 테스트 코드 작성 필요
     @Operation(summary = "회원 탈퇴", description = "회원탈퇴를 진행합니다.")
     @DeleteMapping("/withdrawal")
-    public ResponseEntity<Void> memberWithdrawal(@Valid @RequestBody UsernameCheckRequest request) {
-        memberService.withdrawal(request);
+    public ResponseEntity<Void> memberWithdrawal() {
+        memberService.withdrawal();
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/depromeet/domain/member/application/MemberService.java
+++ b/src/main/java/com/depromeet/domain/member/application/MemberService.java
@@ -135,12 +135,8 @@ public class MemberService {
         return response;
     }
 
-    public void withdrawal(UsernameCheckRequest request) {
-        final Member member =
-                memberRepository
-                        .findByUsername(request.username())
-                        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
+    public void withdrawal() {
+        final Member member = memberUtil.getCurrentMember();
         refreshTokenRepository.deleteById(member.getId());
         member.withdrawal();
     }

--- a/src/main/java/com/depromeet/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/depromeet/domain/member/dao/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.member.dao;
 
 import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.member.domain.MemberStatus;
 import com.depromeet.domain.member.domain.OauthInfo;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
@@ -10,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
+    Optional<Member> findByOauthInfoAndStatus(OauthInfo oauthInfo, MemberStatus status);
 
     boolean existsByUsername(String username);
 

--- a/src/main/java/com/depromeet/global/util/CookieUtil.java
+++ b/src/main/java/com/depromeet/global/util/CookieUtil.java
@@ -47,4 +47,33 @@ public class CookieUtil {
         }
         return "None";
     }
+
+    public HttpHeaders deleteTokenCookies() {
+
+        String sameSite = determineSameSitePolicy();
+
+        ResponseCookie accessTokenCookie =
+                ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, "")
+                        .path("/")
+                        .maxAge(0)
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(false)
+                        .build();
+
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                        .path("/")
+                        .maxAge(0)
+                        .secure(true)
+                        .sameSite(sameSite)
+                        .httpOnly(false)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #269 

## 📌 작업 내용 및 특이사항
- 기존에 nickname을 사용하고 있는 로직으로 인해 회원탈퇴가 작동하지 않는 이슈를 해결했습니다.
- 회원 탈퇴 시 `OAuthInfo` 를 삭제하는 대신 해당 정보를 유지하고 회원탈퇴한 경우에는 재가입이 가능하도록 변경했습니다.
- 쿠키 유틸리티에 쿠키 삭제 로직을 구현했습니다.

## 📝 참고사항
- 프론트가 회원탈퇴 시 `UsernameCheckRequest` 을 보내지 않도록 수정해야 합니다. 단, 수정하지 않더라도 기능은 작동합니다.

## 📚 기타
- 
