### PR TITLE
fix: 리마인드 푸시 알림할 미션 대상 조건 처리

### DIFF
--- a/src/main/java/com/depromeet/domain/member/dao/MemberRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/member/dao/MemberRepositoryImpl.java
@@ -5,6 +5,7 @@ import static com.depromeet.domain.mission.domain.QMission.*;
 import static com.depromeet.domain.missionRecord.domain.QMissionRecord.*;
 
 import com.depromeet.domain.member.domain.Member;
+import com.depromeet.domain.mission.domain.DurationStatus;
 import com.depromeet.domain.missionRecord.domain.ImageUploadStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
@@ -32,6 +33,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                         missionRecord
                                 .isNull()
                                 .or(missionRecord.uploadStatus.ne(ImageUploadStatus.COMPLETE)),
+                        mission.durationStatus.eq(DurationStatus.IN_PROGRESS),
                         member.fcmInfo.fcmToken.isNotNull(),
                         mission.startedAt.loe(today),
                         mission.finishedAt.goe(today))

--- a/src/main/java/com/depromeet/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/domain/mission/application/MissionService.java
@@ -3,7 +3,6 @@ package com.depromeet.domain.mission.application;
 import com.depromeet.domain.follow.dao.MemberRelationRepository;
 import com.depromeet.domain.member.domain.Member;
 import com.depromeet.domain.mission.dao.MissionRepository;
-import com.depromeet.domain.mission.domain.DurationStatus;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.dto.request.MissionCreateRequest;
 import com.depromeet.domain.mission.dto.request.MissionUpdateRequest;
@@ -244,8 +243,8 @@ public class MissionService {
 
     @Transactional(readOnly = true)
     public List<MissionRemindPushResponse> findAllInProgressMission() {
-        List<Mission> missions =
-                missionRepository.findAllByDurationStatus(DurationStatus.IN_PROGRESS);
+        LocalDateTime today = LocalDateTime.now();
+        List<Mission> missions = missionRepository.findMissionsNonCompleteAndInProgress(today);
         return missions.stream().map(MissionRemindPushResponse::from).toList();
     }
 

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepository.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepository.java
@@ -3,17 +3,9 @@ package com.depromeet.domain.mission.dao;
 import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphType.*;
 
 import com.depromeet.domain.member.domain.Member;
-import com.depromeet.domain.mission.domain.DurationStatus;
 import com.depromeet.domain.mission.domain.Mission;
-import java.util.List;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionRepository extends JpaRepository<Mission, Long>, MissionRepositoryCustom {
     Mission findTopByMemberOrderBySortDesc(Member member);
-
-    @EntityGraph(
-            attributePaths = {"member"},
-            type = FETCH)
-    List<Mission> findAllByDurationStatus(DurationStatus status);
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryCustom.java
@@ -18,4 +18,6 @@ public interface MissionRepositoryCustom {
     List<Mission> findAllFinishedMission(Long memberId);
 
     List<Mission> findMissionsWithRecordsByDate(LocalDate date, Long memberId);
+
+    List<Mission> findMissionsNonCompleteAndInProgress(LocalDateTime today);
 }

--- a/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/domain/mission/dao/MissionRepositoryImpl.java
@@ -7,6 +7,7 @@ import static com.depromeet.domain.missionRecord.domain.QMissionRecord.*;
 import com.depromeet.domain.mission.domain.DurationStatus;
 import com.depromeet.domain.mission.domain.Mission;
 import com.depromeet.domain.mission.domain.MissionVisibility;
+import com.depromeet.domain.missionRecord.domain.ImageUploadStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -102,6 +103,24 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
                                         .goe(date))
                         .fetchJoin();
         return query.fetch();
+    }
+
+    @Override
+    public List<Mission> findMissionsNonCompleteAndInProgress(LocalDateTime today) {
+        return jpaQueryFactory
+                .selectFrom(mission)
+                .leftJoin(mission.member, member)
+                .fetchJoin()
+                .leftJoin(mission.missionRecords, missionRecord)
+                .on(missionRecord.createdAt.loe(today))
+                .where(
+                        missionRecord
+                                .isNull()
+                                .or(missionRecord.uploadStatus.ne(ImageUploadStatus.COMPLETE)),
+                        mission.durationStatus.eq(DurationStatus.IN_PROGRESS),
+                        mission.startedAt.loe(today),
+                        mission.finishedAt.goe(today))
+                .fetch();
     }
 
     // 미션의 사용자 id 조건 검증 메서드

