### PR TITLE
fix: 미션 기록 삭제가 안되는 문제

### DIFF
--- a/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
@@ -2,20 +2,14 @@ package com.depromeet.domain.missionRecord.domain;
 
 import com.depromeet.domain.common.model.BaseTimeEntity;
 import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.domain.reaction.domain.Reaction;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,6 +44,9 @@ public class MissionRecord extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_id")
     private Mission mission;
+
+    @OneToMany(mappedBy = "missionRecord", cascade = CascadeType.REMOVE)
+    private List<Reaction> reactions = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private MissionRecord(


### PR DESCRIPTION
## 🌱 관련 이슈
- close #356

## 📌 작업 내용 및 특이사항
- 미션기록에 리액션 컬렉션 추가했습니다.
- cascade remove 걸어서 미션기록 제거 시 자동으로 연관된 리액션 제거되도록 했습니다.
- 관련하여 테스트 코드 작성해두었습니다.
- 피드와 통합하는 이슈는 생각보다 문제가 많아서 별도 이슈로 작업하겠습니다

## 📝 참고사항
- 

## 📚 기타
- 
