### PR TITLE
chore: storage 환경변수 범용 키(STORAGE_*)로 통일 및 설정 정리

### DIFF
--- a/src/main/resources/application-storage.yml
+++ b/src/main/resources/application-storage.yml
@@ -3,8 +3,8 @@ spring:
     activate:
       on-profile: "storage"
 storage:
-  accessKey: ${AWS_ACCESS_KEY:}
-  secretKey: ${AWS_SECRET_KEY:}
-  bucket: ${S3_BUCKET:}
-  region: ${AWS_REGION:}
-  endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
+  accessKey: ${STORAGE_ACCESS_KEY:}
+  secretKey: ${STORAGE_SECRET_KEY:}
+  bucket: ${STORAGE_BUCKET:}
+  region: ${STORAGE_REGION:ap-northeast-2}
+  endpoint: ${STORAGE_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #432 

## 📌 작업 내용 및 특이사항
- AWS S3에서 Cloudflare R2로 스토리지 마이그레이션 완료
- 스토리지 환경변수 키를 AWS_ → STORAGE_로 통일하여 범용화
- R2 호환을 위한 endpoint/region 기본값 설정

📝 참고사항
- R2는 region을 사용하지 않지만, AWS SDK 호환성을 위해 기본값(ap-northeast-2) 유지
- 기존 환경변수 키: `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `S3_BUCKET`, `AWS_REGION`, `S3_ENDPOINT`
- 변경된 환경변수 키: `STORAGE_ACCESS_KEY`, `STORAGE_SECRET_KEY`, `STORAGE_BUCKET`, `STORAGE_REGION`, `STORAGE_ENDPOINT`
- 이후 환경별 .env 파일에서 STORAGE_* 키 사용 필요 (노션 기밀문서 참고)
