### PR TITLE
fix: Remove presignedUrl ACL

### DIFF
--- a/src/main/java/com/depromeet/domain/image/application/ImageService.java
+++ b/src/main/java/com/depromeet/domain/image/application/ImageService.java
@@ -54,7 +54,7 @@ public class ImageService {
                         imageKey,
                         request.imageFileExtension());
 
-        String presignedUrl = imageUtil.createPreSignedUrl(fileName, request.imageFileExtension());
+        String presignedUrl = imageUtil.createUploadUrl(fileName, request.imageFileExtension());
 
         missionRecord.updateUploadStatusPending();
         missionRecordTtlRepository.deleteById(request.missionRecordId());
@@ -100,7 +100,7 @@ public class ImageService {
                         imageKey,
                         request.imageFileExtension());
 
-        String presignedUrl = imageUtil.createPreSignedUrl(fileName, request.imageFileExtension());
+        String presignedUrl = imageUtil.createUploadUrl(fileName, request.imageFileExtension());
 
         imageRepository.save(
                 Image.createImage(

--- a/src/main/java/com/depromeet/global/util/ImageUtil.java
+++ b/src/main/java/com/depromeet/global/util/ImageUtil.java
@@ -2,12 +2,14 @@ package com.depromeet.global.util;
 
 import com.depromeet.domain.image.domain.ImageFileExtension;
 import com.depromeet.infra.config.s3.S3Properties;
+import java.net.URL;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
@@ -19,6 +21,7 @@ public class ImageUtil {
     private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
 
+    @Deprecated(since = "Don't use it by cloudflare ACL")
     @SneakyThrows
     public String createPreSignedUrl(String fileName, ImageFileExtension fileExtension) {
         PutObjectPresignRequest request =
@@ -32,6 +35,27 @@ public class ImageUtil {
                                                 .acl(ObjectCannedACL.PUBLIC_READ))
                         .build();
         return s3Presigner.presignPutObject(request).url().toString();
+    }
+
+    @SneakyThrows
+    public String createUploadUrl(String fileName, ImageFileExtension fileExtension) {
+        String contentType = getContentType(fileExtension);
+
+        PutObjectRequest putObj =
+                PutObjectRequest.builder()
+                        .bucket(s3Properties.bucket())
+                        .key(fileName)
+                        .contentType(contentType) // content-type만 포함
+                        .build();
+
+        PutObjectPresignRequest presignReq =
+                PutObjectPresignRequest.builder()
+                        .putObjectRequest(putObj)
+                        .signatureDuration(Duration.ofMinutes(15))
+                        .build();
+
+        URL url = s3Presigner.presignPutObject(presignReq).url();
+        return url.toString();
     }
 
     private static String getContentType(ImageFileExtension fileExtension) {

--- a/src/main/java/com/depromeet/global/util/ImageUtil.java
+++ b/src/main/java/com/depromeet/global/util/ImageUtil.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -20,22 +19,6 @@ public class ImageUtil {
 
     private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
-
-    @Deprecated(since = "Don't use it by cloudflare ACL")
-    @SneakyThrows
-    public String createPreSignedUrl(String fileName, ImageFileExtension fileExtension) {
-        PutObjectPresignRequest request =
-                PutObjectPresignRequest.builder()
-                        .signatureDuration(Duration.ofMinutes(30))
-                        .putObjectRequest(
-                                builder ->
-                                        builder.bucket(s3Properties.bucket())
-                                                .key(fileName)
-                                                .contentType(getContentType(fileExtension))
-                                                .acl(ObjectCannedACL.PUBLIC_READ))
-                        .build();
-        return s3Presigner.presignPutObject(request).url().toString();
-    }
 
     @SneakyThrows
     public String createUploadUrl(String fileName, ImageFileExtension fileExtension) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #440 

## 📌 작업 내용 및 특이사항
- R2 Storage는 ACL을 지원하지 않거나 무시하는 구성이 흔함. x-amz-acl을 서명에 넣으면 호환성 이슈로 403이 날 수 있으므로 acl 사항 제거

## 📝 참고사항
- https://chatgpt.com/share/68d67fb1-0f14-8005-90cd-e86ca93a789b

## 📚 기타
- 
