### PR TITLE
hotfix: 프로덕션 도커 빌드 시 amd64 이미지 같이 생성

### DIFF
--- a/.github/workflows/production_build_deploy.yml
+++ b/.github/workflows/production_build_deploy.yml
@@ -81,7 +81,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/arm64/v8
+          platforms: linux/arm64/v8, linux/amd64
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
 


### PR DESCRIPTION
## 🌱 관련 이슈

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
- 
