### PR TITLE
feat: 알림센터 Message추가와 클릭 시 대상으로 이동할 수 있도록 자원 ID와 추가

### DIFF
--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -57,7 +57,7 @@ public class FollowService {
                 String.format(PUSH_SERVICE_CONTENT, currentMember.getProfile().getNickname()));
         Notification notification =
                 Notification.createNotification(
-                        NotificationType.FOLLOW, currentMember, targetMember);
+                        NotificationType.FOLLOW, currentMember, targetMember, currentMember.getId());
         notificationRepository.save(notification);
         memberRelationRepository.save(memberRelation);
     }

--- a/src/main/java/com/depromeet/domain/follow/application/FollowService.java
+++ b/src/main/java/com/depromeet/domain/follow/application/FollowService.java
@@ -57,7 +57,10 @@ public class FollowService {
                 String.format(PUSH_SERVICE_CONTENT, currentMember.getProfile().getNickname()));
         Notification notification =
                 Notification.createNotification(
-                        NotificationType.FOLLOW, currentMember, targetMember, currentMember.getId());
+                        NotificationType.FOLLOW,
+                        currentMember,
+                        targetMember,
+                        currentMember.getId());
         notificationRepository.save(notification);
         memberRelationRepository.save(memberRelation);
     }

--- a/src/main/java/com/depromeet/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/depromeet/domain/notification/application/NotificationService.java
@@ -54,7 +54,7 @@ public class NotificationService {
                         mission.getName()));
         Notification notification =
                 Notification.createNotification(
-                        NotificationType.MISSION_URGING, currentMember, targetMember);
+                        NotificationType.MISSION_URGING, currentMember, targetMember, mission.getId());
         notificationRepository.save(notification);
     }
 
@@ -79,7 +79,10 @@ public class NotificationService {
                 .map(
                         notification ->
                                 NotificationFindAllResponse.of(
+                                        notification.getId(),
                                         notification.getNotificationType(),
+                                        notification.getResourceId(),
+                                        getNotificationMessage(notification.getNotificationType(), notification.getSourceMember(), notification.getTargetMember()),
                                         notification.getCreatedAt()))
                 .collect(Collectors.toList());
     }
@@ -99,6 +102,17 @@ public class NotificationService {
     private void validateSelfSending(Long currentMemberId, Long targetMemberId) {
         if (currentMemberId.equals(targetMemberId)) {
             throw new CustomException(ErrorCode.SELF_SENDING_NOT_ALLOWED);
+        }
+    }
+
+    private String getNotificationMessage(NotificationType notificationType, Member sourceMember, Member targetMember) {
+        switch (notificationType) {
+            case FOLLOW:
+                return String.format(PUSH_SERVICE_CONTENT, sourceMember.getProfile().getNickname());
+            case MISSION_URGING:
+                return String.format(PUSH_URGING_CONTENT, sourceMember.getProfile().getNickname(), targetMember.getProfile().getNickname());
+            default:
+                throw new CustomException(ErrorCode.NOTIFICATION_TYPE_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/depromeet/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/depromeet/domain/notification/application/NotificationService.java
@@ -54,7 +54,10 @@ public class NotificationService {
                         mission.getName()));
         Notification notification =
                 Notification.createNotification(
-                        NotificationType.MISSION_URGING, currentMember, targetMember, mission.getId());
+                        NotificationType.MISSION_URGING,
+                        currentMember,
+                        targetMember,
+                        mission.getId());
         notificationRepository.save(notification);
     }
 
@@ -82,7 +85,10 @@ public class NotificationService {
                                         notification.getId(),
                                         notification.getNotificationType(),
                                         notification.getResourceId(),
-                                        getNotificationMessage(notification.getNotificationType(), notification.getSourceMember(), notification.getTargetMember()),
+                                        getNotificationMessage(
+                                                notification.getNotificationType(),
+                                                notification.getSourceMember(),
+                                                notification.getTargetMember()),
                                         notification.getCreatedAt()))
                 .collect(Collectors.toList());
     }
@@ -105,12 +111,16 @@ public class NotificationService {
         }
     }
 
