### PR TITLE
hotfix: 푸시 알림 시 닉네임이 username이 아닌 nickname을 사용하도록 변경(main)

### DIFF
--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -53,7 +53,7 @@ public class FollowService {
         fcmService.sendMessageSync(
                 targetMember.getFcmInfo().getFcmToken(),
                 PUSH_SERVICE_TITLE,
-                String.format(PUSH_SERVICE_CONTENT, currentMember.getUsername()));
+                String.format(PUSH_SERVICE_CONTENT, currentMember.getProfile().getNickname()));
         notificationService.createNotification(
                 NotificationType.FOLLOW, currentMember, targetMember);
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #288 

## 📌 작업 내용 및 특이사항
<img src="https://github.com/depromeet/10mm-server/assets/64088250/8de2b288-c680-43f5-8602-b3ec22331106" width="300"/>

- 현재 푸시 알림 전송 시 팔로우를 한 회원의 닉네임이 null로 나옵니다.
- profile에 존재하는 nickname을 넣어줘야하는데, SNS 로그인 전 아이디/비밀번호 로그인의 username을 넣어주고있음
- nickname을 넣어주도록 변경