### PR TITLE
fix: 본인이 본인을 팔로우하는 경우 Validation 추가

### DIFF
--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -38,6 +38,7 @@ public class FollowService {
 
     public void createFollow(FollowCreateRequest request) {
         final Member currentMember = memberUtil.getCurrentMember();
+        validateSelfFollow(currentMember.getId(), request.targetId());
         Member targetMember = getTargetMember(request.targetId());
 
         boolean existMemberRelation =
@@ -175,6 +176,12 @@ public class FollowService {
                 .forEach(entry -> result.add(MemberFollowedResponse.of(entry.getKey())));
 
         return result;
+    }
+
+    private void validateSelfFollow(Long expectedId, Long actualId) {
+        if (expectedId.equals(actualId)) {
+            throw new CustomException(ErrorCode.FOLLOW_SELF_NOT_ALLOWED);
+        }
     }
 
     private boolean isToday(LocalDateTime dateTime) {

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     FOLLOW_TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "타겟 유저을 찾을 수 없습니다."),
     FOLLOW_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 팔로우 중인 회원입니다."),
     FOLLOW_NOT_EXIST(HttpStatus.BAD_REQUEST, "팔로우 중인 회원만 팔로우 취소가 가능합니다."),
+    FOLLOW_SELF_NOT_ALLOWED(HttpStatus.CONFLICT, "본인을 팔로우 할 수 없습니다."),
 
     // Image
     IMAGE_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지 키를 찾을 수 없습니다."),

--- a/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
@@ -69,6 +69,19 @@ class FollowServiceTest {
         }
 
         @Test
+        void 본인을_팔로우_할_경우_예외를_발생시킨다() {
+            FollowCreateRequest request = new FollowCreateRequest(1L);
+            memberRepository.save(
+                    Member.createNormalMember(
+                            Profile.createProfile("testNickname1", "testImageUrl1")));
+
+            // when, then
+            assertThatThrownBy(() -> followService.createFollow(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.FOLLOW_SELF_NOT_ALLOWED.getMessage());
+        }
+
+        @Test
         void 타겟회원이_존재하지_않는다면_예외를_발생시킨다() {
             // given
             Long targetId = 2L;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #318 

## 📌 작업 내용 및 특이사항
- 현재 프론트에서 접근 할 수 있는 페이지는 없긴 하지만, 로직 상 본인이 본인을 팔로우하는 경우 예외처리를 해주고 있지 않아 본인이 본인팔로우 한 DEV DB에 데이터 존재하여 이를 예외처리 합니다