-    private String getNotificationMessage(NotificationType notificationType, Member sourceMember, Member targetMember) {
+    private String getNotificationMessage(
+            NotificationType notificationType, Member sourceMember, Member targetMember) {
         switch (notificationType) {
             case FOLLOW:
                 return String.format(PUSH_SERVICE_CONTENT, sourceMember.getProfile().getNickname());
             case MISSION_URGING:
-                return String.format(PUSH_URGING_CONTENT, sourceMember.getProfile().getNickname(), targetMember.getProfile().getNickname());
+                return String.format(
+                        PUSH_URGING_CONTENT,
+                        sourceMember.getProfile().getNickname(),
+                        targetMember.getProfile().getNickname());
             default:
                 throw new CustomException(ErrorCode.NOTIFICATION_TYPE_NOT_FOUND);
         }

--- a/src/main/java/com/depromeet/domain/notification/domain/Notification.java
+++ b/src/main/java/com/depromeet/domain/notification/domain/Notification.java
@@ -41,7 +41,10 @@ public class Notification extends BaseTimeEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private Notification(
-            NotificationType notificationType, Member sourceMember, Member targetMember, Long resourceId) {
+            NotificationType notificationType,
+            Member sourceMember,
+            Member targetMember,
+            Long resourceId) {
         this.notificationType = notificationType;
         this.sourceMember = sourceMember;
         this.targetMember = targetMember;
@@ -49,7 +52,10 @@ public class Notification extends BaseTimeEntity {
     }
 
     public static Notification createNotification(
-            NotificationType notificationType, Member currentMember, Member targetMember, Long resourceId) {
+            NotificationType notificationType,
+            Member currentMember,
+            Member targetMember,
+            Long resourceId) {
         return Notification.builder()
                 .notificationType(notificationType)
                 .sourceMember(currentMember)

--- a/src/main/java/com/depromeet/domain/notification/domain/Notification.java
+++ b/src/main/java/com/depromeet/domain/notification/domain/Notification.java
@@ -37,20 +37,24 @@ public class Notification extends BaseTimeEntity {
     @JoinColumn(name = "target_id")
     private Member targetMember;
 
+    private Long resourceId;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Notification(
-            NotificationType notificationType, Member sourceMember, Member targetMember) {
+            NotificationType notificationType, Member sourceMember, Member targetMember, Long resourceId) {
         this.notificationType = notificationType;
         this.sourceMember = sourceMember;
         this.targetMember = targetMember;
+        this.resourceId = resourceId;
     }
 
     public static Notification createNotification(
-            NotificationType notificationType, Member currentMember, Member targetMember) {
+            NotificationType notificationType, Member currentMember, Member targetMember, Long resourceId) {
         return Notification.builder()
                 .notificationType(notificationType)
                 .sourceMember(currentMember)
                 .targetMember(targetMember)
+                .resourceId(resourceId)
                 .build();
     }
 }

--- a/src/main/java/com/depromeet/domain/notification/dto/NotificationFindAllResponse.java
+++ b/src/main/java/com/depromeet/domain/notification/dto/NotificationFindAllResponse.java
@@ -6,11 +6,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record NotificationFindAllResponse(
+        @Schema(description = "알림 ID") Long notificationId,
         @Schema(description = "알림 타입") NotificationType notificationType,
+        @Schema(description = "자원 ID") Long resourceId,
+        @Schema(description = "알림 메시지") String message,
         @Schema(description = "알림 날짜") LocalDateTime createdAt) {
 
     public static NotificationFindAllResponse of(
-            NotificationType notificationType, LocalDateTime createdAt) {
-        return new NotificationFindAllResponse(notificationType, createdAt);
+            Long notificationId, NotificationType notificationType, Long resourceId, String message, LocalDateTime createdAt) {
+        return new NotificationFindAllResponse(notificationId, notificationType, resourceId, message, createdAt);
     }
 }

--- a/src/main/java/com/depromeet/domain/notification/dto/NotificationFindAllResponse.java
+++ b/src/main/java/com/depromeet/domain/notification/dto/NotificationFindAllResponse.java
@@ -13,7 +13,12 @@ public record NotificationFindAllResponse(
         @Schema(description = "알림 날짜") LocalDateTime createdAt) {
 
     public static NotificationFindAllResponse of(
-            Long notificationId, NotificationType notificationType, Long resourceId, String message, LocalDateTime createdAt) {
-        return new NotificationFindAllResponse(notificationId, notificationType, resourceId, message, createdAt);
+            Long notificationId,
+            NotificationType notificationType,
+            Long resourceId,
+            String message,
+            LocalDateTime createdAt) {
+        return new NotificationFindAllResponse(
+                notificationId, notificationType, resourceId, message, createdAt);
     }
 }

--- a/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/depromeet/global/error/exception/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
     TODAY_COMPLETED_MISSION_SENDING_NOT_ALLOWED(
             HttpStatus.BAD_REQUEST, "오늘 미션을 완료한 미션에는 메세지를 전송할 수 없습니다."),
     FINISHED_MISSION_URGING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "종료된 미션에는 재촉하기를 할 수 없습니다."),
+    NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 알림 타입을 찾을 수 없습니다."),
 
     // Reaction
     REACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리액션을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #409 

## 📌 작업 내용 및 특이사항
- 기존 생성해두었던 notification 테이블의 경우 로그 형태로 값을 저장하고있어
딥링크처리하였을 때 이동 대상이 없어 테이블 컬럼을 추가하였습니다.
- 우병좌 요청으로 메세지 추가하도록 메소드 생성하였습니다.

## 📝 참고사항
- 현재 팔로우의 경우 알림센터의 적재하고 있지 않는데 이부분 추가 이슈에서 작업하겠습니당

## 📚 기타
- 
