### PR TITLE
fix: 종료미션의 경우 재촉하기 불가능하도록 검증 추가

### DIFF
--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -134,4 +134,12 @@ public class Mission extends BaseTimeEntity {
                 .findFirst()
                 .isPresent();
     }
+
+    public boolean isFinished() {
+        if (this.getDurationStatus() == DurationStatus.FINISHED || this.archiveStatus == ArchiveStatus.ARCHIVED
+                || this.getFinishedAt().isBefore(LocalDateTime.now())) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -136,7 +136,8 @@ public class Mission extends BaseTimeEntity {
     }
 
     public boolean isFinished() {
-        if (this.getDurationStatus() == DurationStatus.FINISHED || this.archiveStatus == ArchiveStatus.ARCHIVED
+        if (this.getDurationStatus() == DurationStatus.FINISHED
+                || this.archiveStatus == ArchiveStatus.ARCHIVED
                 || this.getFinishedAt().isBefore(LocalDateTime.now())) {
             return true;
         }

--- a/src/main/java/com/depromeet/domain/notification/application/PushService.java
+++ b/src/main/java/com/depromeet/domain/notification/application/PushService.java
@@ -35,6 +35,7 @@ public class PushService {
         final Member targetMember = mission.getMember();
 
         validateSelfSending(currentMember.getId(), targetMember.getId());
+        validateFinishedMission(mission);
         validateMissionNotCompletedToday(mission);
 
         fcmService.sendMessageSync(
@@ -48,6 +49,12 @@ public class PushService {
                 Notification.createNotification(
                         NotificationType.MISSION_URGING, currentMember, targetMember);
         notificationRepository.save(notification);
+    }
+
+    private void validateFinishedMission(Mission mission) {
+        if (mission.isFinished()) {
+            throw new CustomException(ErrorCode.FINISHED_MISSION_URGING_NOT_ALLOWED);
+        }
     }
 
     private void validateMissionNotCompletedToday(Mission mission) {

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
     SELF_SENDING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "본인에게 메세지를 전송할 수 없습니다."),
     TODAY_COMPLETED_MISSION_SENDING_NOT_ALLOWED(
             HttpStatus.BAD_REQUEST, "오늘 미션을 완료한 미션에는 메세지를 전송할 수 없습니다."),
+    FINISHED_MISSION_URGING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "종료된 미션에는 재촉하기를 할 수 없습니다."),
 
     // Reaction
     REACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리액션을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #325 

## 📌 작업 내용 및 특이사항
- #322 해당 이슈에서 친구 목록에서 종료미션은 보이지 않도록 처리되어있어 문제되진 않지만,
- 종료미션일 경우 재촉하기가 불가능하도록 검증 추가 예정
