### PR TITLE
feat: 팔로우 취소 시 상대의 팔로우 상태 응답하도록 변경

### DIFF
--- a/src/main/java/com/depromeet/domain/follow/api/FollowController.java
+++ b/src/main/java/com/depromeet/domain/follow/api/FollowController.java
@@ -29,8 +29,9 @@ public class FollowController {
 
     @DeleteMapping
     @Operation(summary = "팔로우 취소", description = "팔로우를 취소합니다.")
-    public void followDelete(@Valid @RequestBody FollowDeleteRequest request) {
-        followService.deleteFollow(request);
+    public ResponseEntity<FollowerDeletedResponse> followDelete(
+            @Valid @RequestBody FollowDeleteRequest request) {
+        return ResponseEntity.ok(followService.deleteFollow(request));
     }
 
     @GetMapping("/{targetId}")

--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -62,7 +62,7 @@ public class FollowService {
         memberRelationRepository.save(memberRelation);
     }
 
-    public void deleteFollow(FollowDeleteRequest request) {
+    public FollowerDeletedResponse deleteFollow(FollowDeleteRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
         Member targetMember = getTargetMember(request.targetId());
 
@@ -79,6 +79,14 @@ public class FollowService {
             notificationRepository.delete(notification);
         }
         memberRelationRepository.delete(memberRelation);
+
+        Optional<MemberRelation> optionalMemberRelation =
+                memberRelationRepository.findBySourceIdAndTargetId(
+                        targetMember.getId(), currentMember.getId());
+
+        return optionalMemberRelation.isPresent()
+                ? FollowerDeletedResponse.from(FollowStatus.FOLLOWED_BY_ME)
+                : FollowerDeletedResponse.from(FollowStatus.NOT_FOLLOWING);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
@@ -178,6 +178,55 @@ class FollowServiceTest {
         }
 
         @Test
+        void 상대가_나를_팔로우_하고_있다면_FOLLOW_STATUE가_FOLLOWED_BY_ME로_응답한다() {
+            Long targetId = 2L;
+            FollowDeleteRequest request = new FollowDeleteRequest(targetId);
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("testNickname1", "testImageUrl1")));
+            Member targetMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("testNickname2", "testImageUrl2")));
+            MemberRelation memberRelation =
+                    MemberRelation.createMemberRelation(currentMember, targetMember);
+            MemberRelation memberRelation2 =
+                    MemberRelation.createMemberRelation(targetMember, currentMember);
+            memberRelationRepository.save(memberRelation);
+            memberRelationRepository.save(memberRelation2);
+
+            // when
+            FollowerDeletedResponse response = followService.deleteFollow(request);
+
+            // then
+            assertEquals(FollowStatus.FOLLOWED_BY_ME, response.followStatus());
+        }
+
+        @Test
+        void 상대가_나를_팔로우_하고_있지_않다면_FOLLOW_STATUE가_NOT_FOLLOWING로_응답한다() {
+            Long targetId = 2L;
+            FollowDeleteRequest request = new FollowDeleteRequest(targetId);
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("testNickname1", "testImageUrl1")));
+            Member targetMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("testNickname2", "testImageUrl2")));
+            MemberRelation memberRelation =
+                    MemberRelation.createMemberRelation(currentMember, targetMember);
+            memberRelationRepository.save(memberRelation);
+
+            // when
+            FollowerDeletedResponse response = followService.deleteFollow(request);
+
+            // then
+            assertEquals(FollowStatus.NOT_FOLLOWING, response.followStatus());
+        }
+
+        @Test
         void 정상적이라면_팔로우가_취소된다() {
             Long targetId = 2L;
             FollowDeleteRequest request = new FollowDeleteRequest(targetId);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #295

## 📌 작업 내용 및 특이사항
- 현재 닉네임 검색과 같은 곳에서 팔로우를 취소했을 떄 상대방이 나를 팔로우 하고 있는지 아닌지에 따라 버튼이 `팔로우` / `맞팔로우`로 달라져야 한다 .
- 프론트 닉네임 검색(리스트 뷰)에서 리패칭을 한다면 순서가 달라진다거나 하는 이슈가 있어 팔로우 취소 API 에서 응답