### PR TITLE
feat: 리액션 추가 시 푸시 메세지 발송

### DIFF
--- a/src/main/java/com/depromeet/domain/notification/domain/NotificationType.java
+++ b/src/main/java/com/depromeet/domain/notification/domain/NotificationType.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum NotificationType {
     FOLLOW("팔로우"),
     MISSION_URGING("재촉하기"),
+    REACTION("리액션"),
     ;
 
     private final String value;

--- a/src/main/java/com/depromeet/domain/reaction/application/ReactionService.java
+++ b/src/main/java/com/depromeet/domain/reaction/application/ReactionService.java
@@ -1,10 +1,15 @@
 package com.depromeet.domain.reaction.application;
 
+import static com.depromeet.global.common.constants.PushNotificationConstants.*;
 import static java.util.Comparator.*;
 
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.domain.notification.application.FcmService;
+import com.depromeet.domain.notification.dao.NotificationRepository;
+import com.depromeet.domain.notification.domain.Notification;
+import com.depromeet.domain.notification.domain.NotificationType;
 import com.depromeet.domain.reaction.dao.ReactionRepository;
 import com.depromeet.domain.reaction.domain.EmojiType;
 import com.depromeet.domain.reaction.domain.Reaction;
@@ -30,6 +35,8 @@ public class ReactionService {
     private final MemberUtil memberUtil;
     private final MissionRecordRepository missionRecordRepository;
     private final ReactionRepository reactionRepository;
+    private final FcmService fcmService;
+    private final NotificationRepository notificationRepository;
 
     public List<ReactionGroupByEmojiResponse> findAllReaction(Long missionRecordId) {
         Map<EmojiType, List<Reaction>> reactionMap =
@@ -52,6 +59,17 @@ public class ReactionService {
         validateMyReactionAlreadyExists(member, missionRecord);
 
         Reaction reaction = Reaction.createReaction(request.emojiType(), member, missionRecord);
+        Member targetMember = missionRecord.getMission().getMember();
+        fcmService.sendMessageSync(
+                targetMember.getFcmInfo().getFcmToken(),
+                PUSH_REACTION_TITLE,
+                String.format(
+                        PUSH_REACTION_CONTENT,
+                        member.getProfile().getNickname(),
+                        missionRecord.getMission().getName()));
+        Notification notification =
+                Notification.createNotification(NotificationType.REACTION, member, targetMember);
+        notificationRepository.save(notification);
         return ReactionCreateResponse.from(reactionRepository.save(reaction));
     }
 

--- a/src/main/java/com/depromeet/domain/reaction/application/ReactionService.java
+++ b/src/main/java/com/depromeet/domain/reaction/application/ReactionService.java
@@ -7,9 +7,6 @@ import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.domain.notification.application.FcmService;
-import com.depromeet.domain.notification.dao.NotificationRepository;
-import com.depromeet.domain.notification.domain.Notification;
-import com.depromeet.domain.notification.domain.NotificationType;
 import com.depromeet.domain.reaction.dao.ReactionRepository;
 import com.depromeet.domain.reaction.domain.EmojiType;
 import com.depromeet.domain.reaction.domain.Reaction;
@@ -36,7 +33,6 @@ public class ReactionService {
     private final MissionRecordRepository missionRecordRepository;
     private final ReactionRepository reactionRepository;
     private final FcmService fcmService;
-    private final NotificationRepository notificationRepository;
 
     public List<ReactionGroupByEmojiResponse> findAllReaction(Long missionRecordId) {
         Map<EmojiType, List<Reaction>> reactionMap =
@@ -67,9 +63,6 @@ public class ReactionService {
                         PUSH_REACTION_CONTENT,
                         member.getProfile().getNickname(),
                         missionRecord.getMission().getName()));
-        Notification notification =
-                Notification.createNotification(NotificationType.REACTION, member, targetMember);
-        notificationRepository.save(notification);
         return ReactionCreateResponse.from(reactionRepository.save(reaction));
     }
 

--- a/src/main/java/com/depromeet/global/common/constants/PushNotificationConstants.java
+++ b/src/main/java/com/depromeet/global/common/constants/PushNotificationConstants.java
@@ -11,4 +11,6 @@ public class PushNotificationConstants {
             "아직 오늘 미션을 완료하지 않았어요! 10분 동안 빠르게 완료해볼까요?";
     public static final String PUSH_URGING_TITLE = "누가 내 미션을 기다린대요";
     public static final String PUSH_URGING_CONTENT = "%s님이 %s 미션을 기다리고 있어요 🥺";
+    public static final String PUSH_REACTION_TITLE = "누가 나를 응원했어요!";
+    public static final String PUSH_REACTION_CONTENT = "%s님이 %s 미션을 이모지로 응원했어요!";
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #329 

## 📌 작업 내용 및 특이사항
- 리액션을 추가할 때 해당 미션을 올린 사용자에게 푸시메세지를 발송합니다
- notifiaction 작업 시 이상하게 리액션 조회 Test만 깨지더라구요,,
- notification 쪽은 @woobottle 과 추 후 data에 id값 보내주는 작업해야하는데 그 때 같이 작업하도록 하겠습니다
