### PR TITLE
feat: 미션 전체 현황 - 날짜로 미션 목록 조회

### DIFF
--- a/src/main/java/com/depromeet/domain/mission/api/MissionController.java
+++ b/src/main/java/com/depromeet/domain/mission/api/MissionController.java
@@ -3,29 +3,17 @@ package com.depromeet.domain.mission.api;
 import com.depromeet.domain.mission.application.MissionService;
 import com.depromeet.domain.mission.dto.request.MissionCreateRequest;
 import com.depromeet.domain.mission.dto.request.MissionUpdateRequest;
-import com.depromeet.domain.mission.dto.response.FinishedMissionResponse;
-import com.depromeet.domain.mission.dto.response.FollowMissionFindAllResponse;
-import com.depromeet.domain.mission.dto.response.MissionCreateResponse;
-import com.depromeet.domain.mission.dto.response.MissionFindAllResponse;
-import com.depromeet.domain.mission.dto.response.MissionFindResponse;
-import com.depromeet.domain.mission.dto.response.MissionSymbolStackResponse;
-import com.depromeet.domain.mission.dto.response.MissionUpdateResponse;
+import com.depromeet.domain.mission.dto.response.*;
 import com.depromeet.domain.missionRecord.dto.response.MissionRecordSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "2. [미션]", description = "미션 관련 API입니다.")
 @RestController
