### PR TITLE
feat: 댓글 생성, 수정, 삭제 기능

### DIFF
--- a/src/main/java/com/depromeet/domain/comment/api/CommentController.java
+++ b/src/main/java/com/depromeet/domain/comment/api/CommentController.java
@@ -9,9 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "7. [댓글]", description = "댓글 관련 API")
 @RestController
@@ -26,5 +24,13 @@ public class CommentController {
     public ResponseEntity<CommentDto> commentCreate(@Valid CommentCreateRequest request) {
         CommentDto response = commentService.createComment(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "댓글 수정", description = "댓글을 수정합니다.")
+    @PutMapping("/{commentId}")
+    public ResponseEntity<CommentDto> commentUpdate(
+            @PathVariable Long commentId, @Valid CommentUpdateRequest request) {
+        CommentDto response = commentService.updateComment(commentId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/depromeet/domain/comment/api/CommentController.java
+++ b/src/main/java/com/depromeet/domain/comment/api/CommentController.java
@@ -1,0 +1,30 @@
+package com.depromeet.domain.comment.api;
+
+import com.depromeet.domain.comment.application.CommentService;
+import com.depromeet.domain.comment.dto.request.CommentCreateRequest;
+import com.depromeet.domain.comment.dto.response.CommentDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "7. [댓글]", description = "댓글 관련 API")
+@RestController
+@RequestMapping("/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 추가", description = "미션 기록에 댓글을 추가합니다.")
+    @PostMapping
+    public ResponseEntity<CommentDto> commentCreate(@Valid CommentCreateRequest request) {
+        CommentDto response = commentService.createComment(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/depromeet/domain/comment/api/CommentController.java
+++ b/src/main/java/com/depromeet/domain/comment/api/CommentController.java
@@ -12,7 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "7. [댓글]", description = "댓글 관련 API")
+@Tag(name = "8. [댓글]", description = "댓글 관련 API")
 @RestController
 @RequestMapping("/comments")
 @RequiredArgsConstructor

--- a/src/main/java/com/depromeet/domain/comment/api/CommentController.java
+++ b/src/main/java/com/depromeet/domain/comment/api/CommentController.java
@@ -2,6 +2,7 @@ package com.depromeet.domain.comment.api;
 
 import com.depromeet.domain.comment.application.CommentService;
 import com.depromeet.domain.comment.dto.request.CommentCreateRequest;
+import com.depromeet.domain.comment.dto.request.CommentUpdateRequest;
 import com.depromeet.domain.comment.dto.response.CommentDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,5 +33,12 @@ public class CommentController {
             @PathVariable Long commentId, @Valid CommentUpdateRequest request) {
         CommentDto response = commentService.updateComment(commentId, request);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> commentDelete(@PathVariable Long commentId) {
+        commentService.deleteComment(commentId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/depromeet/domain/comment/application/CommentService.java
+++ b/src/main/java/com/depromeet/domain/comment/application/CommentService.java
@@ -52,6 +52,19 @@ public class CommentService {
         return CommentDto.from(comment);
     }
 
+    public void deleteComment(Long commentId) {
+        final Member member = memberUtil.getCurrentMember();
+
+        Comment comment =
+                commentRepository
+                        .findById(commentId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        validateCommentMemberMismatch(member, comment);
+
+        commentRepository.delete(comment);
+    }
+
     private void validateCommentMemberMismatch(Member member, Comment comment) {
         if (!comment.getMember().equals(member)) {
             throw new CustomException(ErrorCode.COMMENT_MEMBER_MISMATCH);

--- a/src/main/java/com/depromeet/domain/comment/application/CommentService.java
+++ b/src/main/java/com/depromeet/domain/comment/application/CommentService.java
@@ -26,6 +26,7 @@ public class CommentService {
 
     public CommentDto createComment(CommentCreateRequest request) {
         final Member member = memberUtil.getCurrentMember();
+
         MissionRecord missionRecord =
                 missionRecordRepository
                         .findById(request.missionRecordId())

--- a/src/main/java/com/depromeet/domain/comment/application/CommentService.java
+++ b/src/main/java/com/depromeet/domain/comment/application/CommentService.java
@@ -3,6 +3,7 @@ package com.depromeet.domain.comment.application;
 import com.depromeet.domain.comment.dao.CommentRepository;
 import com.depromeet.domain.comment.domain.Comment;
 import com.depromeet.domain.comment.dto.request.CommentCreateRequest;
+import com.depromeet.domain.comment.dto.request.CommentUpdateRequest;
 import com.depromeet.domain.comment.dto.response.CommentDto;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
@@ -34,5 +35,25 @@ public class CommentService {
         commentRepository.save(comment);
 
         return CommentDto.from(comment);
+    }
+
+    public CommentDto updateComment(Long commentId, CommentUpdateRequest request) {
+        final Member member = memberUtil.getCurrentMember();
+
+        Comment comment =
+                commentRepository
+                        .findById(commentId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        validateCommentMemberMismatch(member, comment);
+
+        comment.updateContent(request.content());
+        return CommentDto.from(comment);
+    }
+
+    private void validateCommentMemberMismatch(Member member, Comment comment) {
+        if (!comment.getMember().equals(member)) {
+            throw new CustomException(ErrorCode.COMMENT_MEMBER_MISMATCH);
+        }
     }
 }

--- a/src/main/java/com/depromeet/domain/comment/application/CommentService.java
+++ b/src/main/java/com/depromeet/domain/comment/application/CommentService.java
@@ -1,0 +1,38 @@
+package com.depromeet.domain.comment.application;
+
+import com.depromeet.domain.comment.dao.CommentRepository;
+import com.depromeet.domain.comment.domain.Comment;
+import com.depromeet.domain.comment.dto.request.CommentCreateRequest;
+import com.depromeet.domain.comment.dto.response.CommentDto;
+import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
+import com.depromeet.global.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+
+    private final MemberUtil memberUtil;
+    private final MissionRecordRepository missionRecordRepository;
+    private final CommentRepository commentRepository;
+
+    public CommentDto createComment(CommentCreateRequest request) {
+        final Member member = memberUtil.getCurrentMember();
+        MissionRecord missionRecord =
+                missionRecordRepository
+                        .findById(request.missionRecordId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MISSION_RECORD_NOT_FOUND));
+
+        Comment comment = Comment.createComment(request.content(), member, missionRecord);
+        commentRepository.save(comment);
+
+        return CommentDto.from(comment);
+    }
+}

--- a/src/main/java/com/depromeet/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/depromeet/domain/comment/dao/CommentRepository.java
@@ -1,0 +1,6 @@
+package com.depromeet.domain.comment.dao;
+
+import com.depromeet.domain.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {}

--- a/src/main/java/com/depromeet/domain/comment/domain/Comment.java
+++ b/src/main/java/com/depromeet/domain/comment/domain/Comment.java
@@ -1,0 +1,59 @@
+package com.depromeet.domain.comment.domain;
+
+import com.depromeet.domain.common.model.BaseTimeEntity;
+import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    private String content;
+
+    @org.hibernate.annotations.Comment("댓글을 작성한 회원")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_record_id")
+    private MissionRecord missionRecord;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Comment(String content, Member member, MissionRecord missionRecord) {
+        this.content = content;
+        this.member = member;
+        this.missionRecord = missionRecord;
+    }
+
+    public static Comment createComment(
+            String content, Member member, MissionRecord missionRecord) {
+        return Comment.builder()
+                .content(content)
+                .member(member)
+                .missionRecord(missionRecord)
+                .build();
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/depromeet/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/depromeet/domain/comment/dto/CommentDto.java
@@ -1,0 +1,23 @@
+package com.depromeet.domain.comment.dto;
+
+import com.depromeet.domain.comment.domain.Comment;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record CommentDto(
+        @Schema(description = "댓글 ID", defaultValue = "1") Long commentId,
+        @Schema(description = "댓글 내용", defaultValue = "댓글 내용입니다.") String content,
+        @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                @Schema(
+                        description = "댓글 작성 시간",
+                        defaultValue = "2024-03-25 00:00:00",
+                        type = "string")
+                LocalDateTime createdAt) {
+    public static CommentDto from(Comment comment) {
+        return new CommentDto(comment.getId(), comment.getContent(), comment.getCreatedAt());
+    }
+}

--- a/src/main/java/com/depromeet/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/depromeet/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,12 @@
+package com.depromeet.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record CommentCreateRequest(
+        @NotNull(message = "미션 기록 아이디는 비워둘 수 없습니다.")
+                @Schema(description = "미션 기록 아이디", defaultValue = "1")
+                Long missionRecordId,
+        @NotNull(message = "댓글 내용은 비워둘 수 없습니다.")
+                @Schema(description = "댓글 내용", defaultValue = "댓글 내용입니다.")
+                String content) {}

--- a/src/main/java/com/depromeet/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/depromeet/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.depromeet.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record CommentUpdateRequest(
+        @NotNull(message = "댓글 내용은 비워둘 수 없습니다.")
+                @Schema(description = "댓글 내용", defaultValue = "댓글 내용입니다.")
+                String content) {}

--- a/src/main/java/com/depromeet/domain/comment/dto/response/CommentDto.java
+++ b/src/main/java/com/depromeet/domain/comment/dto/response/CommentDto.java
@@ -1,4 +1,4 @@
-package com.depromeet.domain.comment.dto;
+package com.depromeet.domain.comment.dto.response;
 
 import com.depromeet.domain.comment.domain.Comment;
 import com.fasterxml.jackson.annotation.JsonFormat;

--- a/src/main/java/com/depromeet/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/domain/feed/application/FeedService.java
@@ -119,7 +119,7 @@ public class FeedService {
     }
 
     private List<FeedOneByProfileResponse> extractFeedResponses(List<MissionRecord> records) {
-        return records.stream().map(FeedOneByProfileResponse::of).toList();
+        return records.stream().map(FeedOneByProfileResponse::from).toList();
     }
 
     private List<MissionVisibility> determineVisibilityConditionsByRelationsWithMe(

--- a/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneByProfileResponse.java
+++ b/src/main/java/com/depromeet/domain/feed/dto/response/FeedOneByProfileResponse.java
@@ -35,7 +35,7 @@ public record FeedOneByProfileResponse(
                         type = "string")
                 LocalDateTime finishedAt) {
 
-    public static FeedOneByProfileResponse of(MissionRecord record) {
+    public static FeedOneByProfileResponse from(MissionRecord record) {
         return new FeedOneByProfileResponse(
                 record.getMission().getId(),
                 record.getId(),

--- a/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/domain/missionRecord/domain/MissionRecord.java
@@ -1,5 +1,6 @@
 package com.depromeet.domain.missionRecord.domain;
 
+import com.depromeet.domain.comment.domain.Comment;
 import com.depromeet.domain.common.model.BaseTimeEntity;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.reaction.domain.Reaction;
@@ -14,7 +15,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Comment;
 
 @Getter
 @Entity
@@ -28,10 +28,10 @@ public class MissionRecord extends BaseTimeEntity {
 
     private Duration duration;
 
-    @Comment("미션 일지")
+    @org.hibernate.annotations.Comment("미션 일지")
     private String remark;
 
-    @Comment("인증 사진")
+    @org.hibernate.annotations.Comment("인증 사진")
     private String imageUrl;
 
     @Enumerated(EnumType.STRING)
@@ -47,6 +47,9 @@ public class MissionRecord extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "missionRecord", cascade = CascadeType.REMOVE)
     private List<Reaction> reactions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "missionRecord", cascade = CascadeType.REMOVE)
+    private List<Comment> comments = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private MissionRecord(

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -66,6 +66,10 @@ public enum ErrorCode {
     REACTION_ALREADY_EXISTS(HttpStatus.CONFLICT, "리액션은 미션기록 당 한번만 가능합니다."),
     REACTION_MEMBER_MISMATCH(HttpStatus.CONFLICT, "리액션을 생성한 유저와 로그인된 계정이 일치하지 않습니다."),
     REACTION_SELF_NOT_ALLOWED(HttpStatus.CONFLICT, "자신의 미션 기록에는 리액션을 추가할 수 없습니다."),
+
+    // Comment
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
+    COMMENT_MEMBER_MISMATCH(HttpStatus.CONFLICT, "댓글을 생성한 유저와 로그인된 계정이 일치하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/depromeet/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/depromeet/domain/comment/application/CommentServiceTest.java
@@ -1,0 +1,232 @@
+package com.depromeet.domain.comment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.depromeet.DatabaseCleaner;
+import com.depromeet.domain.comment.dao.CommentRepository;
+import com.depromeet.domain.comment.dto.request.CommentCreateRequest;
+import com.depromeet.domain.comment.dto.request.CommentUpdateRequest;
+import com.depromeet.domain.comment.dto.response.CommentDto;
+import com.depromeet.domain.member.dao.MemberRepository;
+import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.member.domain.OauthInfo;
+import com.depromeet.domain.mission.dao.MissionRepository;
+import com.depromeet.domain.mission.domain.Mission;
+import com.depromeet.domain.mission.domain.MissionCategory;
+import com.depromeet.domain.mission.domain.MissionVisibility;
+import com.depromeet.domain.missionRecord.dao.MissionRecordRepository;
+import com.depromeet.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.global.error.exception.CustomException;
+import com.depromeet.global.error.exception.ErrorCode;
+import com.depromeet.global.security.PrincipalDetails;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CommentServiceTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2024, 3, 26, 5, 0, 0);
+
+    @Autowired private CommentService commentService;
+    @Autowired private CommentRepository commentRepository;
+    @Autowired private DatabaseCleaner databaseCleaner;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private MissionRepository missionRepository;
+    @Autowired private MissionRecordRepository missionRecordRepository;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+    }
+
+    private Member saveAndRegisterMember() {
+        SecurityContextHolder.clearContext();
+        OauthInfo oauthInfo =
+                OauthInfo.createOauthInfo("testOauthId", "testOauthProvider", "testOauthEmail");
+        Member member = Member.createNormalMember(oauthInfo, "testNickname");
+        memberRepository.save(member);
+        PrincipalDetails principalDetails = new PrincipalDetails(member.getId(), "USER");
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                        principalDetails, null, principalDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        return member;
+    }
+
+    private void createMissionAndMissionRecord(Member member) {
+        Mission mission =
+                Mission.createMission(
+                        "testMission",
+                        "testDescription",
+                        1,
+                        MissionCategory.PROJECT,
+                        MissionVisibility.ALL,
+                        NOW.minusDays(5),
+                        NOW.plusDays(5),
+                        null,
+                        member);
+        missionRepository.save(mission);
+        MissionRecord missionRecord =
+                MissionRecord.createMissionRecord(
+                        Duration.ofMinutes(30), NOW.minusMinutes(25), NOW.minusMinutes(5), mission);
+        missionRecordRepository.save(missionRecord);
+    }
+
+    private void logoutAndReloginAs(Long memberId) {
+        SecurityContextHolder.clearContext(); // 현재 회원 로그아웃
+        PrincipalDetails principalDetails = new PrincipalDetails(memberId, "USER");
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                        principalDetails, null, principalDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Nested
+    class 댓글_생성시 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Member member = saveAndRegisterMember();
+            createMissionAndMissionRecord(member);
+
+            // when
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
+            CommentDto commentDto = commentService.createComment(request);
+
+            // then
+            assertThat(commentDto).isNotNull();
+            assertThat(commentDto.commentId()).isEqualTo(1L);
+            assertThat(commentDto.content()).isEqualTo("testContent");
+        }
+
+        @Test
+        void 존재하지_않는_미션기록이면_실패한다() {
+            // given
+            Member member = saveAndRegisterMember();
+
+            // when & then
+            CommentCreateRequest request = new CommentCreateRequest(2L, "testContent");
+
+            assertThatThrownBy(() -> commentService.createComment(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.MISSION_RECORD_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class 댓글_수정시 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Member member = saveAndRegisterMember();
+            createMissionAndMissionRecord(member);
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
+            commentService.createComment(request);
+
+            // when
+            CommentUpdateRequest updateRequest = new CommentUpdateRequest("updatedContent");
+            CommentDto updatedCommentDto = commentService.updateComment(1L, updateRequest);
+
+            // then
+            assertThat(updatedCommentDto).isNotNull();
+            assertThat(updatedCommentDto.commentId()).isEqualTo(1L);
+            assertThat(updatedCommentDto.content()).isEqualTo("updatedContent");
+        }
+
+        @Test
+        void 존재하지_않는_댓글이면_실패한다() {
+            // given
+            Member member = saveAndRegisterMember();
+            createMissionAndMissionRecord(member);
+
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
+            commentService.createComment(request);
+
+            // when & then
+            CommentUpdateRequest updateRequest = new CommentUpdateRequest("updatedContent");
+
+            assertThatThrownBy(() -> commentService.updateComment(2L, updateRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.COMMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 다른_사용자가_작성한_댓글이면_실패한다() {
+            // given
+            Member member = saveAndRegisterMember();
+            createMissionAndMissionRecord(member);
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
+            commentService.createComment(request);
+
+            // when & then
+            saveAndRegisterMember(); // 다른 사용자로 로그인
+            CommentUpdateRequest updateRequest = new CommentUpdateRequest("updatedContent");
+
+            assertThatThrownBy(() -> commentService.updateComment(1L, updateRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.COMMENT_MEMBER_MISMATCH.getMessage());
+        }
+    }
+
+    @Nested
+    class 댓글_삭제시 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Member member = saveAndRegisterMember();
+            createMissionAndMissionRecord(member);
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
+            commentService.createComment(request);
+
+            // when
+            commentService.deleteComment(1L);
+
+            // then
+            assertThat(commentRepository.findById(1L)).isEmpty();
+        }
+
+        @Test
+        void 존재하지_않는_댓글이면_실패한다() {
+            // given
+            Member member = saveAndRegisterMember();
+            createMissionAndMissionRecord(member);
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
+            commentService.createComment(request);
+
+            // when & then
+            assertThatThrownBy(() -> commentService.deleteComment(2L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.COMMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 다른_사용자가_작성한_댓글이면_실패한다() {
+            // given
+            Member member = saveAndRegisterMember();
+            createMissionAndMissionRecord(member);
+            CommentCreateRequest request = new CommentCreateRequest(1L, "testContent");
+            commentService.createComment(request);
+
+            // when & then
+            saveAndRegisterMember(); // 다른 사용자로 로그인
+
+            assertThatThrownBy(() -> commentService.deleteComment(1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.COMMENT_MEMBER_MISMATCH.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #366

## 📌 작업 내용 및 특이사항
- 리액션 기능과 전반적으로 비슷합니다만 조회는 #359 에서 작업하기 위해 제외했습니다.
- 생성 / 수정 DTO 굳이 다르게 둘 필요가 없을 것 같다는 생각이 들어서 공통으로 쓸 `CommentDto` 응답 DTO를 만들었습니다. 확실히 좋네요. 
- 각종 정책 검증하기 위한 테스트 코드를 작성했습니다.

## 📝 참고사항
- 

## 📚 기타
- 
