### PR TITLE
fix: sinceDay 계산 로직 변경

### DIFF
--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneByProfileResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneByProfileResponse.java
@@ -3,8 +3,8 @@ package com.depromeet.domain.feed.dto.response;
 import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 public record FeedOneByProfileResponse(
         @Schema(description = "미션 ID", defaultValue = "1") Long missionId,
@@ -42,7 +42,9 @@ public record FeedOneByProfileResponse(
                 record.getMission().getName(),
                 record.getImageUrl(),
                 record.getDuration().toMinutes(),
-                Duration.between(record.getMission().getStartedAt(), record.getStartedAt()).toDays()
+                ChronoUnit.DAYS.between(
+                                record.getMission().getStartedAt().toLocalDate(),
+                                record.getStartedAt().toLocalDate())
                         + 1,
                 record.getStartedAt(),
                 record.getFinishedAt());

--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneResponse.java
@@ -5,6 +5,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 public record FeedOneResponse(
         @Schema(description = "작성자 ID", defaultValue = "1") Long memberId,
@@ -72,7 +73,7 @@ public record FeedOneResponse(
                 remark,
                 recordImageUrl,
                 duration.toMinutes(),
-                Duration.between(startedAt, recordStartedAt).toDays() + 1,
+                ChronoUnit.DAYS.between(startedAt, recordStartedAt) + 1,
                 startedAt,
                 finishedAt,
                 recordStartedAt);

--- a/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/application/MissionRecordService.java
@@ -83,13 +83,7 @@ public class MissionRecordService {
                 missionRecordRepository
                         .findById(recordId)
                         .orElseThrow(() -> new CustomException(ErrorCode.MISSION_RECORD_NOT_FOUND));
-        long sinceDay =
-                Duration.between(
-                                        missionRecord.getMission().getStartedAt(),
-                                        missionRecord.getStartedAt())
-                                .toDays()
-                        + DAYS_ADJUSTMENT;
-        return MissionRecordFindOneResponse.of(missionRecord, sinceDay);
+        return MissionRecordFindOneResponse.from(missionRecord);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindOneResponse.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/dto/response/MissionRecordFindOneResponse.java
@@ -4,6 +4,7 @@ import com.depromeet.domain.missionRecord.domain.MissionRecord;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 public record MissionRecordFindOneResponse(
         @Schema(description = "미션 기록 ID", defaultValue = "1") Long recordId,
@@ -33,13 +34,16 @@ public record MissionRecordFindOneResponse(
                         defaultValue = "2024-01-03 00:34:00",
                         type = "string")
                 LocalDateTime finishedAt) {
-    public static MissionRecordFindOneResponse of(MissionRecord missionRecord, long sinceDay) {
+    public static MissionRecordFindOneResponse from(MissionRecord missionRecord) {
         return new MissionRecordFindOneResponse(
                 missionRecord.getId(),
                 missionRecord.getRemark(),
                 missionRecord.getImageUrl(),
                 missionRecord.getDuration().toMinutes(),
-                sinceDay,
+                ChronoUnit.DAYS.between(
+                                missionRecord.getMission().getStartedAt().toLocalDate(),
+                                missionRecord.getStartedAt().toLocalDate())
+                        + 1,
                 missionRecord.getStartedAt(),
                 missionRecord.getFinishedAt());
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #348

## 📌 작업 내용 및 특이사항
- 미션 기록에서 미션 시작일 기점으로 N일에 해당하는 날짜에 미션을 완료하였을시 정상적으로 N일이 표시되어야 하지만, 표시되고 있지 않습니다.
- `2024.02.18`에 '등교'라는 미션이 생성되었고, `2024.02.18`에 완료한 기록은 1일차, `2024.02.19`에 완료한 기록은 2일차로 표기되어야 하지만 모두 1일차로 나오고 있습니다.

|1일차에 해당하여 정상|2일차로 표기되어야 하지만 1일차로 표기|피드 뷰에서도 동일한 이슈 존재|
|--|--|--|
|![image](https://github.com/depromeet/10mm-server/assets/64088250/bf5819a9-fdc9-4f7f-a0e6-d0e5f46c209e)|![image](https://github.com/depromeet/10mm-server/assets/64088250/9dcbd3cb-6a86-4beb-a21c-baaf0fa1969d)|![image](https://github.com/depromeet/10mm-server/assets/64088250/b576c637-9699-4e98-aeb8-6754c82a000c)|

- sinceDay의 기존 계산 로직은 LocalDateTime으로 24시간 이상 차이나게 되면, 예상 값보다 +1 되는 문제가 존재합니다.
- 시간과 관계 없이 해당 날짜로만 계산하기 위해 `ChronoUnit.DAYS.between`을 통해 계산하였습니다.
- `sinceDay`를 구하는 곳 모두 변경하였습니다 (피드 탭, 전체 탭, 미션 기록 상세조회)