### PR TITLE
fix: 모바일 개발환경 테스트를 위해 CORS 정책에 ngrok 도메인 추가

### DIFF
--- a/src/main/java/com/depromeet/global/common/constants/UrlConstants.java
+++ b/src/main/java/com/depromeet/global/common/constants/UrlConstants.java
@@ -14,6 +14,8 @@ public enum UrlConstants {
     DEV_DOMAIN_URL("https://www.dev.10mm.today"),
     LOCAL_DOMAIN_URL("http://localhost:3000"),
 
+    NGROK_DOMAIN_URL("https://*.ngrok-free.app"),
+
     IMAGE_DOMAIN_URL("https://image.10mm.today"),
     ;
 

--- a/src/main/java/com/depromeet/global/common/constants/UrlConstants.java
+++ b/src/main/java/com/depromeet/global/common/constants/UrlConstants.java
@@ -13,6 +13,7 @@ public enum UrlConstants {
     PROD_DOMAIN_URL("https://www.10mm.today"),
     DEV_DOMAIN_URL("https://www.dev.10mm.today"),
     LOCAL_DOMAIN_URL("http://localhost:3000"),
+    LOCAL_SECURE_DOMAIN_URL("https://localhost:3000"),
 
     NGROK_DOMAIN_URL("https://*.ngrok-free.app"),
 

--- a/src/main/java/com/depromeet/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/depromeet/global/config/security/WebSecurityConfig.java
@@ -126,6 +126,7 @@ public class WebSecurityConfig {
         if (springEnvironmentUtil.isDevProfile()) {
             configuration.addAllowedOriginPattern(UrlConstants.DEV_DOMAIN_URL.getValue());
             configuration.addAllowedOriginPattern(UrlConstants.LOCAL_DOMAIN_URL.getValue());
+            configuration.addAllowedOriginPattern(UrlConstants.LOCAL_SECURE_DOMAIN_URL.getValue());
             configuration.addAllowedOriginPattern(UrlConstants.NGROK_DOMAIN_URL.getValue());
         }
 

--- a/src/main/java/com/depromeet/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/depromeet/global/config/security/WebSecurityConfig.java
@@ -126,6 +126,7 @@ public class WebSecurityConfig {
         if (springEnvironmentUtil.isDevProfile()) {
             configuration.addAllowedOriginPattern(UrlConstants.DEV_DOMAIN_URL.getValue());
             configuration.addAllowedOriginPattern(UrlConstants.LOCAL_DOMAIN_URL.getValue());
+            configuration.addAllowedOriginPattern(UrlConstants.NGROK_DOMAIN_URL.getValue());
         }
 
         configuration.addAllowedHeader("*");


### PR DESCRIPTION
## 🌱 관련 이슈
- close #291

## 📌 작업 내용 및 특이사항
- CORS 설정에 `*.ngrok-free.app` 오리진 패턴 추가
- 프론트 로컬 https 접속을 위해 `https://localhost:3000` 오리진 패턴 추가

## 📝 참고사항
- 

## 📚 기타
- 