--- a/src/main/java/com/depromeet/global/common/constants/PushNotificationConstants.java
+++ b/src/main/java/com/depromeet/global/common/constants/PushNotificationConstants.java
@@ -16,5 +16,5 @@ public class PushNotificationConstants {
     public static final String PUSH_MISSION_REMIND_TITLE = "10분이 지났어요!";
     public static final String PUSH_MISSION_REMIND_CONTENT = "지금부터 미션 인증을 할 수 있어요 🕑";
     public static final String PUSH_MISSION_START_REMIND_TITLE = "미션을 시작할 시간이에요!";
-    public static final String PUSH_MISSION_START_REMIND_CONTENT = "10분을 투자하여 %s 미션을 완료해 보세요 🥳";
+    public static final String PUSH_MISSION_START_REMIND_CONTENT = "10분만 투자해서 %s 미션을 완료해봐요 🥳";
 }

--- a/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
+++ b/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
@@ -28,7 +28,7 @@ public class MissionBatchScheduler {
     }
 
     // 매 10분마다 schedule 실행
-    @Scheduled(cron = "0 */10 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 */2 * * * *", zone = "Asia/Seoul")
     public void missionRemindPushNotification() {
         log.info("Mission Remind Push Notification batch execute");
 
@@ -37,13 +37,13 @@ public class MissionBatchScheduler {
         inProgressMissions.forEach(this::sendMissionRemindPushNotification);
     }
 
-    private void sendMissionRemindPushNotification(MissionRemindPushResponse mission) {
+    private void sendMissionRemindPushNotification(MissionRemindPushResponse response) {
         LocalTime currentTime = LocalTime.now().truncatedTo(ChronoUnit.MINUTES);
-        if (currentTime.equals(mission.remindAt())) {
+        if (currentTime.equals(response.remindAt())) {
             fcmService.sendMessageSync(
-                    mission.fcmToken(),
+                    response.fcmToken(),
                     PUSH_MISSION_START_REMIND_TITLE,
-                    String.format(PUSH_MISSION_START_REMIND_CONTENT, mission.name()));
+                    String.format(PUSH_MISSION_START_REMIND_CONTENT, response.name()));
         }
     }
 }

--- a/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
+++ b/src/main/java/com/depromeet/scheduler/mission/MissionBatchScheduler.java
@@ -28,7 +28,7 @@ public class MissionBatchScheduler {
     }
 
     // 매 10분마다 schedule 실행
-    @Scheduled(cron = "0 */2 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 */10 * * * *", zone = "Asia/Seoul")
     public void missionRemindPushNotification() {
         log.info("Mission Remind Push Notification batch execute");
 
@@ -37,13 +37,13 @@ public class MissionBatchScheduler {
         inProgressMissions.forEach(this::sendMissionRemindPushNotification);
     }
 
-    private void sendMissionRemindPushNotification(MissionRemindPushResponse response) {
+    private void sendMissionRemindPushNotification(MissionRemindPushResponse remindPushResponse) {
         LocalTime currentTime = LocalTime.now().truncatedTo(ChronoUnit.MINUTES);
-        if (currentTime.equals(response.remindAt())) {
+        if (currentTime.equals(remindPushResponse.remindAt())) {
             fcmService.sendMessageSync(
-                    response.fcmToken(),
+                    remindPushResponse.fcmToken(),
                     PUSH_MISSION_START_REMIND_TITLE,
-                    String.format(PUSH_MISSION_START_REMIND_CONTENT, response.name()));
+                    String.format(PUSH_MISSION_START_REMIND_CONTENT, remindPushResponse.name()));
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #381 

## 📌 작업 내용 및 특이사항
- 리마인드 알림 조회 쿼리 시 필요한 조건처리 기존 `@EntityGraph`를 지우고 Querydsl로 전환하여 조건처리
- 미션을 완료했는지 안했는 지 여부 판단 조건이 필요

## 📝 참고사항
- 알림 메세지 내용(body) 변경
- 22시 리마인드 알림, 미션 진행중인지에 대한 where절 하나 추가 (findMissionNonCompletedMembers 메서드)

## 📚 기타
- 
