### PR TITLE
chore: PostgreSQL 마이그레이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 

--- a/src/main/java/com/depromeet/domain/notification/domain/Notification.java
+++ b/src/main/java/com/depromeet/domain/notification/domain/Notification.java
@@ -10,7 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,11 +29,11 @@ public class Notification extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private NotificationType notificationType;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "source_id")
     private Member sourceMember;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "target_id")
     private Member targetMember;
 

--- a/src/main/java/com/depromeet/domain/ranking/dao/RankingRepository.java
+++ b/src/main/java/com/depromeet/domain/ranking/dao/RankingRepository.java
@@ -15,9 +15,9 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
     @Modifying
     @Query(
             value =
-                    "INSERT INTO Ranking (member_id, symbol_stack, created_at) "
+                    "INSERT INTO ranking (member_id, symbol_stack, created_at) "
                             + "VALUES (:memberId, :symbolStack, NOW()) "
-                            + "ON DUPLICATE KEY UPDATE member_id = :memberId, symbol_stack = :symbolStack, updated_at = NOW()",
+                            + "ON CONFLICT (member_id) DO UPDATE SET member_id = :memberId, symbol_stack = :symbolStack, updated_at = NOW()",
             nativeQuery = true)
     void updateSymbolStackAndMemberId(
             @Param("symbolStack") long symbolStack, @Param("memberId") Long memberId);

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -3,13 +3,13 @@ spring:
     activate:
       on-profile: "datasource"
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&tinyInt1isBit=false
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     hikari:
       maxLifetime: 580000
       maximum-pool-size: 20
-    password: ${MYSQL_PASSWORD}
-    username: ${MYSQL_USERNAME}
+    driver-class-name: org.postgresql.Driver
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
   jpa:
     properties:
       hibernate:

--- a/src/test/java/com/depromeet/DatabaseCleaner.java
+++ b/src/test/java/com/depromeet/DatabaseCleaner.java
@@ -28,14 +28,47 @@ public class DatabaseCleaner {
     private static void deleteAll(JdbcTemplate jdbcTemplate, EntityManager entityManager) {
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
         for (String tableName : findDatabaseTableNames(jdbcTemplate)) {
-            entityManager
-                    .createNativeQuery("TRUNCATE TABLE %s".formatted(tableName))
-                    .executeUpdate();
+            deleteDataFromTable(entityManager, tableName);
+            resetAutoIncrementColumn(jdbcTemplate, entityManager, tableName);
         }
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
     }
 
+    private static void deleteDataFromTable(EntityManager entityManager, String tableName) {
+        String deleteQuery = "DELETE FROM %s".formatted(tableName);
+        entityManager.createNativeQuery(deleteQuery).executeUpdate();
+    }
+
+    private static void resetAutoIncrementColumn(
+            JdbcTemplate jdbcTemplate, EntityManager entityManager, String tableName) {
+        String autoIncrementColumn = findAutoIncrementColumn(jdbcTemplate, tableName);
+        String resetQuery =
+                "ALTER TABLE %s ALTER COLUMN %s RESTART WITH 1"
+                        .formatted(tableName, autoIncrementColumn);
+        entityManager.createNativeQuery(resetQuery).executeUpdate();
+    }
+
+    private static String findAutoIncrementColumn(JdbcTemplate jdbcTemplate, String tableName) {
+        String query =
+                """
+			SELECT column_name FROM information_schema.columns
+			WHERE table_schema = ? AND table_name = ? AND is_identity = 'YES'
+			""";
+
+        List<String> columns =
+                jdbcTemplate.query(
+                        query, (rs, rowNum) -> rs.getString("column_name"), "public", tableName);
+
+        return columns.getFirst();
+    }
+
     private static List<String> findDatabaseTableNames(JdbcTemplate jdbcTemplate) {
-        return jdbcTemplate.query("SHOW TABLES", (rs, rowNum) -> rs.getString(1)).stream().toList();
+        String query =
+                """
+			SELECT table_name FROM information_schema.tables
+			WHERE table_schema = ? AND table_type = 'BASE TABLE'
+			ORDER BY table_name
+			""";
+        return jdbcTemplate.query(query, (rs, rowNum) -> rs.getString("table_name"), "public");
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: "test"
 
   datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=PostgreSQL;DATABASE_TO_LOWER=true;DEFAULT_NULL_ORDERING=HIGH
 
   jpa:
     properties:


### PR DESCRIPTION
## 🌱 관련 이슈
- close #427

## 📌 작업 내용 및 특이사항
- rds 대신 supabase free tier를 사용하기로 결정했습니다.
- 이에 맞춰 mysql -> postgresql 데이터 마이그레이션 및 코드베이스 수정 진행했습니다.
- 데이터 마이그레이션의 경우 hibernate가 postgresql에서 ddl-auto로 만들어주는 스키마에 맞춰서 넣어줬습니다.
- 이때 자잘하게 맞춰줘야 되는 부분이 있었는데 자세한 건 아래서 설명드리겠습니다.

### 알림 엔티티 일대다 매핑으로 변경
- postgresql에서 알림 엔티티가 source_id 및 target_id에 대하여 unique 제약조건을 추가하는 문제가 있었습니다 (mysql에서는 해당 제약조건 없었음)
- postgresql에서는 onetoone을 '원래 엔티티에 대하여 단 하나의 대상 엔티티만 매핑되는 경우'로 해석하기에 unique 제약조건을 추가합니다. 그리고 사실 이게 의미론적으로 더 맞습니다. 
- notification의 경우 하나의 알림에 대하여 하나의 소스 혹은 하나의 타깃과만 매핑되지 않습니다. 하나의 알림이 여러 개의 소스 또는 타깃과 매핑될 수 있죠 -> 따라서 manytoone이 의미적으로 더 적절합니다
- 따라서 manytoone으로 수정해줬습니다

### 랭킹 레포지터리 네이티브 SQL 수정 및 테스트 환경에서의 모킹 / 스터빙
- mysql의 on duplicate key의 경우 postgresql의 on conflict do update와 대응됩니다. 수정해줬습니다.
- 다만 on conflict do update의 경우 h2의 postgresql 호환 모드에서 지원되지 않습니다.
- 따라서 테스트에서는 RankingRepository를 모킹한 뒤 (다른 기능은 정상 작동할 수 있게 SpyBean을 사용합니다) 호환이 가능하도록 merge into + when을 사용하도록 스터빙했습니다.

### 그 외...
- DB 클리너 로직 postgresql 방식에 맞게 수정
- 환경변수 MYSQL_XXX 접두사 DB_XXX로 변경

등이 있습니다.

## 📝 참고사항
- 

## 📚 기타
- 
