### PR TITLE
feat: 미션별 통계 API

### DIFF
--- a/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/api/MissionRecordController.java
@@ -57,4 +57,10 @@ public class MissionRecordController {
         missionRecordService.deleteInProgressMissionRecord();
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "미션 상세 통계", description = "미션별 상세")
+    @GetMapping("/statistics/{missionId}")
+    public MissionStatisticsResponse missionStatistics(@PathVariable Long missionId) {
+        return missionRecordService.findMissionStatistics(missionId);
+    }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.missionRecord.application;
 
 import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.mission.application.MissionService;
 import com.depromeet.domain.mission.dao.MissionRepository;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
@@ -11,6 +12,7 @@ import com.depromeet.domain.missionRecord.domain.MissionRecordTtl;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordCreateRequest;
 import com.depromeet.domain.missionRecord.dto.request.MissionRecordUpdateRequest;
 import com.depromeet.domain.missionRecord.dto.response.*;
+import com.depromeet.domain.missionRecord.dto.response.MissionStatisticsResponse;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.util.MemberUtil;
@@ -18,6 +20,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,7 @@ public class MissionRecordService {
     private static final int DAYS_ADJUSTMENT = 1;
 
     private final MemberUtil memberUtil;
+    private final MissionService missionService;
     private final MissionRepository missionRepository;
     private final MissionRecordRepository missionRecordRepository;
     private final MissionRecordTtlRepository missionRecordTtlRepository;
@@ -150,7 +154,96 @@ public class MissionRecordService {
         }
     }
 
