### PR TITLE
feat: 미션 리마인드 알림 시간 설정 및 시간에 따른 푸시 알림 전송

### DIFF
--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -255,7 +255,8 @@ public class MissionService {
         mission.updateMission(
                 missionUpdateRequest.name(),
                 missionUpdateRequest.content(),
-                missionUpdateRequest.visibility());
+                missionUpdateRequest.visibility(),
+				missionUpdateRequest.remindedTime());
         return MissionUpdateResponse.from(mission);
     }
 

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -243,8 +243,10 @@ public class MissionService {
     }
 
     @Transactional(readOnly = true)
-    public List<Mission> findAllInProgressMission() {
-        return missionRepository.findAllByDurationStatus(DurationStatus.IN_PROGRESS);
+    public List<MissionRemindPushResponse> findAllInProgressMission() {
+        List<Mission> missions =
+                missionRepository.findAllByDurationStatus(DurationStatus.IN_PROGRESS);
+        return missions.stream().map(MissionRemindPushResponse::from).toList();
     }
 
     public MissionUpdateResponse updateMission(

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -256,7 +256,7 @@ public class MissionService {
                 missionUpdateRequest.name(),
                 missionUpdateRequest.content(),
                 missionUpdateRequest.visibility(),
-				missionUpdateRequest.remindedTime());
+                missionUpdateRequest.remindedTime());
         return MissionUpdateResponse.from(mission);
     }
 

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -256,7 +256,7 @@ public class MissionService {
                 missionUpdateRequest.name(),
                 missionUpdateRequest.content(),
                 missionUpdateRequest.visibility(),
-                missionUpdateRequest.remindedTime());
+                missionUpdateRequest.remindAt());
         return MissionUpdateResponse.from(mission);
     }
 
@@ -282,7 +282,7 @@ public class MissionService {
                 missionCreateRequest.visibility(),
                 startedAt,
                 startedAt.plusWeeks(2),
-                missionCreateRequest.remindedTime(),
+                missionCreateRequest.remindAt(),
                 member);
     }
 

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -3,6 +3,7 @@ package com.depromeet.domain.mission.application;
 import com.depromeet.domain.follow.dao.MemberRelationRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.dao.MissionRepository;
+import com.depromeet.domain.mission.domain.DurationStatus;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.dto.request.MissionCreateRequest;
 import com.depromeet.domain.mission.dto.request.MissionUpdateRequest;
@@ -242,8 +243,8 @@ public class MissionService {
     }
 
     @Transactional(readOnly = true)
