### PR TITLE
feat: 미션 기록 조회 시 COMPLETE 일때 missionRecordId 추가

### DIFF
--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -80,7 +80,11 @@ public class MissionService {
             // 당일 수행한 미션기록의 인증사진이 존재하면 COMPLETE
             if (optionalRecord.get().getUploadStatus() == ImageUploadStatus.COMPLETE) {
                 results.add(
-                        MissionFindAllResponse.of(mission, MissionStatus.COMPLETED, null, optionalRecord.get().getId()));
+                        MissionFindAllResponse.of(
+                                mission,
+                                MissionStatus.COMPLETED,
+                                null,
+                                optionalRecord.get().getId()));
                 continue;
             }
 

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -80,7 +80,7 @@ public class MissionService {
             // 당일 수행한 미션기록의 인증사진이 존재하면 COMPLETE
             if (optionalRecord.get().getUploadStatus() == ImageUploadStatus.COMPLETE) {
                 results.add(
-                        MissionFindAllResponse.of(mission, MissionStatus.COMPLETED, null, null));
+                        MissionFindAllResponse.of(mission, MissionStatus.COMPLETED, null, optionalRecord.get().getId()));
                 continue;
             }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #343

## 📌 작업 내용 및 특이사항
- 현재 REQUIRED일때만 missionRecordId를 넘겨주는데, 미션 목록에서 리액션을 같이 조회해야하고, 리액션은 missionRecordId를 통해서 조회하기 때문에 해당 필드에 값이 추가되어야 합니다
