### PR TITLE
test: missionService 테스트 코드 Transactional 삭제

### DIFF
--- a/src/main/java/com/depromeet/global/util/CookieUtil.java
+++ b/src/main/java/com/depromeet/global/util/CookieUtil.java
@@ -59,7 +59,7 @@ public class CookieUtil {
                         .maxAge(0)
                         .secure(true)
                         .sameSite(sameSite)
-                        .httpOnly(false)
+                        .httpOnly(true)
                         .build();
 
         ResponseCookie refreshTokenCookie =
@@ -68,7 +68,7 @@ public class CookieUtil {
                         .maxAge(0)
                         .secure(true)
                         .sameSite(sameSite)
-                        .httpOnly(false)
+                        .httpOnly(true)
                         .build();
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
@@ -21,7 +21,6 @@ import com.depromeet.domain.mission.dto.response.MissionFindResponse;
 import com.depromeet.domain.mission.dto.response.MissionUpdateResponse;
 import com.depromeet.global.security.PrincipalDetails;
 import com.depromeet.global.util.MemberUtil;
-import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
@@ -44,7 +43,6 @@ class MissionServiceTest {
     @Autowired private MissionRepository missionRepository;
     @Autowired private MemberRepository memberRepository;
     @Autowired private DatabaseCleaner databaseCleaner;
-    @Autowired private EntityManager entityManager;
     @Autowired private MemberUtil memberUtil;
 
     @BeforeEach

--- a/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/domain/mission/service/MissionServiceTest.java
@@ -35,7 +35,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -108,7 +107,6 @@ class MissionServiceTest {
     }
 
     @Test
-    @Transactional
     void 미션_리스트를_조회한다() {
         // given
         LocalDateTime startedAt = LocalDateTime.now();
@@ -125,7 +123,7 @@ class MissionServiceTest {
                                         LocalTime.of(21, 0)))
                 .forEach(
                         request ->
-                                entityManager.persist(
+                                missionRepository.save(
                                         Mission.createMission(
                                                 request.name(),
                                                 request.content(),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #385 

## 📌 작업 내용 및 특이사항
- 테스트 코드는 databaseCleaner 를 사용하고 있는데, `@Transactional` 유일하게 하나 남아있어서 삭제 및 테스트 수정

## 📝 참고사항
- 잠수함 패치로 CookieUtil에서 ResponseCookie httpOnly 옵션 true 변경

## 📚 기타
- 
