### PR TITLE
feat: 미션 단건조회 응답 값에 미션 시작시간과 끝나는 시간 추가

### DIFF
--- a/src/main/java/com/depromeet/domain/mission/dto/response/MissionFindResponse.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/response/MissionFindResponse.java
@@ -5,7 +5,9 @@ import com.depromeet.domain.mission.domain.DurationStatus;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.domain.MissionCategory;
 import com.depromeet.domain.mission.domain.MissionVisibility;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 
 public record MissionFindResponse(
         @Schema(description = "미션 ID", defaultValue = "1") Long missionId,
@@ -16,7 +18,25 @@ public record MissionFindResponse(
         @Schema(description = "미션 진행 여부", defaultValue = "IN_PROGRESS")
                 DurationStatus durationStatus,
         @Schema(description = "미션 아카이빙 상태", defaultValue = "NONE") ArchiveStatus status,
-        @Schema(description = "미션 정렬 값", defaultValue = "1") Integer sort) {
+        @Schema(description = "미션 정렬 값", defaultValue = "1") Integer sort,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 시작 시간",
+                        defaultValue = "2023-01-03 00:00:00",
+                        type = "string")
+                LocalDateTime startedAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 종료 시간",
+                        defaultValue = "2024-01-03 00:34:00",
+                        type = "string")
+                LocalDateTime finishedAt) {
 
     public static MissionFindResponse from(Mission mission) {
         return new MissionFindResponse(
@@ -27,6 +47,8 @@ public record MissionFindResponse(
                 mission.getVisibility(),
                 mission.getDurationStatus(),
                 mission.getArchiveStatus(),
-                mission.getSort());
+                mission.getSort(),
+                mission.getStartedAt(),
+                mission.getFinishedAt());
     }
 }

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -123,7 +123,9 @@ class MissionControllerTest {
                                 MissionVisibility.ALL,
                                 DurationStatus.IN_PROGRESS,
                                 ArchiveStatus.NONE,
-                                1));
+                                1,
+                                LocalDateTime.of(2024, 01, 01, 1, 5, 0),
+                                LocalDateTime.of(2024, 01, 15, 1, 5, 0)));
 
         // when, then
         ResultActions perform =


### PR DESCRIPTION
## 🌱 관련 이슈
- close #303 

## 📌 작업 내용 및 특이사항
<img width="724" alt="image" src="https://github.com/depromeet/10mm-server/assets/64088250/4bf6c34f-4489-4570-8420-4a59a576b45b"/>


- 종료 미션 페이지 개발 중 해당 미션이 언제부터 언제 끝났는지 기간을 넣어줘야하는데 현재 미션 조회에서는 응답 값에 시작시간과 끝나는 시간이 존재하지 않아서 추가
(@sumi-0011 님 요청)
- 미션 단건조회 테스트 코드 변경