### PR TITLE
hotfix: 도커 이미지를 arm64 플랫폼으로 빌드하도록 수정

### DIFF
--- a/.github/workflows/production_build_deploy.yml
+++ b/.github/workflows/production_build_deploy.yml
@@ -81,6 +81,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/arm64/v8
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
 


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
- 