-    private void validateMissionRecordDuration(Duration duration) {
+	@Transactional(readOnly = true)
+	public MissionStatisticsResponse findMissionStatistics(Long missionId) {
+		Mission mission = findMissionById(missionId);
+		LocalDateTime startedAt = mission.getStartedAt();
+		LocalDateTime finishedAt = mission.getFinishedAt();
+		LocalDateTime today = LocalDateTime.now();
+
+		List<MissionRecord> missionRecords = missionRecordRepository.findAllByMissionId(missionId);
+
+		// 달성률
+		double totalMissionAttainRate = calculateMissionAttainRate(
+			missionRecords.size(),
+			Duration.between(startedAt, finishedAt.isBefore(today) ? finishedAt : today).toDays() + DAYS_ADJUSTMENT);
+
+		// 시간표 생성
+		List<FocusMissionTimeOfDay> timeTable = generateRecordTimeTable(missionRecords);
+
+		// 최대 연속성 계산
+		long maxContinuousSuccessDay = calculateMaxContinuousSuccessDay(startedAt, finishedAt, missionRecords);
+
+		// 전체 번개 스택
+		long totalSymbolStack = calculateTotalSymbolStack(timeTable);
+
+		// 전체 수행시간
+		long sumDuration = calculateSumDuration(timeTable);
+
+		// 전체 수행 시간 (시간)
+		long totalMissionHour = sumDuration / 60;
+
+		// 전체 수행 시간 (분)
+		long totalMissionMinute = sumDuration % 60;
+
+		return MissionStatisticsResponse.of(
+			totalMissionHour,
+			totalMissionMinute,
+			totalSymbolStack,
+			maxContinuousSuccessDay,
+			missionRecords.size(),
+			totalMissionAttainRate,
+			startedAt,
+			finishedAt,
+			timeTable);
+	}
+
+	private List<FocusMissionTimeOfDay> generateRecordTimeTable(List<MissionRecord> missionRecords) {
+		return missionRecords.stream()
+			.map(record -> FocusMissionTimeOfDay.of(
+				record.getDuration().toMinutes() / 10,
+				record.getDuration().toMinutes(),
+				record.getStartedAt(),
+				record.getFinishedAt()))
+			.toList();
+	}
+
+	private long calculateMaxContinuousSuccessDay(LocalDateTime startedAt, LocalDateTime finishedAt, List<MissionRecord> missionRecords) {
+		long continuousSuccessDay = 1;
+		long maxContinuousSuccessDay = 0;
+		LocalDate previousDate = null;
+
+		for (MissionRecord missionRecord : missionRecords) {
+			LocalDate currentDate = missionRecord.getStartedAt().toLocalDate();
+
+			// startedAt과 finishedAt 사이에 있는 일자일 때만 고려
+			if (currentDate.isAfter(startedAt.toLocalDate()) && currentDate.isBefore(finishedAt.toLocalDate())) {
+				if (previousDate != null && currentDate.minusDays(1).isEqual(previousDate)) {
+					continuousSuccessDay++;
+				} else {
+					continuousSuccessDay = 1; // 연속성이 깨진 경우 초기화
+				}
+
+				if (continuousSuccessDay > maxContinuousSuccessDay) {
+					maxContinuousSuccessDay = continuousSuccessDay;
+				}
+
+				previousDate = currentDate;
+			}
+		}
+		return maxContinuousSuccessDay;
+	}
+
+	private long calculateTotalSymbolStack(List<FocusMissionTimeOfDay> timeTable) {
+		return timeTable.stream().mapToLong(FocusMissionTimeOfDay::symbolStack).sum();
+	}
+
+	private long calculateSumDuration(List<FocusMissionTimeOfDay> timeTable) {
+		return timeTable.stream().mapToLong(FocusMissionTimeOfDay::durationMinute).sum();
+	}
+
+
+	private void validateMissionRecordDuration(Duration duration) {
         if (duration.getSeconds() > 3600L) {
             throw new CustomException(ErrorCode.MISSION_RECORD_DURATION_OVERBALANCE);
         }
@@ -161,4 +254,9 @@ public class MissionRecordService {
             throw new CustomException(ErrorCode.MISSION_RECORD_USER_MISMATCH);
         }
     }
+
+    private double calculateMissionAttainRate(long completeSize, long totalSize) {
+        return Math.round((double) completeSize / totalSize * 1000) / 10.0;
+    }
+
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -11,6 +11,8 @@ public interface MissionRecordRepositoryCustom {
 
     List<MissionRecord> findAllByMissionIdAndYearMonth(Long missionId, YearMonth yearMonth);
 
+    List<MissionRecord> findAllByMissionId(Long missionId);
+
     List<FeedOneResponse> findFeedAll(List<Member> members);
 
     List<MissionRecord> findFeedAllByMemberId(Long memberId, List<MissionVisibility> visibilities);

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -38,6 +38,15 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     }
 
     @Override
+    public List<MissionRecord> findAllByMissionId(Long missionId) {
+        return jpaQueryFactory
+                .selectFrom(missionRecord)
+                .where(missionIdEq(missionId), uploadStatusCompleteEq())
+                .orderBy(missionRecord.startedAt.asc())
+                .fetch();
+    }
+
+    @Override
     public boolean isCompletedMissionExistsToday(Long missionId) {
         LocalDate now = LocalDate.now();
         MissionRecord missionRecordFetchOne =
@@ -118,5 +127,9 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
 
     private BooleanExpression dayEq(int day) {
         return missionRecord.startedAt.dayOfMonth().eq(day);
+    }
+
+    private BooleanExpression uploadStatusCompleteEq() {
+        return missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE);
     }
 }

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/FocusMissionTimeOfDay.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/FocusMissionTimeOfDay.java
@@ -1,0 +1,37 @@
+package com.depromeet.domain.missionRecord.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record FocusMissionTimeOfDay(
+        @Schema(description = "번개 수", defaultValue = "3") long symbolStack,
+        @Schema(description = "미션 수행 시간 (Minute)", defaultValue = "34") long durationMinute,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 기록 시작 시간",
+                        defaultValue = "2024-01-01 00:34:00",
+                        type = "string")
+                LocalDateTime startedAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 기록 종료 시간",
+                        defaultValue = "2024-01-15 00:34:00",
+                        type = "string")
+                LocalDateTime finishedAt) {
+
+    public static FocusMissionTimeOfDay of(
+            long symbolStack,
+            long durationMinute,
+            LocalDateTime startedAt,
+            LocalDateTime finishedAt) {
+        return new FocusMissionTimeOfDay(
+			symbolStack, durationMinute, startedAt, finishedAt);
+    }
+}

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionStatisticsResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionStatisticsResponse.java
@@ -1,0 +1,56 @@
+package com.depromeet.domain.missionRecord.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MissionStatisticsResponse(
+        @Schema(description = "수행 시간(시간)", defaultValue = "3") long totalMissionHour,
+        @Schema(description = "수행 시간(분)", defaultValue = "8") long totalMissionMinute,
+        @Schema(description = "번개 수", defaultValue = "8") long totalSymbolStack,
+        @Schema(description = "연속 성공일", defaultValue = "4") long continuousSuccessDay,
+        @Schema(description = "총 성공일", defaultValue = "9") long totalSuccessDay,
+        @Schema(description = "달성률", defaultValue = "20.4") double totalMissionAttainRate,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "집중 시작 시각",
+                        defaultValue = "2024-01-01 00:34:00",
+                        type = "string")
+                LocalDateTime startedAt,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "집중 마친 시각",
+                        defaultValue = "2024-01-15 00:34:00",
+                        type = "string")
+                LocalDateTime finishedAt,
+        @Schema(description = "미션 수행 타임 테이블") List<FocusMissionTimeOfDay> timeTable) {
+
+    public static MissionStatisticsResponse of(
+            long totalMissionHour,
+            long totalMissionMinute,
+            long totalSymbolStack,
+            long continuousSuccessDay,
+            long totalSuccessDay,
+            double totalMissionAttainRate,
+            LocalDateTime startedAt,
+            LocalDateTime finishedAt,
+            List<FocusMissionTimeOfDay> timeTable) {
+        return new MissionStatisticsResponse(
+                totalMissionHour,
+                totalMissionMinute,
+                totalSymbolStack,
+                continuousSuccessDay,
+                totalSuccessDay,
+                totalMissionAttainRate,
+                startedAt,
+                finishedAt,
+                timeTable);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #271 

## 📌 작업 내용 및 특이사항
- 미션별 통계 API
- MissionStatisticsResponse DTO는 아래 첨부된 이미지에 fit한 response 모델을 프론트와 약속
<img width="331" alt="image" src="https://github.com/depromeet/10mm-server/assets/68099546/62736c1c-0b96-4d18-a63a-41a9f20e2518">


## 📝 참고사항
- 계산을 맞춰서 하느라 조금 지저분한 코드일 수 있으니 `매운 리뷰` 부탁드립니도

## 📚 기타
- 
