### PR TITLE
hotfix: 통계 미션 목록 조회 날짜 비교 추가

### DIFF
--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -313,7 +313,7 @@ public class MissionService {
 
         List<MissionSummaryItem> result =
                 missions.stream()
-                        .map(mission -> getMissionSummaryItem(mission))
+                        .map(mission -> getMissionSummaryItem(mission, date))
                         .sorted(
                                 Comparator.comparing(MissionSummaryItem::missionStatus)
                                         .reversed()
@@ -321,12 +321,6 @@ public class MissionService {
                                                 Comparator.comparing(MissionSummaryItem::finishedAt)
                                                         .reversed()))
                         .collect(Collectors.toList());
-
-        result.sort(
-                Comparator.comparing(MissionSummaryItem::missionStatus)
-                        .reversed()
-                        .thenComparing(
-                                Comparator.comparing(MissionSummaryItem::finishedAt).reversed()));
 
         long missionAllCount = missions.size();
         long missionCompleteCount =
@@ -341,13 +335,17 @@ public class MissionService {
                 missionAllCount, missionCompleteCount, missionNoneCount, result);
     }
 
-    private static MissionSummaryItem getMissionSummaryItem(Mission mission) {
+    private static MissionSummaryItem getMissionSummaryItem(Mission mission, LocalDate date) {
         boolean isCompleted =
                 mission.getMissionRecords().stream()
                         .anyMatch(
                                 missionRecord ->
                                         missionRecord.getUploadStatus()
-                                                == ImageUploadStatus.COMPLETE);
+                                                        == ImageUploadStatus.COMPLETE
+                                                && missionRecord
+                                                        .getStartedAt()
+                                                        .toLocalDate()
+                                                        .equals(date));
         return isCompleted
                 ? MissionSummaryItem.of(mission, MissionStatus.COMPLETED)
                 : MissionSummaryItem.of(mission, MissionStatus.NONE);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #323

## 📌 작업 내용 및 특이사항
- 입력 받은 날짜에 해당하는 기록이 존재하는지 여부를 체크해야하는데 체크하고 있지 않는 문제를 해결
