### PR TITLE
refactor: 피드 탭 개선

### DIFF
--- a/src/main/java/com/depromeet/domain/feed/api/FeedController.java
+++ b/src/main/java/com/depromeet/domain/feed/api/FeedController.java
@@ -3,6 +3,7 @@ package com.depromeet.domain.feed.api;
 import com.depromeet.domain.feed.application.FeedService;
 import com.depromeet.domain.feed.dto.response.FeedOneByProfileResponse;
 import com.depromeet.domain.feed.dto.response.FeedOneResponse;
+import com.depromeet.domain.mission.domain.MissionVisibility;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,8 +24,9 @@ public class FeedController {
 
     @Operation(summary = "피드 탭", description = "피드 탭을 조회합니다.")
     @GetMapping("/me")
-    public List<FeedOneResponse> feedFindAll() {
-        return feedService.findAllFeed();
+    public List<FeedOneResponse> feedFindAll(
+            @RequestParam(value = "visibility", required = false) MissionVisibility visibility) {
+        return feedService.findAllFeed(visibility);
     }
 
     @Operation(summary = "프로필 피드", description = "피드 탭을 조회합니다.")

--- a/src/main/java/com/depromeet/domain/feed/api/FeedController.java
+++ b/src/main/java/com/depromeet/domain/feed/api/FeedController.java
@@ -23,10 +23,16 @@ public class FeedController {
     private final FeedService feedService;
 
     @Operation(summary = "피드 탭", description = "피드 탭을 조회합니다.")
-    @GetMapping("/me")
+    @GetMapping
     public List<FeedOneResponse> feedFindAll(
             @RequestParam(value = "visibility", required = false) MissionVisibility visibility) {
-        return feedService.findAllFeed(visibility);
+        return feedService.findAllFeedByVisibility(visibility);
+    }
+
+    @Operation(summary = "피드 탭", description = "피드 탭을 조회합니다.")
+    @GetMapping("/me")
+    public List<FeedOneResponse> feedFindAll() {
+        return feedService.findAllFeed();
     }
 
     @Operation(summary = "프로필 피드", description = "피드 탭을 조회합니다.")

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -31,9 +31,14 @@ public class FeedService {
 
     @Transactional(readOnly = true)
     public List<FeedOneResponse> findAllFeed(MissionVisibility visibility) {
-        if (visibility.equals(MissionVisibility.ALL)) {
+		List<MissionVisibility> visibilities = new ArrayList<>();
+		visibilities.add(visibility);
+		if (!visibilities.contains(MissionVisibility.ALL)) {
+			visibilities.add(MissionVisibility.FOLLOWER); // ALL이 아닌 경우에 FOLLOWER를 추가합니다.
+		}
+		if (visibilities.contains(MissionVisibility.ALL)) {
             final List<Member> members = memberRepository.findAll();
-            return missionRecordRepository.findFeedByVisibility(members, visibility);
+            return missionRecordRepository.findFeedByVisibility(members, visibilities);
         }
 
         final Member currentMember = memberUtil.getCurrentMember();
@@ -44,7 +49,7 @@ public class FeedService {
                         .collect(Collectors.toList());
         sourceMembers.add(currentMember);
 
-        return missionRecordRepository.findFeedByVisibility(sourceMembers, visibility);
+        return missionRecordRepository.findFeedByVisibility(sourceMembers, visibilities);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -13,7 +13,7 @@ public interface MissionRecordRepositoryCustom {
 
     List<MissionRecord> findAllByCompletedMission(Long missionId);
 
-    List<FeedOneResponse> findFeedAll(List<Member> members);
+    List<FeedOneResponse> findFeedByVisibility(List<Member> members, MissionVisibility visibility);
 
     List<MissionRecord> findFeedAllByMemberId(Long memberId, List<MissionVisibility> visibilities);
 

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -13,7 +13,10 @@ public interface MissionRecordRepositoryCustom {
 
     List<MissionRecord> findAllByCompletedMission(Long missionId);
 
-    List<FeedOneResponse> findFeedByVisibility(List<Member> members, List<MissionVisibility> visibilities);
+    List<FeedOneResponse> findFeedAll(List<Member> members);
+
+    List<FeedOneResponse> findFeedByVisibility(
+            List<Member> members, MissionVisibility... visibility);
 
     List<MissionRecord> findFeedAllByMemberId(Long memberId, List<MissionVisibility> visibilities);
 

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryCustom.java
@@ -13,7 +13,7 @@ public interface MissionRecordRepositoryCustom {
 
     List<MissionRecord> findAllByCompletedMission(Long missionId);
 
-    List<FeedOneResponse> findFeedByVisibility(List<Member> members, MissionVisibility visibility);
+    List<FeedOneResponse> findFeedByVisibility(List<Member> members, List<MissionVisibility> visibilities);
 
     List<MissionRecord> findFeedAllByMemberId(Long memberId, List<MissionVisibility> visibilities);
 

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -98,7 +98,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
                 .where(
                         missionRecord.mission.member.in(members),
                         visibilityCondition,
-                        missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
+                        uploadStatusCompleteEq())
                 .orderBy(missionRecord.finishedAt.desc())
                 .limit(FEED_TAB_LIMIT)
                 .fetch();
@@ -114,7 +114,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
                 .where(
                         mission.visibility.in(visibilities),
                         mission.member.id.eq(memberId),
-                        missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
+                        uploadStatusCompleteEq())
                 .orderBy(missionRecord.startedAt.desc())
                 .fetch();
     }

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -62,8 +62,18 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     }
 
     @Override
+    public List<FeedOneResponse> findFeedAll(List<Member> members) {
+        return findFeedByVisibility(members, MissionVisibility.FOLLOWER, MissionVisibility.ALL);
+    }
+
+    @Override
     public List<FeedOneResponse> findFeedByVisibility(
-            List<Member> members, List<MissionVisibility> visibilities) {
+            List<Member> members, MissionVisibility... visibilities) {
+        BooleanExpression visibilityCondition = null;
+        if (visibilities != null && visibilities.length > 0) {
+            visibilityCondition = missionRecord.mission.visibility.in(visibilities);
+        }
+
         return jpaQueryFactory
                 .select(
                         Projections.constructor(
@@ -87,7 +97,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
                 .on(mission.member.id.eq(missionRecord.mission.member.id))
                 .where(
                         missionRecord.mission.member.in(members),
-                        missionRecord.mission.visibility.in(visibilities),
+                        visibilityCondition,
                         missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
                 .orderBy(missionRecord.finishedAt.desc())
                 .limit(FEED_TAB_LIMIT)

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -14,6 +14,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -62,7 +63,8 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
     }
 
     @Override
-    public List<FeedOneResponse> findFeedAll(List<Member> members) {
+    public List<FeedOneResponse> findFeedByVisibility(
+            List<Member> members, MissionVisibility visibility) {
         return jpaQueryFactory
                 .select(
                         Projections.constructor(
@@ -86,8 +88,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
                 .on(mission.member.id.eq(missionRecord.mission.member.id))
                 .where(
                         missionRecord.mission.member.in(members),
-                        missionRecord.mission.visibility.in(
-                                MissionVisibility.FOLLOWER, MissionVisibility.ALL),
+                        missionRecord.mission.visibility.in(visibility),
                         missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
                 .orderBy(missionRecord.finishedAt.desc())
                 .limit(FEED_TAB_LIMIT)

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -14,7 +14,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -63,7 +63,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
 
     @Override
     public List<FeedOneResponse> findFeedByVisibility(
-            List<Member> members, MissionVisibility visibility) {
+            List<Member> members, List<MissionVisibility> visibilities) {
         return jpaQueryFactory
                 .select(
                         Projections.constructor(
@@ -87,7 +87,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
                 .on(mission.member.id.eq(missionRecord.mission.member.id))
                 .where(
                         missionRecord.mission.member.in(members),
-                        missionRecord.mission.visibility.in(visibility),
+                        missionRecord.mission.visibility.in(visibilities),
                         missionRecord.uploadStatus.eq(ImageUploadStatus.COMPLETE))
                 .orderBy(missionRecord.finishedAt.desc())
                 .limit(FEED_TAB_LIMIT)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,5 +33,3 @@ logging:
 
 fcm:
   certification: ${FCM_CERTIFICATION:}
-server:
-  port: 8889

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,5 @@ logging:
 
 fcm:
   certification: ${FCM_CERTIFICATION:}
+server:
+  port: 8889


### PR DESCRIPTION
## 🌱 관련 이슈
- close #331 

## 📌 작업 내용 및 특이사항
- 피드에 `전체`, `팔로우`에 대한 탭 분리를 진행
- 기존 API에서 QueryString을 추가하는 로직이 생기면 배포시점이 엉키기에 / 경로에 QueryString을 사용하도록 개선

## 📝 참고사항
- 

## 📚 기타
- 