@@ -65,6 +53,12 @@ public class MissionController {
     @GetMapping("/summary")
     public MissionRecordSummaryResponse missionRecordFindSummary() {
         return missionService.findSummaryMissionRecord();
+    }
+
+    @Operation(summary = "미션 전체 현황 - 리스트", description = "년, 월, 일을 입력받아 해당 날짜의 미션 리스트를 조회합니다.")
+    @GetMapping("/summary-list")
+    public MissionSummaryListResponse missionSummaryList(@RequestParam LocalDate date) {
+        return missionService.findSummaryList(date);
     }
 
     @Operation(summary = "종료미션 보관함", description = "종료된 미션 리스트를 조회합니다.")

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -313,20 +313,13 @@ public class MissionService {
 
         List<MissionSummaryItem> result =
                 missions.stream()
-                        .map(
-                                mission -> {
-                                    boolean isCompleted =
-                                            mission.getMissionRecords().stream()
-                                                    .anyMatch(
-                                                            missionRecord ->
-                                                                    missionRecord.getUploadStatus()
-                                                                            == ImageUploadStatus
-                                                                                    .COMPLETE);
-                                    return isCompleted
-                                            ? MissionSummaryItem.of(
-                                                    mission, MissionStatus.COMPLETED)
-                                            : MissionSummaryItem.of(mission, MissionStatus.NONE);
-                                })
+                        .map(mission -> getMissionSummaryItem(mission))
+                        .sorted(
+                                Comparator.comparing(MissionSummaryItem::missionStatus)
+                                        .reversed()
+                                        .thenComparing(
+                                                Comparator.comparing(MissionSummaryItem::finishedAt)
+                                                        .reversed()))
                         .collect(Collectors.toList());
 
         result.sort(
@@ -346,5 +339,17 @@ public class MissionService {
         long missionNoneCount = missionAllCount - missionCompleteCount;
         return MissionSummaryListResponse.of(
                 missionAllCount, missionCompleteCount, missionNoneCount, result);
+    }
+
+    private static MissionSummaryItem getMissionSummaryItem(Mission mission) {
+        boolean isCompleted =
+                mission.getMissionRecords().stream()
+                        .anyMatch(
+                                missionRecord ->
+                                        missionRecord.getUploadStatus()
+                                                == ImageUploadStatus.COMPLETE);
+        return isCompleted
+                ? MissionSummaryItem.of(mission, MissionStatus.COMPLETED)
+                : MissionSummaryItem.of(mission, MissionStatus.NONE);
     }
 }

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -304,6 +304,7 @@ public class MissionService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public MissionSummaryListResponse findSummaryList(LocalDate date) {
         final Member currentMember = memberUtil.getCurrentMember();
         List<Mission> missions =

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -24,7 +24,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -312,15 +311,23 @@ public class MissionService {
         List<Mission> missions =
                 missionRepository.findMissionsWithRecordsByDate(date, currentMember.getId());
 
-        List<MissionSummaryItem> result = missions.stream()
-                .map(mission -> {
-                    boolean isCompleted = mission.getMissionRecords().stream()
-                            .anyMatch(missionRecord -> missionRecord.getUploadStatus() == ImageUploadStatus.COMPLETE);
-                    return isCompleted ?
-                            MissionSummaryItem.of(mission, MissionStatus.COMPLETED) :
-                            MissionSummaryItem.of(mission, MissionStatus.NONE);
-                })
-                .collect(Collectors.toList());
+        List<MissionSummaryItem> result =
+                missions.stream()
+                        .map(
+                                mission -> {
+                                    boolean isCompleted =
+                                            mission.getMissionRecords().stream()
+                                                    .anyMatch(
+                                                            missionRecord ->
+                                                                    missionRecord.getUploadStatus()
+                                                                            == ImageUploadStatus
+                                                                                    .COMPLETE);
+                                    return isCompleted
+                                            ? MissionSummaryItem.of(
+                                                    mission, MissionStatus.COMPLETED)
+                                            : MissionSummaryItem.of(mission, MissionStatus.NONE);
+                                })
+                        .collect(Collectors.toList());
 
         result.sort(
                 Comparator.comparing(MissionSummaryItem::missionStatus)

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.depromeet.domain.mission.dao;
 
 import com.depromeet.domain.mission.domain.Mission;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -15,4 +16,6 @@ public interface MissionRepositoryCustom {
     void updateFinishedDurationStatus(LocalDateTime today);
 
     List<Mission> findAllFinishedMission(Long memberId);
+
+    List<Mission> findMissionsWithRecordsByDate(LocalDate date, Long memberId);
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -82,6 +83,22 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
                 .where(memberIdEq(memberId), durationStatusFinishedEq())
                 .orderBy(mission.finishedAt.desc())
                 .fetch();
+    }
+
+    @Override
+    public List<Mission> findMissionsWithRecordsByDate(LocalDate date, Long memberId) {
+        LocalDateTime startedAt = date.atTime(0, 0, 0);
+        LocalDateTime finishedAt = date.atTime(23, 59, 59);
+        JPAQuery<Mission> query =
+                jpaQueryFactory
+                        .selectFrom(mission)
+                        .leftJoin(mission.missionRecords, missionRecord)
+                        .where(
+                                memberIdEq(memberId),
+                                mission.startedAt.loe(startedAt),
+                                mission.finishedAt.goe(finishedAt))
+                        .fetchJoin();
+        return query.fetch();
     }
 
     // 미션의 사용자 id 조건 검증 메서드

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -88,7 +88,7 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
     @Override
     public List<Mission> findMissionsWithRecordsByDate(LocalDate date, Long memberId) {
         LocalDateTime startedAt = date.atTime(0, 0, 0);
-        LocalDateTime finishedAt = date.atTime(23, 59, 59);
+        LocalDateTime finishedAt = startedAt.plusDays(1);
         JPAQuery<Mission> query =
                 jpaQueryFactory
                         .selectFrom(mission)

--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -128,10 +128,9 @@ public class Mission extends BaseTimeEntity {
                 .filter(
                         record ->
                                 record.getStartedAt()
-                                        .toLocalDate()
-                                        .equals(LocalDateTime.now().toLocalDate())
-                                        && record.getUploadStatus() == ImageUploadStatus.COMPLETE
-                )
+                                                .toLocalDate()
+                                                .equals(LocalDateTime.now().toLocalDate())
+                                        && record.getUploadStatus() == ImageUploadStatus.COMPLETE)
                 .findFirst()
                 .isPresent();
     }

--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -2,6 +2,7 @@ package com.depromeet.domain.mission.domain;
 
 import com.depromeet.domain.common.model.BaseTimeEntity;
 import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.missionRecord.domain.ImageUploadStatus;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -128,7 +129,9 @@ public class Mission extends BaseTimeEntity {
                         record ->
                                 record.getStartedAt()
                                         .toLocalDate()
-                                        .equals(LocalDateTime.now().toLocalDate()))
+                                        .equals(LocalDateTime.now().toLocalDate())
+                                        && record.getUploadStatus() == ImageUploadStatus.COMPLETE
+                )
                 .findFirst()
                 .isPresent();
     }

--- a/src/main/java/com/depromeet/domain/mission/dto/response/MissionSummaryItem.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/response/MissionSummaryItem.java
@@ -1,0 +1,33 @@
+package com.depromeet.domain.mission.dto.response;
+
+import com.depromeet.domain.mission.domain.*;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record MissionSummaryItem(
+        @Schema(description = "미션 ID", defaultValue = "1") Long missionId,
+        @Schema(description = "미션 이름", defaultValue = "default name") String name,
+        @Schema(description = "미션 카테고리", defaultValue = "STUDY") MissionCategory category,
+        @Schema(description = "미션 공개여부", defaultValue = "ALL") MissionVisibility visibility,
+        @Schema(description = "미션 상태", defaultValue = "1") MissionStatus missionStatus,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "미션 종료 시간",
+                        defaultValue = "2024-01-03 00:34:00",
+                        type = "string")
+                LocalDateTime finishedAt) {
+
+    public static MissionSummaryItem of(Mission mission, MissionStatus missionStatus) {
+        return new MissionSummaryItem(
+                mission.getId(),
+                mission.getName(),
+                mission.getCategory(),
+                mission.getVisibility(),
+                missionStatus,
+                mission.getFinishedAt());
+    }
+}

--- a/src/main/java/com/depromeet/domain/mission/dto/response/MissionSummaryListResponse.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/response/MissionSummaryListResponse.java
@@ -1,0 +1,18 @@
+package com.depromeet.domain.mission.dto.response;
+
+import java.util.List;
+
+public record MissionSummaryListResponse(
+        long missionAllCount,
+        long missionCompleteCount,
+        long missionNoneCount,
+        List<MissionSummaryItem> missionSummaryItems) {
+    public static MissionSummaryListResponse of(
+            long missionAllCount,
+            long missionCompleteCount,
+            long missionNoneCount,
+            List<MissionSummaryItem> missionSummaryItems) {
+        return new MissionSummaryListResponse(
+                missionAllCount, missionCompleteCount, missionNoneCount, missionSummaryItems);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #305

## 📌 작업 내용 및 특이사항
<img width="223" alt="image" src="https://github.com/depromeet/10mm-server/assets/64088250/0d72dd95-029c-4fc9-b70c-d9e3f7c8c641">

- 날짜를 선택했을 때 해당 날짜에 미션 리스트와 미션을 완수하였는지 안하였는지 확인 할 수 있어야 합니다.
- 정렬 조건은 완료한 미션 먼저오고 미완료 미션은 후에 오고, 같은 순서일때는 먼저 종료된 미션이 나중에 와야합니다.(아래 이미지 참고)
<img width="605" alt="image" src="https://github.com/depromeet/10mm-server/assets/64088250/ff7d6ca3-b840-41f8-af25-f073377bb0cd">
