### PR TITLE
feat: 소셜 로그인 후 랜딩 상태 결정하는 기능 구현

### DIFF
--- a/src/main/java/com/depromeet/domain/auth/domain/LandingStatus.java
+++ b/src/main/java/com/depromeet/domain/auth/domain/LandingStatus.java
@@ -1,0 +1,7 @@
+package com.depromeet.domain.auth.domain;
+
+public enum LandingStatus {
+    TO_MAIN,
+    TO_ONBOARDING,
+    ;
+}

--- a/src/main/java/com/depromeet/domain/auth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/depromeet/domain/auth/dto/response/SocialLoginResponse.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.auth.dto.response;
 
+import com.depromeet.domain.auth.domain.LandingStatus;
 import com.depromeet.domain.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -7,13 +8,16 @@ public record SocialLoginResponse(
         @Schema(description = "멤버 ID", defaultValue = "1") Long memberId,
         @Schema(description = "엑세스 토큰", defaultValue = "accessToken") String accessToken,
         @Schema(description = "리프레시 토큰", defaultValue = "refreshToken") String refreshToken,
-        @Schema(description = "게스트 여부", defaultValue = "false") boolean isGuest) {
+        @Schema(description = "게스트 여부", defaultValue = "false") boolean isGuest,
+        @Schema(description = "랜딩 상태", defaultValue = "TO_MAIN") LandingStatus landingStatus) {
 
-    public static SocialLoginResponse from(Member member, TokenPairResponse tokenPairResponse) {
+    public static SocialLoginResponse of(
+            Member member, TokenPairResponse tokenPairResponse, LandingStatus landingStatus) {
         return new SocialLoginResponse(
                 member.getId(),
                 tokenPairResponse.accessToken(),
                 tokenPairResponse.refreshToken(),
-                false);
+                false,
+                landingStatus);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #372

## 📌 작업 내용 및 특이사항
- 어지간하면 `Member` 도메인 내부 상태로 `LandingStatus` 를 결정할 수 있으면 더 깔끔한 로직이 나왔을텐데 (`LandingStatus.of(member)`) 같은 식으로요) 뭔가... 뭔가 아쉽네요
- 일단 서비스 단에서 결정하는 것으로 해두었습니다. 
- 랜딩 상태를 결정하려면 멤버의 존재 여부가 필요한데, 이 부분은 `fetchOrCreate` 의 내부 로직에서 쓰고 있어서 `fetchOrCreate` 를 제거하고 대신 `findByOidcUser` 를 사용하여 서비스 메서드 전체 컨텍스트에서 존재 여부를 참조할 수 있도록 구현했습니다.

## 📝 참고사항
- 

## 📚 기타
- 