-    public List<Mission> findInProgressMission() {
-        return missionRepository.findAllInProgressMission();
+    public List<Mission> findAllInProgressMission() {
+        return missionRepository.findAllByDurationStatus(DurationStatus.IN_PROGRESS);
     }
 
     public MissionUpdateResponse updateMission(

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -276,6 +276,7 @@ public class MissionService {
                 missionCreateRequest.visibility(),
                 startedAt,
                 startedAt.plusWeeks(2),
+				missionCreateRequest.remindedAt(),
                 member);
     }
 

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -241,6 +241,11 @@ public class MissionService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public List<Mission> findInProgressMission() {
+        return missionRepository.findAllInProgressMission();
+    }
+
     public MissionUpdateResponse updateMission(
             MissionUpdateRequest missionUpdateRequest, Long missionId) {
         Mission mission =
@@ -276,7 +281,7 @@ public class MissionService {
                 missionCreateRequest.visibility(),
                 startedAt,
                 startedAt.plusWeeks(2),
-				missionCreateRequest.remindedAt(),
+                missionCreateRequest.remindedTime(),
                 member);
     }
 

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepository.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepository.java
@@ -1,13 +1,19 @@
 package com.depromeet.domain.mission.dao;
 
+import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphType.*;
+
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.domain.DurationStatus;
 import com.depromeet.domain.mission.domain.Mission;
 import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionRepository extends JpaRepository<Mission, Long>, MissionRepositoryCustom {
     Mission findTopByMemberOrderBySortDesc(Member member);
 
+    @EntityGraph(
+            attributePaths = {"member"},
+            type = FETCH)
     List<Mission> findAllByDurationStatus(DurationStatus status);
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepository.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepository.java
@@ -1,9 +1,13 @@
 package com.depromeet.domain.mission.dao;
 
 import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.mission.domain.DurationStatus;
 import com.depromeet.domain.mission.domain.Mission;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionRepository extends JpaRepository<Mission, Long>, MissionRepositoryCustom {
     Mission findTopByMemberOrderBySortDesc(Member member);
+
+    List<Mission> findAllByDurationStatus(DurationStatus status);
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
@@ -18,4 +18,6 @@ public interface MissionRepositoryCustom {
     List<Mission> findAllFinishedMission(Long memberId);
 
     List<Mission> findMissionsWithRecordsByDate(LocalDate date, Long memberId);
+
+    List<Mission> findAllInProgressMission();
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
@@ -18,6 +18,4 @@ public interface MissionRepositoryCustom {
     List<Mission> findAllFinishedMission(Long memberId);
 
     List<Mission> findMissionsWithRecordsByDate(LocalDate date, Long memberId);
-
-    List<Mission> findAllInProgressMission();
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -104,6 +104,13 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
         return query.fetch();
     }
 
+    @Override
+    public List<Mission> findAllInProgressMission() {
+        JPAQuery<Mission> query =
+                jpaQueryFactory.selectFrom(mission).where(durationStatusInProgress());
+        return query.fetch();
+    }
+
     // 미션의 사용자 id 조건 검증 메서드
     private BooleanExpression memberIdEq(Long memberId) {
         return memberId == null ? null : mission.member.id.eq(memberId);

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -104,13 +104,6 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
         return query.fetch();
     }
 
-    @Override
-    public List<Mission> findAllInProgressMission() {
-        JPAQuery<Mission> query =
-                jpaQueryFactory.selectFrom(mission).where(durationStatusInProgress());
-        return query.fetch();
-    }
-
     // 미션의 사용자 id 조건 검증 메서드
     private BooleanExpression memberIdEq(Long memberId) {
         return memberId == null ? null : mission.member.id.eq(memberId);

--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -124,11 +124,12 @@ public class Mission extends BaseTimeEntity {
                 .build();
     }
 
-    public void updateMission(String name, String content, MissionVisibility visibility, LocalTime remindedTime) {
+    public void updateMission(
+            String name, String content, MissionVisibility visibility, LocalTime remindedTime) {
         this.name = name;
         this.content = content;
         this.visibility = visibility;
-		this.remindedTime = remindedTime;
+        this.remindedTime = remindedTime;
     }
 
     public boolean isCompletedMissionToday() {

--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -124,10 +124,11 @@ public class Mission extends BaseTimeEntity {
                 .build();
     }
 
-    public void updateMission(String name, String content, MissionVisibility visibility) {
+    public void updateMission(String name, String content, MissionVisibility visibility, LocalTime remindedTime) {
         this.name = name;
         this.content = content;
         this.visibility = visibility;
+		this.remindedTime = remindedTime;
     }
 
     public boolean isCompletedMissionToday() {

--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -63,6 +63,8 @@ public class Mission extends BaseTimeEntity {
 
     private LocalDateTime finishedAt;
 
+	private LocalDateTime remindedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -81,6 +83,7 @@ public class Mission extends BaseTimeEntity {
             MissionVisibility visibility,
             LocalDateTime startedAt,
             LocalDateTime finishedAt,
+			LocalDateTime remindedAt,
             Member member) {
         this.name = name;
         this.content = content;
@@ -91,6 +94,7 @@ public class Mission extends BaseTimeEntity {
         this.visibility = visibility;
         this.startedAt = startedAt;
         this.finishedAt = finishedAt;
+		this.remindedAt = remindedAt;
         this.member = member;
     }
 
@@ -102,6 +106,7 @@ public class Mission extends BaseTimeEntity {
             MissionVisibility visibility,
             LocalDateTime startedAt,
             LocalDateTime finishedAt,
+			LocalDateTime remindedAt,
             Member member) {
         return Mission.builder()
                 .name(name)
@@ -113,6 +118,7 @@ public class Mission extends BaseTimeEntity {
                 .visibility(visibility)
                 .startedAt(startedAt)
                 .finishedAt(finishedAt)
+				.remindedAt(remindedAt)
                 .member(member)
                 .build();
     }

--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -17,6 +17,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -63,7 +64,7 @@ public class Mission extends BaseTimeEntity {
 
     private LocalDateTime finishedAt;
 
-	private LocalDateTime remindedAt;
+    private LocalTime remindedTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -83,7 +84,7 @@ public class Mission extends BaseTimeEntity {
             MissionVisibility visibility,
             LocalDateTime startedAt,
             LocalDateTime finishedAt,
-			LocalDateTime remindedAt,
+            LocalTime remindedTime,
             Member member) {
         this.name = name;
         this.content = content;
@@ -94,7 +95,7 @@ public class Mission extends BaseTimeEntity {
         this.visibility = visibility;
         this.startedAt = startedAt;
         this.finishedAt = finishedAt;
-		this.remindedAt = remindedAt;
+        this.remindedTime = remindedTime;
         this.member = member;
     }
 
@@ -106,7 +107,7 @@ public class Mission extends BaseTimeEntity {
             MissionVisibility visibility,
             LocalDateTime startedAt,
             LocalDateTime finishedAt,
-			LocalDateTime remindedAt,
+            LocalTime remindedTime,
             Member member) {
         return Mission.builder()
                 .name(name)
@@ -118,7 +119,7 @@ public class Mission extends BaseTimeEntity {
                 .visibility(visibility)
                 .startedAt(startedAt)
                 .finishedAt(finishedAt)
-				.remindedAt(remindedAt)
+                .remindedTime(remindedTime)
                 .member(member)
                 .build();
     }

--- a/src/main/java/com/depromeet/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/domain/mission/domain/Mission.java
@@ -64,7 +64,7 @@ public class Mission extends BaseTimeEntity {
 
     private LocalDateTime finishedAt;
 
-    private LocalTime remindedTime;
+    private LocalTime remindAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -84,7 +84,7 @@ public class Mission extends BaseTimeEntity {
             MissionVisibility visibility,
             LocalDateTime startedAt,
             LocalDateTime finishedAt,
-            LocalTime remindedTime,
+            LocalTime remindAt,
             Member member) {
         this.name = name;
         this.content = content;
@@ -95,7 +95,7 @@ public class Mission extends BaseTimeEntity {
         this.visibility = visibility;
         this.startedAt = startedAt;
         this.finishedAt = finishedAt;
-        this.remindedTime = remindedTime;
+        this.remindAt = remindAt;
         this.member = member;
     }
 
@@ -107,7 +107,7 @@ public class Mission extends BaseTimeEntity {
             MissionVisibility visibility,
             LocalDateTime startedAt,
             LocalDateTime finishedAt,
-            LocalTime remindedTime,
+            LocalTime remindAt,
             Member member) {
         return Mission.builder()
                 .name(name)
@@ -119,17 +119,17 @@ public class Mission extends BaseTimeEntity {
                 .visibility(visibility)
                 .startedAt(startedAt)
                 .finishedAt(finishedAt)
-                .remindedTime(remindedTime)
+                .remindAt(remindAt)
                 .member(member)
                 .build();
     }
 
     public void updateMission(
-            String name, String content, MissionVisibility visibility, LocalTime remindedTime) {
+            String name, String content, MissionVisibility visibility, LocalTime remindAt) {
         this.name = name;
         this.content = content;
         this.visibility = visibility;
-        this.remindedTime = remindedTime;
+        this.remindAt = remindAt;
     }
 
     public boolean isCompletedMissionToday() {

--- a/src/main/java/com/depromeet/domain/mission/dto/request/MissionCreateRequest.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/request/MissionCreateRequest.java
@@ -20,4 +20,4 @@ public record MissionCreateRequest(
         @NotNull @Schema(description = "미션 공개여부", defaultValue = "ALL")
                 MissionVisibility visibility,
         @Schema(description = "미션 리마인드 알림 시간", defaultValue = "00:50:00", type = "string")
-                LocalTime remindedTime) {}
+                LocalTime remindAt) {}

--- a/src/main/java/com/depromeet/domain/mission/dto/request/MissionCreateRequest.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/request/MissionCreateRequest.java
@@ -1,13 +1,12 @@
 package com.depromeet.domain.mission.dto.request;
 
-import java.time.LocalDateTime;
-
 import com.depromeet.domain.mission.domain.MissionCategory;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalTime;
 
 public record MissionCreateRequest(
         @NotBlank(message = "이름은 비워둘 수 없습니다.")
@@ -20,9 +19,5 @@ public record MissionCreateRequest(
         @NotNull @Schema(description = "미션 카테고리", defaultValue = "STUDY") MissionCategory category,
         @NotNull @Schema(description = "미션 공개여부", defaultValue = "ALL")
                 MissionVisibility visibility,
-		@Schema(
-			description = "미션 리마인드 알림 시간",
-			defaultValue = "2024-01-01 00:34:00",
-			type = "string")
-		LocalDateTime remindedAt
-		) {}
+        @Schema(description = "미션 리마인드 알림 시간", defaultValue = "00:50:00", type = "string")
+                LocalTime remindedTime) {}

--- a/src/main/java/com/depromeet/domain/mission/dto/request/MissionCreateRequest.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/request/MissionCreateRequest.java
@@ -1,5 +1,7 @@
 package com.depromeet.domain.mission.dto.request;
 
+import java.time.LocalDateTime;
+
 import com.depromeet.domain.mission.domain.MissionCategory;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,4 +19,10 @@ public record MissionCreateRequest(
                 String content,
         @NotNull @Schema(description = "미션 카테고리", defaultValue = "STUDY") MissionCategory category,
         @NotNull @Schema(description = "미션 공개여부", defaultValue = "ALL")
-                MissionVisibility visibility) {}
+                MissionVisibility visibility,
+		@Schema(
+			description = "미션 리마인드 알림 시간",
+			defaultValue = "2024-01-01 00:34:00",
+			type = "string")
+		LocalDateTime remindedAt
+		) {}

--- a/src/main/java/com/depromeet/domain/mission/dto/request/MissionUpdateRequest.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/request/MissionUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.depromeet.domain.mission.dto.request;
 
+import java.time.LocalDateTime;
+
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -16,4 +18,9 @@ public record MissionUpdateRequest(
                 String content,
         @NotNull(message = "미션 공개 여부가 null일 수 없습니다.")
                 @Schema(description = "미션 공개여부", defaultValue = "ALL")
-                MissionVisibility visibility) {}
+                MissionVisibility visibility,
+		@Schema(
+			description = "미션 리마인드 알림 시간",
+			defaultValue = "2024-01-01 00:34:00",
+			type = "string")
+		LocalDateTime remindedAt) {}

--- a/src/main/java/com/depromeet/domain/mission/dto/request/MissionUpdateRequest.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/request/MissionUpdateRequest.java
@@ -19,4 +19,4 @@ public record MissionUpdateRequest(
                 @Schema(description = "미션 공개여부", defaultValue = "ALL")
                 MissionVisibility visibility,
         @Schema(description = "미션 리마인드 알림 시간", defaultValue = "00:50:00", type = "string")
-                LocalTime remindedTime) {}
+                LocalTime remindAt) {}

--- a/src/main/java/com/depromeet/domain/mission/dto/request/MissionUpdateRequest.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/request/MissionUpdateRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public record MissionUpdateRequest(
         @NotBlank(message = "이름은 비워둘 수 없습니다.")
@@ -18,8 +19,5 @@ public record MissionUpdateRequest(
         @NotNull(message = "미션 공개 여부가 null일 수 없습니다.")
                 @Schema(description = "미션 공개여부", defaultValue = "ALL")
                 MissionVisibility visibility,
-        @Schema(
-                        description = "미션 리마인드 알림 시간",
-                        defaultValue = "2024-01-01 00:34:00",
-                        type = "string")
-                LocalDateTime remindedAt) {}
+		@Schema(description = "미션 리마인드 알림 시간", defaultValue = "00:50:00", type = "string")
+		LocalTime remindedTime) {}

--- a/src/main/java/com/depromeet/domain/mission/dto/request/MissionUpdateRequest.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/request/MissionUpdateRequest.java
@@ -1,12 +1,11 @@
 package com.depromeet.domain.mission.dto.request;
 
-import java.time.LocalDateTime;
-
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 
 public record MissionUpdateRequest(
         @NotBlank(message = "이름은 비워둘 수 없습니다.")
@@ -19,8 +18,8 @@ public record MissionUpdateRequest(
         @NotNull(message = "미션 공개 여부가 null일 수 없습니다.")
                 @Schema(description = "미션 공개여부", defaultValue = "ALL")
                 MissionVisibility visibility,
-		@Schema(
-			description = "미션 리마인드 알림 시간",
-			defaultValue = "2024-01-01 00:34:00",
-			type = "string")
-		LocalDateTime remindedAt) {}
+        @Schema(
+                        description = "미션 리마인드 알림 시간",
+                        defaultValue = "2024-01-01 00:34:00",
+                        type = "string")
+                LocalDateTime remindedAt) {}

--- a/src/main/java/com/depromeet/domain/mission/dto/request/MissionUpdateRequest.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/request/MissionUpdateRequest.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record MissionUpdateRequest(
@@ -19,5 +18,5 @@ public record MissionUpdateRequest(
         @NotNull(message = "미션 공개 여부가 null일 수 없습니다.")
                 @Schema(description = "미션 공개여부", defaultValue = "ALL")
                 MissionVisibility visibility,
-		@Schema(description = "미션 리마인드 알림 시간", defaultValue = "00:50:00", type = "string")
-		LocalTime remindedTime) {}
+        @Schema(description = "미션 리마인드 알림 시간", defaultValue = "00:50:00", type = "string")
+                LocalTime remindedTime) {}

--- a/src/main/java/com/depromeet/domain/mission/dto/response/MissionRemindPushResponse.java
+++ b/src/main/java/com/depromeet/domain/mission/dto/response/MissionRemindPushResponse.java
@@ -6,22 +6,27 @@ import com.depromeet.domain.mission.domain.MissionVisibility;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalTime;
 
-public record MissionCreateResponse(
+public record MissionRemindPushResponse(
         @Schema(description = "미션 ID", defaultValue = "1") Long missionId,
         @Schema(description = "미션 이름", defaultValue = "default name") String name,
         @Schema(description = "미션 내용", defaultValue = "default content") String content,
         @Schema(description = "미션 카테고리", defaultValue = "STUDY") MissionCategory category,
         @Schema(description = "미션 공개여부", defaultValue = "ALL") MissionVisibility visibility,
         @Schema(description = "미션 리마인드 알림 시간", defaultValue = "00:50:00", type = "string")
-                LocalTime remindAt) {
+                LocalTime remindAt,
+        @Schema(description = "사용자 ID", defaultValue = "1") Long memberId,
+        @Schema(description = "FCM 토큰", defaultValue = "fcm-token", type = "string")
+                String fcmToken) {
 
-    public static MissionCreateResponse from(Mission mission) {
-        return new MissionCreateResponse(
+    public static MissionRemindPushResponse from(Mission mission) {
+        return new MissionRemindPushResponse(
                 mission.getId(),
                 mission.getName(),
                 mission.getContent(),
                 mission.getCategory(),
                 mission.getVisibility(),
-                mission.getRemindAt());
+                mission.getRemindAt(),
+                mission.getMember().getId(),
+                mission.getMember().getFcmInfo().getFcmToken());
     }
 }

--- a/src/main/java/com/depromeet/global/common/constants/PushNotificationConstants.java
+++ b/src/main/java/com/depromeet/global/common/constants/PushNotificationConstants.java
@@ -15,6 +15,6 @@ public class PushNotificationConstants {
     public static final String PUSH_REACTION_CONTENT = "%s님이 %s 미션을 이모지로 응원했어요!";
     public static final String PUSH_MISSION_REMIND_TITLE = "10분이 지났어요!";
     public static final String PUSH_MISSION_REMIND_CONTENT = "지금부터 미션 인증을 할 수 있어요 🕑";
-    public static final String PUSH_MISSION_START_REMIND_TITLE = "미션 시작 리마인드";
-    public static final String PUSH_MISSION_START_REMIND_CONTENT = "미션을 시작할 시간이에요!";
+    public static final String PUSH_MISSION_START_REMIND_TITLE = "미션을 시작할 시간이에요!";
+    public static final String PUSH_MISSION_START_REMIND_CONTENT = "10분을 투자하여 %s 미션을 완료해 보세요 🥳";
 }

--- a/src/main/java/com/depromeet/global/common/constants/PushNotificationConstants.java
+++ b/src/main/java/com/depromeet/global/common/constants/PushNotificationConstants.java
@@ -15,4 +15,6 @@ public class PushNotificationConstants {
     public static final String PUSH_REACTION_CONTENT = "%s님이 %s 미션을 이모지로 응원했어요!";
     public static final String PUSH_MISSION_REMIND_TITLE = "10분이 지났어요!";
     public static final String PUSH_MISSION_REMIND_CONTENT = "지금부터 미션 인증을 할 수 있어요 🕑";
+    public static final String PUSH_MISSION_START_REMIND_TITLE = "미션 시작 리마인드";
+    public static final String PUSH_MISSION_START_REMIND_CONTENT = "미션을 시작할 시간이에요!";
 }

--- a/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
+++ b/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
@@ -1,6 +1,12 @@
 package com.depromeet.scheduler.mission;
 
 import com.depromeet.domain.mission.application.MissionService;
+import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.domain.notification.application.FcmService;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,11 +17,32 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class MissionBatchScheduler {
     private final MissionService missionService;
+    private final FcmService fcmService;
 
     // 자정에 schedule 실행
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void updateFinishedDurationStatus() {
         log.info("DurationStatus Update batch execute");
         missionService.updateFinishedDurationStatus();
+    }
+
+    // 매 10분마다 schedule 실행
+    @Scheduled(cron = "0 0/10 * * * *", zone = "Asia/Seoul")
+    public void missionRemindPushNotification() {
+        log.info("Mission Remind Push Notification batch execute");
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalTime currentTime = LocalTime.of(now.getHour(), now.getMinute());
+
+        List<String> fcmTokenList = findFcmTokensForRemindPush(currentTime);
+        fcmService.sendGroupMessageAsync(fcmTokenList, "미션 리마인드", "미션이 다가오고 있어요");
+    }
+
+    private List<String> findFcmTokensForRemindPush(LocalTime currentTime) {
+        List<Mission> inProgressMissions = missionService.findInProgressMission();
+        return inProgressMissions.stream()
+                .filter(mission -> currentTime.equals(mission.getRemindedTime()))
+                .map(mission -> mission.getMember().getFcmInfo().getFcmToken())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
+++ b/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
@@ -42,7 +42,7 @@ public class MissionBatchScheduler {
     private void findFcmTokensForRemindPush(
             LocalTime currentTime, List<Mission> inProgressMissions) {
         inProgressMissions.stream()
-                .filter(mission -> currentTime.equals(mission.getRemindedTime()))
+                .filter(mission -> currentTime.equals(mission.getRemindAt()))
                 .forEach(
                         mission -> {
                             String fcmToken = mission.getMember().getFcmInfo().getFcmToken();

--- a/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
+++ b/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
@@ -1,5 +1,7 @@
 package com.depromeet.scheduler.mission;
 
+import static com.depromeet.global.common.constants.PushNotificationConstants.*;
+
 import com.depromeet.domain.mission.application.MissionService;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.notification.application.FcmService;
@@ -35,7 +37,8 @@ public class MissionBatchScheduler {
         LocalTime currentTime = LocalTime.of(now.getHour(), now.getMinute());
 
         List<String> fcmTokenList = findFcmTokensForRemindPush(currentTime);
-        fcmService.sendGroupMessageAsync(fcmTokenList, "미션 리마인드", "미션이 다가오고 있어요");
+        fcmService.sendGroupMessageAsync(
+                fcmTokenList, PUSH_MISSION_START_REMIND_TITLE, PUSH_MISSION_START_REMIND_CONTENT);
     }
 
     private List<String> findFcmTokensForRemindPush(LocalTime currentTime) {

--- a/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
+++ b/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
@@ -32,16 +32,12 @@ public class MissionBatchScheduler {
     public void missionRemindPushNotification() {
         log.info("Mission Remind Push Notification batch execute");
 
-        LocalTime now =
-                LocalTime.parse(LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm")));
-
-        List<MissionRemindPushResponse> inProgressMissions =
-                missionService.findAllInProgressMission();
-        sendFcmTokensForRemindPush(now, inProgressMissions);
+        sendFcmTokensForRemindPush(missionService.findAllInProgressMission());
     }
 
-    private void sendFcmTokensForRemindPush(
-            LocalTime currentTime, List<MissionRemindPushResponse> inProgressMissions) {
+    private void sendFcmTokensForRemindPush(List<MissionRemindPushResponse> inProgressMissions) {
+        LocalTime currentTime =
+                LocalTime.parse(LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm")));
         inProgressMissions.stream()
                 .filter(mission -> currentTime.equals(mission.remindAt()))
                 .forEach(

--- a/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
+++ b/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
@@ -5,7 +5,6 @@ import static com.depromeet.global.common.constants.PushNotificationConstants.*;
 import com.depromeet.domain.mission.application.MissionService;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.notification.application.FcmService;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -32,14 +31,13 @@ public class MissionBatchScheduler {
     public void missionRemindPushNotification() {
         log.info("Mission Remind Push Notification batch execute");
 
-        LocalDateTime now = LocalDateTime.now();
-        LocalTime currentTime = LocalTime.of(now.getHour(), now.getMinute());
+        LocalTime now = LocalTime.now();
 
-        List<Mission> inProgressMissions = missionService.findInProgressMission();
-        findFcmTokensForRemindPush(currentTime, inProgressMissions);
+        List<Mission> inProgressMissions = missionService.findAllInProgressMission();
+        sendFcmTokensForRemindPush(now, inProgressMissions);
     }
 
-    private void findFcmTokensForRemindPush(
+    private void sendFcmTokensForRemindPush(
             LocalTime currentTime, List<Mission> inProgressMissions) {
         inProgressMissions.stream()
                 .filter(mission -> currentTime.equals(mission.getRemindAt()))

--- a/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
+++ b/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
@@ -35,7 +35,8 @@ public class MissionBatchScheduler {
         LocalTime now =
                 LocalTime.parse(LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm")));
 
-        List<MissionRemindPushResponse> inProgressMissions = missionService.findAllInProgressMission();
+        List<MissionRemindPushResponse> inProgressMissions =
+                missionService.findAllInProgressMission();
         sendFcmTokensForRemindPush(now, inProgressMissions);
     }
 

--- a/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/depromeet/domain/follow/application/FollowServiceTest.java
@@ -493,6 +493,7 @@ class FollowServiceTest {
                                     MissionVisibility.ALL,
                                     missionStartedAt,
                                     missionFinishedAt,
+                                    null,
                                     targetMember2));
 
             LocalDateTime missionRecordStartedAt = today;

--- a/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
+++ b/src/test/java/com/depromeet/domain/image/application/ImageServiceTest.java
@@ -25,6 +25,7 @@ import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.security.PrincipalDetails;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -95,7 +96,8 @@ class ImageServiceTest {
                             "testMissionName",
                             "testMissionContent",
                             MissionCategory.STUDY,
-                            MissionVisibility.ALL);
+                            MissionVisibility.ALL,
+                            LocalTime.of(21, 0));
             MissionCreateResponse missionCreateResponse =
                     missionService.createMission(missionCreateRequest);
 
@@ -133,7 +135,8 @@ class ImageServiceTest {
                             "testMissionName",
                             "testMissionContent",
                             MissionCategory.STUDY,
-                            MissionVisibility.ALL);
+                            MissionVisibility.ALL,
+                            LocalTime.of(21, 0));
             MissionCreateResponse missionCreateResponse =
                     missionService.createMission(missionCreateRequest);
 
@@ -210,7 +213,8 @@ class ImageServiceTest {
                             "testMissionName",
                             "testMissionContent",
                             MissionCategory.STUDY,
-                            MissionVisibility.ALL);
+                            MissionVisibility.ALL,
+                            LocalTime.of(21, 0));
             MissionCreateResponse missionCreateResponse =
                     missionService.createMission(missionCreateRequest);
 

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -68,7 +68,8 @@ class MissionControllerTest {
                                 "testMissionName",
                                 "testMissionContent",
                                 MissionCategory.STUDY,
-                                MissionVisibility.ALL));
+                                MissionVisibility.ALL,
+                                LocalTime.of(21, 0)));
         // when, then
         ResultActions perform =
                 mockMvc.perform(

--- a/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/domain/mission/controller/MissionControllerTest.java
@@ -28,6 +28,7 @@ import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -57,7 +58,8 @@ class MissionControllerTest {
                         "testMissionName",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
 
         given(missionService.createMission(any()))
                 .willReturn(
@@ -91,7 +93,11 @@ class MissionControllerTest {
         // given
         MissionCreateRequest createRequest =
                 new MissionCreateRequest(
-                        null, "testMissionContent", MissionCategory.STUDY, MissionVisibility.ALL);
+                        null,
+                        "testMissionContent",
+                        MissionCategory.STUDY,
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
 
         // when, then
         ResultActions perform =
@@ -160,6 +166,7 @@ class MissionControllerTest {
                         MissionVisibility.ALL,
                         missionStartedAt,
                         missionFinishedAt,
+                        LocalTime.of(21, 0),
                         member);
 
         List<MissionFindAllResponse> missionList =
@@ -189,7 +196,10 @@ class MissionControllerTest {
         // given
         MissionUpdateRequest updateRequest =
                 new MissionUpdateRequest(
-                        "testMissionName", "testMissionContent", MissionVisibility.NONE);
+                        "testMissionName",
+                        "testMissionContent",
+                        MissionVisibility.NONE,
+                        LocalTime.of(21, 0));
         given(missionService.updateMission(any(), any())).willReturn(new MissionUpdateResponse(1L));
 
         // when, then
@@ -211,7 +221,8 @@ class MissionControllerTest {
     void 미션이름을_null로_수정할_수_없다() throws Exception {
         // given
         MissionUpdateRequest updateRequest =
-                new MissionUpdateRequest(null, "testMissionContent", MissionVisibility.NONE);
+                new MissionUpdateRequest(
+                        null, "testMissionContent", MissionVisibility.NONE, LocalTime.of(21, 0));
         given(missionService.updateMission(any(), any())).willReturn(new MissionUpdateResponse(1L));
 
         // when, then

--- a/src/test/java/com/depromeet/domain/mission/domain/MissionTest.java
+++ b/src/test/java/com/depromeet/domain/mission/domain/MissionTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.member.domain.Profile;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +33,7 @@ class MissionTest {
                         MissionVisibility.ALL,
                         startedAt,
                         finishedAt,
+                        LocalTime.of(21, 0),
                         member);
 
         // when
@@ -55,6 +57,7 @@ class MissionTest {
                         MissionVisibility.ALL,
                         startedAt,
                         finishedAt,
+                        LocalTime.of(21, 0),
                         member);
 
         // when
@@ -78,6 +81,7 @@ class MissionTest {
                         MissionVisibility.ALL,
                         startedAt,
                         finishedAt,
+                        LocalTime.of(21, 0),
                         member);
 
         // when

--- a/src/test/java/com/depromeet/domain/mission/repository/MissionRepositoryTest.java
+++ b/src/test/java/com/depromeet/domain/mission/repository/MissionRepositoryTest.java
@@ -13,6 +13,7 @@ import com.depromeet.domain.mission.domain.MissionCategory;
 import com.depromeet.domain.mission.domain.MissionVisibility;
 import com.depromeet.domain.mission.dto.request.MissionCreateRequest;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -52,7 +53,8 @@ class MissionRepositoryTest {
                         "testMissionName",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
 
         // when
         Mission saveMission =
@@ -65,6 +67,7 @@ class MissionRepositoryTest {
                                 missionCreateRequest.visibility(),
                                 startedAt,
                                 startedAt.plusWeeks(2),
+                                LocalTime.of(21, 0),
                                 saveMember));
 
         // then
@@ -85,7 +88,8 @@ class MissionRepositoryTest {
                         "testMissionNameMoreThan",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
 
         // when
         Mission mission =
@@ -97,6 +101,7 @@ class MissionRepositoryTest {
                         missionCreateRequest.visibility(),
                         startedAt,
                         startedAt.plusWeeks(2),
+                        LocalTime.of(21, 0),
                         saveMember);
 
         // then
@@ -113,7 +118,8 @@ class MissionRepositoryTest {
                         "testMissionName",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
         LocalDateTime startedAt = LocalDateTime.now();
         Mission saveMission =
                 missionRepository.save(
@@ -125,6 +131,7 @@ class MissionRepositoryTest {
                                 missionCreateRequest.visibility(),
                                 startedAt,
                                 startedAt.plusWeeks(2),
+                                LocalTime.of(21, 0),
                                 saveMember));
         // when
         Optional<Mission> findMission = missionRepository.findById(saveMission.getId());
@@ -152,7 +159,8 @@ class MissionRepositoryTest {
                                         "testMissionName_" + i,
                                         "testMissionContent_" + i,
                                         MissionCategory.STUDY,
-                                        MissionVisibility.ALL))
+                                        MissionVisibility.ALL,
+                                        LocalTime.of(21, 0)))
                 .forEach(
                         request ->
                                 missionRepository.save(
@@ -164,6 +172,7 @@ class MissionRepositoryTest {
                                                 request.visibility(),
                                                 startedAt,
                                                 startedAt.plusWeeks(2),
+                                                LocalTime.of(21, 0),
                                                 saveMember)));
 
         // when

--- a/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
@@ -22,6 +22,7 @@ import com.depromeet.global.security.PrincipalDetails;
 import com.depromeet.global.util.MemberUtil;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +68,8 @@ class MissionServiceTest {
                         "testMissionName",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
 
         // when
         MissionCreateResponse mission = missionService.createMission(missionCreateRequest);
@@ -88,7 +90,8 @@ class MissionServiceTest {
                         "testMissionName",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
         MissionCreateResponse saveMission = missionService.createMission(missionCreateRequest);
 
         // when
@@ -114,7 +117,8 @@ class MissionServiceTest {
                                         "testMissionName_" + i,
                                         "testMissionContent_" + i,
                                         MissionCategory.STUDY,
-                                        MissionVisibility.ALL))
+                                        MissionVisibility.ALL,
+                                        LocalTime.of(21, 0)))
                 .forEach(
                         request ->
                                 entityManager.persist(
@@ -126,6 +130,7 @@ class MissionServiceTest {
                                                 request.visibility(),
                                                 startedAt,
                                                 startedAt.plusWeeks(2),
+                                                LocalTime.of(21, 0),
                                                 memberUtil.getCurrentMember())));
 
         // when
@@ -150,10 +155,12 @@ class MissionServiceTest {
                         "testMissionName",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
         MissionCreateResponse saveMission = missionService.createMission(missionCreateRequest);
         MissionUpdateRequest missionUpdateRequest =
-                new MissionUpdateRequest("modifyName", "modifyContent", MissionVisibility.FOLLOWER);
+                new MissionUpdateRequest(
+                        "modifyName", "modifyContent", MissionVisibility.FOLLOWER, null);
 
         // when
         MissionUpdateResponse modifyMission =
@@ -171,10 +178,11 @@ class MissionServiceTest {
                         "testMissionName",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
         MissionCreateResponse saveMission = missionService.createMission(missionCreateRequest);
         MissionUpdateRequest missionUpdateRequest =
-                new MissionUpdateRequest(null, "modifyContent", MissionVisibility.FOLLOWER);
+                new MissionUpdateRequest(null, "modifyContent", MissionVisibility.FOLLOWER, null);
 
         // when, then
         assertThatThrownBy(
@@ -193,11 +201,15 @@ class MissionServiceTest {
                         "testMissionName",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
         MissionCreateResponse saveMission = missionService.createMission(missionCreateRequest);
         MissionUpdateRequest missionUpdateRequest =
                 new MissionUpdateRequest(
-                        "modifyMissionName_test", "modifyContent", MissionVisibility.FOLLOWER);
+                        "modifyMissionName_test",
+                        "modifyContent",
+                        MissionVisibility.FOLLOWER,
+                        null);
 
         // when, then
         assertThatThrownBy(
@@ -216,7 +228,8 @@ class MissionServiceTest {
                         "testMissionName",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
         MissionCreateResponse saveMission = missionService.createMission(missionCreateRequest);
 
         // when
@@ -235,7 +248,8 @@ class MissionServiceTest {
                         "testMissionName",
                         "testMissionContent",
                         MissionCategory.STUDY,
-                        MissionVisibility.ALL);
+                        MissionVisibility.ALL,
+                        LocalTime.of(21, 0));
         missionService.createMission(missionCreateRequest);
 
         // when

--- a/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/application/MissionRecordServiceTest.java
@@ -24,6 +24,7 @@ import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.util.SecurityUtil;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -65,6 +66,7 @@ class MissionRecordServiceTest {
                         MissionVisibility.ALL,
                         missionStartedAt,
                         missionStartedAt.plusWeeks(2),
+                        LocalTime.of(21, 0),
                         member);
         missionRepository.save(mission);
     }

--- a/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
+++ b/src/test/java/com/depromeet/domain/missionRecord/domain/MissionRecordTest.java
@@ -13,6 +13,7 @@ import com.depromeet.global.error.exception.ErrorCode;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +34,7 @@ class MissionRecordTest {
                         MissionVisibility.ALL,
                         missionStartedAt,
                         missionFinishedAt,
+                        LocalTime.of(21, 0),
                         member);
 
         @Test

--- a/src/test/java/com/depromeet/domain/notification/application/PushServiceTest.java
+++ b/src/test/java/com/depromeet/domain/notification/application/PushServiceTest.java
@@ -26,6 +26,7 @@ import com.depromeet.global.security.PrincipalDetails;
 import com.depromeet.global.util.MemberUtil;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -114,6 +115,7 @@ class PushServiceTest {
                             MissionVisibility.ALL,
                             missionStartedAt,
                             missionFinishedAt,
+                            LocalTime.of(21, 0),
                             currentMember));
 
             // when, then
@@ -146,6 +148,7 @@ class PushServiceTest {
                             MissionVisibility.ALL,
                             missionStartedAt,
                             missionFinishedAt,
+                            LocalTime.of(21, 0),
                             targetMember));
 
             // when, then
@@ -180,6 +183,7 @@ class PushServiceTest {
                                     MissionVisibility.ALL,
                                     missionStartedAt,
                                     missionFinishedAt,
+                                    LocalTime.of(21, 0),
                                     targetMember));
 
             LocalDateTime missionRecordStartedAt = today;
@@ -232,6 +236,7 @@ class PushServiceTest {
                             MissionVisibility.ALL,
                             missionStartedAt,
                             missionFinishedAt,
+                            LocalTime.of(21, 0),
                             targetMember));
 
             // when

--- a/src/test/java/com/depromeet/domain/notification/application/PushServiceTest.java
+++ b/src/test/java/com/depromeet/domain/notification/application/PushServiceTest.java
@@ -23,7 +23,6 @@ import com.depromeet.domain.notification.dto.request.PushUrgingSendRequest;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.security.PrincipalDetails;
-import com.depromeet.global.util.MemberUtil;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -43,8 +42,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class PushServiceTest {
     @Autowired private DatabaseCleaner databaseCleaner;
-
-    @Autowired private MemberUtil memberUtil;
 
     @MockBean private FcmService fcmService;
 
@@ -128,10 +125,7 @@ class PushServiceTest {
         void 종료된_미션을_재촉할_경우_예외를_발생시킨다() {
             // given
             PushUrgingSendRequest request = new PushUrgingSendRequest(1L);
-            Member currentMember =
-                    memberRepository.save(
-                            Member.createNormalMember(
-                                    Profile.createProfile("testNickname1", "testImageUrl1")));
+
             Member targetMember =
                     memberRepository.save(
                             Member.createNormalMember(
@@ -161,10 +155,7 @@ class PushServiceTest {
         void 미션이_당일_완료된_경우_예외를_발생시킨다() {
             // given
             PushUrgingSendRequest request = new PushUrgingSendRequest(1L);
-            Member currentMember =
-                    memberRepository.save(
-                            Member.createNormalMember(
-                                    Profile.createProfile("testNickname1", "testImageUrl1")));
+
             Member targetMember =
                     memberRepository.save(
                             Member.createNormalMember(
@@ -213,10 +204,7 @@ class PushServiceTest {
             when(fcmService.sendMessageSync(any(), any(), any())).thenReturn(null);
 
             PushUrgingSendRequest request = new PushUrgingSendRequest(1L);
-            Member currentMember =
-                    memberRepository.save(
-                            Member.createNormalMember(
-                                    Profile.createProfile("testNickname1", "testImageUrl1")));
+
             Member targetMember =
                     memberRepository.save(
                             Member.createNormalMember(

--- a/src/test/java/com/depromeet/domain/notification/application/PushServiceTest.java
+++ b/src/test/java/com/depromeet/domain/notification/application/PushServiceTest.java
@@ -23,6 +23,7 @@ import com.depromeet.domain.notification.dto.request.PushUrgingSendRequest;
 import com.depromeet.global.error.exception.CustomException;
 import com.depromeet.global.error.exception.ErrorCode;
 import com.depromeet.global.security.PrincipalDetails;
+import com.depromeet.global.util.MemberUtil;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -42,6 +43,8 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class PushServiceTest {
     @Autowired private DatabaseCleaner databaseCleaner;
+
+    @Autowired private MemberUtil memberUtil;
 
     @MockBean private FcmService fcmService;
 
@@ -125,7 +128,10 @@ class PushServiceTest {
         void 종료된_미션을_재촉할_경우_예외를_발생시킨다() {
             // given
             PushUrgingSendRequest request = new PushUrgingSendRequest(1L);
-
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("testNickname1", "testImageUrl1")));
             Member targetMember =
                     memberRepository.save(
                             Member.createNormalMember(
@@ -155,7 +161,10 @@ class PushServiceTest {
         void 미션이_당일_완료된_경우_예외를_발생시킨다() {
             // given
             PushUrgingSendRequest request = new PushUrgingSendRequest(1L);
-
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("testNickname1", "testImageUrl1")));
             Member targetMember =
                     memberRepository.save(
                             Member.createNormalMember(
@@ -204,7 +213,10 @@ class PushServiceTest {
             when(fcmService.sendMessageSync(any(), any(), any())).thenReturn(null);
 
             PushUrgingSendRequest request = new PushUrgingSendRequest(1L);
-
+            Member currentMember =
+                    memberRepository.save(
+                            Member.createNormalMember(
+                                    Profile.createProfile("testNickname1", "testImageUrl1")));
             Member targetMember =
                     memberRepository.save(
                             Member.createNormalMember(

--- a/src/test/java/com/depromeet/domain/reaction/application/ReactionServiceTest.java
+++ b/src/test/java/com/depromeet/domain/reaction/application/ReactionServiceTest.java
@@ -76,6 +76,7 @@ class ReactionServiceTest {
                         MissionVisibility.ALL,
                         NOW.minusDays(5),
                         NOW.plusDays(5),
+                        null,
                         member);
         missionRepository.save(mission);
         MissionRecord missionRecord =


### PR DESCRIPTION
## 🌱 관련 이슈
- close #363 

## 📌 작업 내용 및 특이사항
- 미션 시작 리마인드 알림시간 설정을 위한 mission 엔티티에 remindedTime(nullable) 추가
- 생성, 수정 시 remindedTime LocalTime 필드 추가 Request하도록 구현
- Scheduler에서 매 10분마다 In-progress인 미션 대상으로 전체 조회
- 조회 후 현재 now의 LocalTime과 설정한 미션 리마인드 시간 LocalTime과 동일한 지 체크
- 체크 후 대상 미션에 대하여 fcmToken을 each로 {미션명}을 파라미터로 받아 적합하게 조합한 푸시 알림 전송

## 📝 참고사항
- 

## 📚 기타
- 
